### PR TITLE
feat(ui): move Preferences button to tab bar with toggle behavior

### DIFF
--- a/desktop/src/components/header.rs
+++ b/desktop/src/components/header.rs
@@ -3,7 +3,7 @@ use dioxus::prelude::*;
 
 use crate::components::icon::{Icon, IconName};
 use crate::components::theme_selector::ThemeSelector;
-use crate::state::{AppState, TabContent};
+use crate::state::AppState;
 
 #[component]
 pub fn Header() -> Element {
@@ -160,24 +160,6 @@ pub fn Header() -> Element {
 
                 // Theme selector
                 ThemeSelector { current_theme: state.current_theme }
-
-                // Preferences button
-                {
-                    let is_preferences_active = current_tab
-                        .as_ref()
-                        .is_some_and(|tab| matches!(tab.content, TabContent::Preferences));
-                    rsx! {
-                        button {
-                            class: "nav-button preferences-button",
-                            class: if is_preferences_active { "active" },
-                            title: "Preferences",
-                            onclick: move |_| {
-                                state.open_preferences();
-                            },
-                            Icon { name: IconName::Gear, size: 18 }
-                        }
-                    }
-                }
             }
         }
     }

--- a/desktop/src/components/tab_bar.rs
+++ b/desktop/src/components/tab_bar.rs
@@ -45,6 +45,9 @@ pub fn TabBar() -> Element {
 
             // New tab button
             NewTabButton {}
+
+            // Preferences button
+            PreferencesButton {}
         }
     }
 }
@@ -223,6 +226,27 @@ fn NewTabButton() -> Element {
                 state.add_empty_tab(true);
             },
             Icon { name: IconName::Add, size: 16 }
+        }
+    }
+}
+
+#[component]
+fn PreferencesButton() -> Element {
+    let mut state = use_context::<AppState>();
+    let current_tab = state.current_tab();
+    let is_preferences_active = current_tab
+        .as_ref()
+        .is_some_and(|tab| matches!(tab.content, crate::state::TabContent::Preferences));
+
+    rsx! {
+        button {
+            class: "tab-preferences",
+            class: if is_preferences_active { "active" },
+            title: "Preferences",
+            onclick: move |_| {
+                state.toggle_preferences();
+            },
+            Icon { name: IconName::Gear, size: 16 }
         }
     }
 }

--- a/desktop/src/state/app_state/tabs.rs
+++ b/desktop/src/state/app_state/tabs.rs
@@ -242,6 +242,31 @@ impl AppState {
             self.active_tab.set(new_index);
         }
     }
+
+    /// Toggle preferences tab. Opens if not present, closes if currently active.
+    pub fn toggle_preferences(&mut self) {
+        // Check if preferences tab already exists
+        let tabs = self.tabs.read();
+        let preferences_index = tabs
+            .iter()
+            .position(|tab| matches!(tab.content, TabContent::Preferences));
+        drop(tabs);
+
+        if let Some(index) = preferences_index {
+            // Preferences tab exists - check if it's the active tab
+            let active_index = *self.active_tab.read();
+            if active_index == index {
+                // Close the preferences tab
+                self.close_tab(index);
+            } else {
+                // Switch to the preferences tab
+                self.switch_to_tab(index);
+            }
+        } else {
+            // No preferences tab - open new one
+            self.open_preferences();
+        }
+    }
 }
 
 #[cfg(test)]

--- a/renderer/style/components/tab-bar.css
+++ b/renderer/style/components/tab-bar.css
@@ -118,3 +118,27 @@
 .tab-new:hover {
   opacity: 1;
 }
+
+.tab-preferences {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  border-radius: 3px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 3px;
+  margin-left: auto;
+  transition: all 0.15s;
+  opacity: 0.5;
+}
+
+.tab-preferences:hover {
+  opacity: 1;
+}
+
+.tab-preferences.active {
+  opacity: 0.8;
+  color: var(--accent-bg);
+}


### PR DESCRIPTION
## Summary
- Move Preferences button from header to tab bar
- Add toggle behavior: close if active, switch if inactive, open if not present
- Implement `toggle_preferences()` with tab deduplication logic

## Why
The header navigation area was becoming cluttered with the Preferences button competing for space with theme selector and other controls. Moving it to the tab bar aligns with modern editor patterns (like VS Code) where persistent settings controls live alongside content tabs.

The toggle behavior improves UX by making the button state-aware:
- Clicking when preferences is active → close the tab (intuitive dismissal)
- Clicking when another tab is active → switch to preferences (quick access)
- Clicking when no preferences tab exists → open new preferences tab

This prevents duplicate preferences tabs while providing a consistent, predictable interaction pattern.

## Test Plan
- [ ] Click Preferences button when no preferences tab exists → opens new tab
- [ ] Click Preferences button when preferences tab exists but inactive → switches to it
- [ ] Click Preferences button when preferences tab is active → closes the tab
- [ ] Verify button shows active state when preferences tab is current
- [ ] Verify button styling matches tab bar design language