### PR TITLE
fix: pin dioxus-cli to version 0.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
           cache-dependency-path: ./web/pnpm-lock.yaml
       - uses: taiki-e/install-action@v2
         with:
-          tool: dioxus-cli
+          tool: dioxus-cli@0.6
       - run: just setup
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -57,7 +57,7 @@ jobs:
           cache-dependency-path: ./web/pnpm-lock.yaml
       - uses: taiki-e/install-action@v2
         with:
-          tool: dioxus-cli
+          tool: dioxus-cli@0.6
       - run: just setup
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -84,7 +84,7 @@ jobs:
           cache-dependency-path: ./web/pnpm-lock.yaml
       - uses: taiki-e/install-action@v2
         with:
-          tool: dioxus-cli
+          tool: dioxus-cli@0.6
       - run: just setup
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Pin `dioxus-cli` version to 0.6 in GitHub Actions workflow to resolve build artifact issues.

## Changes

- Updated all three build jobs (Linux, Windows, macOS) to use `dioxus-cli@0.6` instead of the latest version
- This ensures consistent build artifacts across all platforms and prevents compatibility issues

## Reason

Without version pinning, the workflow was using the latest version of dioxus-cli, which could introduce breaking changes and cause build artifact inconsistencies.

## Test Plan

- [x] Verify workflow syntax is correct
- [ ] Confirm builds succeed on all platforms (Linux, Windows, macOS)
- [ ] Verify generated artifacts are consistent and functional

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned dioxus CLI tool to version 0.6 in CI/CD workflows to standardize build environment configuration across setup, check, test, and build stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->