### PR TITLE
chore: Consider deltaY and deltaMode for smoother diagram scaling

### DIFF
--- a/renderer/src/mermaid-window-controller.ts
+++ b/renderer/src/mermaid-window-controller.ts
@@ -198,7 +198,11 @@ class MermaidWindowController {
 
     // Exponential zoom: scale relative to current zoom level
     // This provides natural feel - same perceived change at any zoom level
-    const zoomFactor = event.deltaY > 0 ? 0.9 : 1.1; // 10% change per tick
+    const deltaScale = this.#getDeltaModeScale(event.deltaMode);
+    const deltaY = event.deltaY * deltaScale;
+    const ZOOM_SCALE = 0.01;
+    const zoomFactor = Math.exp(-deltaY * ZOOM_SCALE);
+
     const oldScale = this.#state.scale;
     const newScale = Math.max(0.1, Math.min(this.#maxZoom, oldScale * zoomFactor));
 
@@ -224,6 +228,19 @@ class MermaidWindowController {
 
   #handleDoubleClick(): void {
     this.#fitToWindow();
+  }
+
+  #getDeltaModeScale(deltaMode: number): number {
+    switch (deltaMode) {
+      case WheelEvent.DOM_DELTA_PIXEL:
+        return 1;
+      case WheelEvent.DOM_DELTA_LINE:
+        return 10;
+      case WheelEvent.DOM_DELTA_PAGE:
+        return 20;
+      default:
+        return 1;
+    }
   }
 
   #zoom(delta: number): void {


### PR DESCRIPTION
## Motivation

Previously, Arto only supported constant scaling per scroll event.

Before: too fast and discrete scaling, hard to control with some devices (e.g. trackpads on Macbook Pro)

https://github.com/user-attachments/assets/e6dde93b-526e-4364-94eb-57a374121f2c

## Summary

We can check deltaY and deltaMode to properly compute the diagram scale.
This achieves smoother scaling behavior in many devices, including devices with trackpads (e.g. Macbook Pro).

After: smoother and continuous scaling

https://github.com/user-attachments/assets/b983de61-6f62-4e07-a2c9-407fa0ba2743

## Notes

Ideas are partially from https://github.com/traPtitech/traQ_S-UI/pull/4071.
If desired, we can distinguish "trackpad pinch events" and "normal scroll events (e.g. from mouse)" by checking if event.ctrlKey is set.
This PR changes zoom behavior for all scroll events, so if the original behavior for "normal scroll events" is desired, we can restore the behavior while changing behavior only for "pinch events".