### PR TITLE
Revert "fix: implement proper cleanup for file watcher to prevent resource leaks"

### DIFF
--- a/src/components/content/file_viewer.rs
+++ b/src/components/content/file_viewer.rs
@@ -1,5 +1,4 @@
 use dioxus::prelude::*;
-use dioxus_core::use_drop;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
@@ -135,69 +134,37 @@ fn use_file_loader(
 
 /// Hook to watch file for changes and trigger reload
 fn use_file_watcher(file: PathBuf, reload_trigger: Signal<usize>) {
-    // Store cancellation sender in a signal so we can access it in use_drop
-    let mut cancel_tx_signal = use_signal(|| None::<tokio::sync::oneshot::Sender<()>>);
-
     use_effect(use_reactive!(|file| {
         let mut reload_trigger = reload_trigger;
         let file = file.clone();
 
-        // Cancel previous watcher if it exists
-        if let Some(old_cancel_tx) = cancel_tx_signal.take() {
-            tracing::debug!("Cancelling previous watcher for: {:?}", file);
-            let _ = old_cancel_tx.send(());
-        }
-
-        // Create a new oneshot channel for cancellation
-        let (cancel_tx, mut cancel_rx) = tokio::sync::oneshot::channel::<()>();
-        cancel_tx_signal.set(Some(cancel_tx));
-
         spawn(async move {
             let file_path = file.clone();
+            let (tx, mut rx) = tokio::sync::mpsc::channel::<()>(10);
 
-            // Watch the file and get a RAII guard
-            let Ok((_guard, mut rx)) = FILE_WATCHER.watch(file_path.clone()).await else {
-                tracing::error!("Failed to register file watcher for {:?}", file_path);
+            if let Err(e) = FILE_WATCHER.watch(file_path.clone(), tx).await {
+                tracing::error!(
+                    "Failed to register file watcher for {:?}: {:?}",
+                    file_path,
+                    e
+                );
                 return;
-            };
-
-            // Monitor both file changes and cancellation signal
-            loop {
-                tokio::select! {
-                    // Handle cancellation signal from cleanup
-                    _ = &mut cancel_rx => {
-                        tracing::debug!("File watcher cancelled for {:?}", file_path);
-                        break;
-                    }
-                    // Handle file change notifications
-                    result = rx.recv() => {
-                        match result {
-                            Some(()) => {
-                                tracing::info!("File change detected, reloading: {:?}", file_path);
-                                reload_trigger.set(reload_trigger() + 1);
-                            }
-                            None => {
-                                // Channel closed, exit loop
-                                tracing::debug!("File watcher channel closed for {:?}", file_path);
-                                break;
-                            }
-                        }
-                    }
-                }
             }
 
-            // Guard is automatically dropped here, unwatching the file
-            tracing::debug!("File watcher task ended for {:?}", file_path);
+            while rx.recv().await.is_some() {
+                tracing::info!("File change detected, reloading: {:?}", file_path);
+                reload_trigger.set(reload_trigger() + 1);
+            }
+
+            if let Err(e) = FILE_WATCHER.unwatch(file_path.clone()).await {
+                tracing::error!(
+                    "Failed to unregister file watcher for {:?}: {:?}",
+                    file_path,
+                    e
+                );
+            }
         });
     }));
-
-    // Cleanup when component is unmounted
-    use_drop(move || {
-        if let Some(cancel_tx) = cancel_tx_signal.take() {
-            tracing::debug!("Cleaning up file watcher on component drop");
-            let _ = cancel_tx.send(());
-        }
-    });
 }
 
 /// Hook to setup JavaScript handler for markdown link clicks

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -3,13 +3,10 @@ use notify_debouncer_full::{
 };
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::{
-    atomic::{AtomicU64, Ordering},
-    Arc, LazyLock, Mutex,
-};
+use std::sync::{Arc, LazyLock, Mutex};
 use std::time::Duration;
 use thiserror::Error;
-use tokio::sync::mpsc::{self, Receiver, Sender};
+use tokio::sync::mpsc::{self, Sender};
 
 #[derive(Debug, Error)]
 pub enum WatcherError {
@@ -19,44 +16,14 @@ pub enum WatcherError {
 
 type WatcherResult<T> = Result<T, WatcherError>;
 
-/// Unique identifier for each file watcher
-type WatcherId = u64;
-
-/// Type alias for the watcher map to reduce complexity
-type WatcherMap = HashMap<PathBuf, HashMap<WatcherId, Sender<()>>>;
-
-/// RAII guard for file watching
-/// Automatically unwatches the file when dropped
-pub struct FileWatchGuard {
-    path: PathBuf,
-    watcher_id: WatcherId,
-    command_tx: Sender<FileWatcherCommand>,
-}
-
-impl Drop for FileWatchGuard {
-    fn drop(&mut self) {
-        tracing::debug!(
-            "Dropping FileWatchGuard for {:?} (watcher_id: {})",
-            self.path,
-            self.watcher_id
-        );
-        // Send unwatch command when guard is dropped
-        let _ = self.command_tx.blocking_send(FileWatcherCommand::Unwatch(
-            self.path.clone(),
-            self.watcher_id,
-        ));
-    }
-}
-
 /// Global file watcher that manages file change notifications
 pub struct FileWatcher {
     command_tx: Sender<FileWatcherCommand>,
-    next_watcher_id: Arc<AtomicU64>,
 }
 
 enum FileWatcherCommand {
-    Watch(PathBuf, WatcherId, Sender<()>),
-    Unwatch(PathBuf, WatcherId),
+    Watch(PathBuf, Sender<()>),
+    Unwatch(PathBuf),
 }
 
 impl FileWatcher {
@@ -66,8 +33,8 @@ impl FileWatcher {
         // Spawn a dedicated thread for the file watcher
         std::thread::spawn(move || {
             // Map of file paths to their notification channels
-            // Inner HashMap maps WatcherId to Sender for precise unwatch operations
-            let watchers: Arc<Mutex<WatcherMap>> = Arc::new(Mutex::new(HashMap::new()));
+            let watchers: Arc<Mutex<HashMap<PathBuf, Vec<Sender<()>>>>> =
+                Arc::new(Mutex::new(HashMap::new()));
             let watchers_clone = watchers.clone();
 
             // Create a debouncer with 500ms delay
@@ -88,25 +55,12 @@ impl FileWatcher {
                         }
 
                         // Notify all watchers for changed files
-                        let mut watchers = watchers_clone.lock().unwrap();
+                        let watchers = watchers_clone.lock().unwrap();
                         for path in changed_paths {
-                            if let Some(senders_map) = watchers.get_mut(&path) {
+                            if let Some(senders) = watchers.get(&path) {
                                 tracing::debug!("File changed: {:?}", path);
-
-                                // Collect closed channels to remove them
-                                let mut closed_ids = Vec::new();
-
-                                for (watcher_id, sender) in senders_map.iter() {
-                                    if sender.blocking_send(()).is_err() {
-                                        // Channel is closed, mark for removal
-                                        closed_ids.push(*watcher_id);
-                                    }
-                                }
-
-                                // Remove closed channels
-                                for id in closed_ids {
-                                    senders_map.remove(&id);
-                                    tracing::debug!("Removed closed watcher {} for {:?}", id, path);
+                                for sender in senders {
+                                    let _ = sender.blocking_send(());
                                 }
                             }
                         }
@@ -130,14 +84,11 @@ impl FileWatcher {
             // Process commands
             loop {
                 match command_rx.blocking_recv() {
-                    Some(FileWatcherCommand::Watch(path, watcher_id, tx)) => {
+                    Some(FileWatcherCommand::Watch(path, tx)) => {
                         let mut watchers = watchers.lock().unwrap();
                         let is_first = !watchers.contains_key(&path);
 
-                        watchers
-                            .entry(path.clone())
-                            .or_default()
-                            .insert(watcher_id, tx);
+                        watchers.entry(path.clone()).or_default().push(tx);
 
                         // Only start watching if this is the first watcher for this file
                         if is_first {
@@ -147,16 +98,13 @@ impl FileWatcher {
                                 tracing::info!("Started watching file: {:?}", path);
                             }
                         }
-                        tracing::debug!("Registered watcher {} for {:?}", watcher_id, path);
                     }
-                    Some(FileWatcherCommand::Unwatch(path, watcher_id)) => {
+                    Some(FileWatcherCommand::Unwatch(path)) => {
                         let mut watchers = watchers.lock().unwrap();
-                        if let Some(senders_map) = watchers.get_mut(&path) {
-                            senders_map.remove(&watcher_id);
-                            tracing::debug!("Unregistered watcher {} for {:?}", watcher_id, path);
-
+                        if let Some(senders) = watchers.get_mut(&path) {
+                            senders.pop();
                             // If no more watchers for this file, stop watching
-                            if senders_map.is_empty() {
+                            if senders.is_empty() {
                                 watchers.remove(&path);
                                 if let Err(e) = debouncer.unwatch(&path) {
                                     tracing::error!("Failed to unwatch file {:?}: {:?}", path, e);
@@ -174,36 +122,23 @@ impl FileWatcher {
             }
         });
 
-        Self {
-            command_tx,
-            next_watcher_id: Arc::new(AtomicU64::new(1)),
-        }
+        Self { command_tx }
     }
 
     /// Watch a file and receive notifications when it changes
-    /// Returns a RAII guard and a receiver channel
-    /// The file will be automatically unwatched when the guard is dropped
-    pub async fn watch(&self, path: PathBuf) -> WatcherResult<(FileWatchGuard, Receiver<()>)> {
-        // Generate unique watcher ID
-        let watcher_id = self.next_watcher_id.fetch_add(1, Ordering::SeqCst);
-
-        // Create channel for file change notifications
-        let (tx, rx) = mpsc::channel(10);
-
-        // Send watch command
+    pub async fn watch(&self, path: PathBuf, tx: Sender<()>) -> WatcherResult<()> {
         self.command_tx
-            .send(FileWatcherCommand::Watch(path.clone(), watcher_id, tx))
+            .send(FileWatcherCommand::Watch(path, tx))
             .await
-            .map_err(|_| WatcherError::CommandFailed)?;
+            .map_err(|_| WatcherError::CommandFailed)
+    }
 
-        // Create RAII guard
-        let guard = FileWatchGuard {
-            path,
-            watcher_id,
-            command_tx: self.command_tx.clone(),
-        };
-
-        Ok((guard, rx))
+    /// Stop watching a file
+    pub async fn unwatch(&self, path: PathBuf) -> WatcherResult<()> {
+        self.command_tx
+            .send(FileWatcherCommand::Unwatch(path))
+            .await
+            .map_err(|_| WatcherError::CommandFailed)
     }
 }
 


### PR DESCRIPTION
Reverts lambdalisue/rs-arto#18

It seems this PR cause segmentation fault

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal file watching mechanism to use a streamlined channel-based architecture, replacing the previous ID-based tracking system.
  * Improved watcher registration and lifecycle management for more efficient resource handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->