### PR TITLE
feat: add automatic Homebrew tap dispatch on release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,3 +184,16 @@ jobs:
             ---
 
             For more information, see the [README](https://github.com/${{ github.repository }}).
+
+  dispatch:
+    if: ${{ github.event_name == 'release' }}
+    needs: [release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch to Homebrew tap
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          repository: lambdalisue/homebrew-arto
+          event-type: release
+          client-payload: '{"version": "${{ github.event.release.tag_name }}", "repository": "${{ github.repository }}"}'


### PR DESCRIPTION
## Summary

- Added workflow job to automatically dispatch to `homebrew-arto` repository when releases are published
- Uses `peter-evans/repository-dispatch@v3` action for reliable repository dispatch
- Sends version tag and repository information as client payload

## Implementation

The new `dispatch` job:
- Triggers only on release events
- Runs after the `release` job completes successfully
- Dispatches `release` event to `lambdalisue/homebrew-arto`
- Includes version tag and source repository in payload

## Setup Required

Add `HOMEBREW_TAP_TOKEN` secret to this repository:

1. Create a Fine-grained Personal Access Token:
   - Repository access: `lambdalisue/homebrew-arto`
   - Permissions: Contents (Read and write)

2. Add as repository secret:
   - Name: `HOMEBREW_TAP_TOKEN`
   - Value: Generated token

## Test Plan

- [ ] Verify workflow syntax is valid (CI check)
- [ ] Confirm secret `HOMEBREW_TAP_TOKEN` is configured
- [ ] Test with next release to ensure dispatch is sent successfully
- [ ] Verify homebrew-arto repository receives the dispatch event

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release automation workflow to streamline the deployment process across repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->