### PR TITLE
Fix(window): Reopen hidden window on dock icon click

### DIFF
--- a/src/window/main.rs
+++ b/src/window/main.rs
@@ -67,6 +67,7 @@ pub fn focus_last_focused_main_window() -> bool {
                 .filter_map(|w| w.upgrade())
                 .find(|ctx| ctx.window.id() == main_window_id)
                 .map(|ctx| {
+                    ctx.window.set_visible(true);
                     ctx.window.set_focus();
                     true
                 })


### PR DESCRIPTION
On macOS, when all windows are hidden (not closed), clicking the app icon in the Dock should reopen the last focused window.

The `focus_last_focused_main_window` function was correctly identifying the window to focus but was only calling `set_focus()`. This does not make a hidden window visible.

By adding `set_visible(true)` before `set_focus()`, the window is now correctly unhidden and brought to the foreground, aligning with the expected behavior of macOS applications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Windows now properly display when brought into focus, ensuring visibility is enforced before being activated.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->