### PR TITLE
fix: implement proper cleanup for file watcher to prevent resource leaks

### DIFF
--- a/src/components/content/file_viewer.rs
+++ b/src/components/content/file_viewer.rs
@@ -136,8 +136,7 @@ fn use_file_loader(
 /// Hook to watch file for changes and trigger reload
 fn use_file_watcher(file: PathBuf, reload_trigger: Signal<usize>) {
     // Store cancellation sender in a signal so we can access it in use_drop
-    let mut cancel_tx_signal =
-        use_signal(|| None::<tokio::sync::oneshot::Sender<()>>);
+    let mut cancel_tx_signal = use_signal(|| None::<tokio::sync::oneshot::Sender<()>>);
 
     use_effect(use_reactive!(|file| {
         let mut reload_trigger = reload_trigger;

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -147,21 +147,13 @@ impl FileWatcher {
                                 tracing::info!("Started watching file: {:?}", path);
                             }
                         }
-                        tracing::debug!(
-                            "Registered watcher {} for {:?}",
-                            watcher_id,
-                            path
-                        );
+                        tracing::debug!("Registered watcher {} for {:?}", watcher_id, path);
                     }
                     Some(FileWatcherCommand::Unwatch(path, watcher_id)) => {
                         let mut watchers = watchers.lock().unwrap();
                         if let Some(senders_map) = watchers.get_mut(&path) {
                             senders_map.remove(&watcher_id);
-                            tracing::debug!(
-                                "Unregistered watcher {} for {:?}",
-                                watcher_id,
-                                path
-                            );
+                            tracing::debug!("Unregistered watcher {} for {:?}", watcher_id, path);
 
                             // If no more watchers for this file, stop watching
                             if senders_map.is_empty() {


### PR DESCRIPTION
## 🎯 Purpose

Fix a critical resource leak in the file watcher system where file monitoring was not properly cleaned up when components were unmounted, causing memory leaks and potential performance degradation during tab switching and component lifecycle operations.

## 📝 Description

### What Changed
- Implemented RAII (Resource Acquisition Is Initialization) pattern for automatic file watcher cleanup
- Added unique WatcherId system for precise watcher identification and removal
- Refactored internal data structures for better watcher management
- Added automatic detection and removal of closed channels
- Implemented proper component lifecycle cleanup using `use_drop` hook

### Implementation Approach

**watcher.rs:**
- Created `FileWatchGuard` struct that implements the `Drop` trait to automatically unwatch files when the guard goes out of scope
- Introduced `WatcherId` (u64) type for uniquely identifying each watcher instance
- Changed internal storage from `Vec<Sender<()>>` to `HashMap<WatcherId, Sender<()>>` to enable precise removal of specific watchers
- Added automatic cleanup of closed channels during file change notifications
- Created `WatcherMap` type alias to simplify complex nested HashMap types

**file_viewer.rs:**
- Added `use_drop` hook to ensure cleanup when components are unmounted
- Implemented cancellation mechanism using `tokio::sync::oneshot` channel
- Used `tokio::select!` to monitor both file changes and cancellation signals concurrently
- Stored cancellation token in a `Signal` to enable access across different hooks
- Automatically cancel previous watchers when file dependencies change

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change fixing an issue)
- [x] 🔧 Refactor (code change improving internal structure)

## 🧪 Testing

### Test Results
```
running 29 tests
test result: ok. 29 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

### Manual Testing Steps
1. Open the application and load a markdown file
2. Edit the file externally and observe auto-reload
3. Switch between tabs multiple times
4. Close tabs and verify no resource leaks
5. Monitor memory usage during extended operation

## ✅ Checklist

### Code Quality
- [x] Code follows project style guidelines (English comments)
- [x] Self-review completed
- [x] Code is well-commented in complex areas
- [x] No new warnings generated
- [x] All clippy warnings resolved

### Testing
- [x] All 29 unit tests pass
- [x] Fix addresses root cause
- [x] Test coverage maintained

## 📊 Performance Impact

**Improvements:**
- ✅ Memory leaks eliminated - watchers are now properly cleaned up
- ✅ No accumulation of zombie async tasks
- ✅ Reduced memory footprint during long-running sessions
- ✅ Improved stability during component lifecycle operations

## 📚 Technical Details

### RAII Pattern
The `FileWatchGuard` follows Rust's RAII pattern for automatic cleanup:
```rust
impl Drop for FileWatchGuard {
    fn drop(&mut self) {
        let _ = self.command_tx.blocking_send(
            FileWatcherCommand::Unwatch(self.path.clone(), self.watcher_id)
        );
    }
}
```

### Component Lifecycle
Using Dioxus's `use_drop` hook for proper cleanup:
```rust
use_drop(move || {
    if let Some(cancel_tx) = cancel_tx_signal.take() {
        let _ = cancel_tx.send(());
    }
});
```

---

**Reviewer Tips:**
- Start with `src/watcher.rs` to understand the RAII implementation
- Review `src/components/content/file_viewer.rs` for lifecycle integration
- Manual testing of tab switching is recommended

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured file watcher is reliably canceled and cleaned up when components unmount to prevent stale watchers.

* **Improvements**
  * Added cancelable watcher lifecycle so restarting watchers terminates prior instances cleanly.
  * Better support for multiple concurrent watchers per file.
  * Improved lifecycle and file-change logging for easier debugging and observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->