### PR TITLE
fix: correct keyboard shortcuts in welcome documentation

### DIFF
--- a/assets/welcome.md
+++ b/assets/welcome.md
@@ -20,7 +20,7 @@ To open a markdown file:
 - Use `Cmd+O` to browse and open a file
 - Use `Cmd+Shift+O` to open a directory (with file explorer)
 - Use `Cmd+T` to open a new tab
-- Use `Cmd+\` to toggle the sidebar file explorer
+- Use `Cmd+B` to toggle the sidebar file explorer
 
 ## Keyboard Shortcuts
 
@@ -30,7 +30,7 @@ To open a markdown file:
 | :------------ | :--------------------------- |
 | `Cmd+O`       | Open a file                  |
 | `Cmd+Shift+O` | Open a directory             |
-| `Cmd+\`       | Toggle sidebar file explorer |
+| `Cmd+B`       | Toggle sidebar file explorer |
 
 **Navigation**
 
@@ -46,7 +46,6 @@ To open a markdown file:
 | `Cmd+N`       | Open a new window    |
 | `Cmd+T`       | Open a new tab       |
 | `Cmd+W`       | Close current tab    |
-| `Cmd+Shift+T` | Close all tabs       |
 | `Cmd+Shift+W` | Close current window |
 
 **View**

--- a/src/components/content/no_file_view.rs
+++ b/src/components/content/no_file_view.rs
@@ -40,7 +40,15 @@ pub fn NoFileView() -> Element {
                         span {
                             class: "no-file-hint-text",
                             "Use "
-                            kbd { class: "no-file-hint-kbd", "Cmd+O" }
+                            kbd {
+                                class: "no-file-hint-kbd",
+                                {
+                                    #[cfg(target_os = "macos")]
+                                    { "Cmd+O" }
+                                    #[cfg(not(target_os = "macos"))]
+                                    { "Ctrl+O" }
+                                }
+                            }
                             " to open a file"
                         }
                     }


### PR DESCRIPTION
## Summary

Fixes #4 - Corrects incorrect keyboard shortcuts in the welcome page documentation.

## Changes

- **Fixed sidebar toggle shortcut**: Changed from `Cmd+\` to `Cmd+B` to match actual implementation
- **Removed non-existent shortcut**: Removed `Cmd+Shift+T` for "Close all tabs" as it's not implemented
- **Platform-aware UI hint**: Made the "Open file" keyboard hint in NoFileView component platform-aware (shows `Cmd+O` on macOS, `Ctrl+O` on other platforms)

## Details

The welcome.md documentation had two incorrect keyboard shortcuts:

1. **Sidebar toggle**: Listed as `Cmd+\` but actually implemented as `Cmd+B` (menu.rs:173 uses `Code::KeyB`)
2. **Close all tabs**: Listed as `Cmd+Shift+T` but has no keyboard shortcut in the implementation (menu.rs:152 shows `CloseAllTabs` has no accelerator)

Additionally, the NoFileView component was hardcoding "Cmd+O" for all platforms, while the actual menu system uses platform-specific modifiers (Cmd on macOS, Ctrl elsewhere).

## Test plan

- [x] Code compiles successfully
- [x] Build succeeds
- [ ] Verify welcome.md displays correct shortcuts
- [ ] Test on macOS that shortcuts work as documented
- [ ] Test on Linux/Windows that Ctrl+O works for opening files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated keyboard shortcuts guide: Sidebar toggle changed from Cmd+\ to Cmd+B
  * Removed Close all tabs keyboard shortcut entry

* **Improvements**
  * Keyboard shortcut labels now display correct OS-specific shortcuts (Cmd+O on macOS, Ctrl+O on other systems)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->