### PR TITLE
fix: add Edit menu to enable clipboard operations (Cmd+C, Cmd+V, etc.)

### DIFF
--- a/src/menu.rs
+++ b/src/menu.rs
@@ -99,6 +99,7 @@ pub fn build_menu() -> Menu {
     add_app_menu(&menu);
 
     add_file_menu(&menu);
+    add_edit_menu(&menu);
     add_view_menu(&menu);
     add_history_menu(&menu);
     add_window_menu(&menu);
@@ -160,6 +161,22 @@ fn add_file_menu(menu: &Menu) {
         .unwrap();
 
     menu.append(&file_menu).unwrap();
+}
+
+fn add_edit_menu(menu: &Menu) {
+    let edit_menu = Submenu::new("Edit", true);
+
+    edit_menu
+        .append_items(&[
+            &PredefinedMenuItem::cut(Some("Cut")),
+            &PredefinedMenuItem::copy(Some("Copy")),
+            &PredefinedMenuItem::paste(Some("Paste")),
+            &PredefinedMenuItem::separator(),
+            &PredefinedMenuItem::select_all(Some("Select All")),
+        ])
+        .unwrap();
+
+    menu.append(&edit_menu).unwrap();
 }
 
 fn add_view_menu(menu: &Menu) {


### PR DESCRIPTION
## Summary

Fixes #9 - Users can now copy selected text using standard keyboard shortcuts (Cmd+C on macOS, Ctrl+C on Windows/Linux).

## Changes

- Added a standard Edit menu with predefined menu items for clipboard operations:
  - **Cut** (Cmd+X / Ctrl+X)
  - **Copy** (Cmd+C / Ctrl+C)
  - **Paste** (Cmd+V / Ctrl+V)
  - **Select All** (Cmd+A / Ctrl+A)

## Implementation Details

The fix uses `PredefinedMenuItem` from the `muda` library, which provides native OS-level clipboard integration:

- Automatically registers platform-appropriate keyboard shortcuts
- Integrates seamlessly with the WebView content
- No custom event handlers required
- Cross-platform compatible (macOS, Windows, Linux)

## Testing

1. Build and run the application: `cargo run`
2. Open a Markdown file
3. Select text in the rendered content
4. Press Cmd+C (or Ctrl+C on Windows/Linux) to copy
5. Paste into another application to verify clipboard operation
6. Verify the Edit menu appears in the menu bar with all clipboard operations

## Related Documentation

- Investigation report: `CLIPBOARD_INVESTIGATION_REPORT.md`
- [muda PredefinedMenuItem documentation](https://docs.rs/muda/latest/muda/struct.PredefinedMenuItem.html)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Edit menu with standard editing actions including Cut, Copy, Paste, and Select All for improved text manipulation capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->