### PR TITLE
Fix release workflow by adding missing tag parameter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,6 +130,7 @@ jobs:
       - run: find .
       - uses: ncipollo/release-action@v1.20.0
         with:
+          tag: ${{ github.event.release.tag_name }}
           allowUpdates: true
           artifactErrorsFailBuild: true
           artifacts: ./artifacts/arto-*/Arto_*.dmg


### PR DESCRIPTION
## Summary
- Add `tag` parameter to `ncipollo/release-action` in release workflow

## Why
The release job was failing with error "No tag found in ref or input!" because the action couldn't automatically detect the tag. In GitHub release events, `github.ref` points to the branch (main) rather than the tag itself. By explicitly providing the tag using `github.event.release.tag_name`, the action can correctly identify which release to update with artifacts.

## Test Plan
- [ ] Create a new release (e.g., v0.11.1) to trigger the workflow
- [ ] Verify the release job completes successfully
- [ ] Confirm DMG artifacts are attached to the release