### PR TITLE
Add Quick Access bookmarking feature to sidebar

### DIFF
--- a/desktop/src/bookmarks.rs
+++ b/desktop/src/bookmarks.rs
@@ -1,0 +1,378 @@
+//! Bookmark management for Quick Access feature.
+//!
+//! This module provides:
+//! - `Bookmark`: A single bookmarked file or directory
+//! - `Bookmarks`: Collection of bookmarks with persistence
+//! - `BOOKMARKS`: Global static for app-wide bookmark access
+//! - `BOOKMARKS_CHANGED`: Broadcast channel for cross-window sync
+
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+use tokio::sync::broadcast;
+
+/// A single bookmark entry for Quick Access
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Bookmark {
+    /// Path to the bookmarked file or directory
+    pub path: PathBuf,
+    /// Custom display name (if None, use file/directory name)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+impl Bookmark {
+    /// Create a new bookmark with the given path
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self {
+            path: path.into(),
+            name: None,
+        }
+    }
+
+    /// Get display name (custom name or filename)
+    pub fn display_name(&self) -> &str {
+        self.name.as_deref().unwrap_or_else(|| {
+            self.path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("Unknown")
+        })
+    }
+
+    /// Check if this bookmark points to a directory
+    pub fn is_dir(&self) -> bool {
+        self.path.is_dir()
+    }
+
+    /// Check if the bookmarked path exists
+    pub fn exists(&self) -> bool {
+        self.path.exists()
+    }
+}
+
+/// Bookmarks storage (saved to bookmarks.json)
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct Bookmarks {
+    /// List of bookmarked paths
+    pub items: Vec<Bookmark>,
+}
+
+impl Bookmarks {
+    /// Get the bookmarks file path
+    fn path() -> PathBuf {
+        const FILENAME: &str = "bookmarks.json";
+        if let Some(mut path) = dirs::data_local_dir() {
+            path.push("arto");
+            path.push(FILENAME);
+            return path;
+        }
+
+        // Fallback to home directory
+        if let Some(mut path) = dirs::home_dir() {
+            path.push(".arto");
+            path.push(FILENAME);
+            return path;
+        }
+
+        PathBuf::from(FILENAME)
+    }
+
+    /// Load bookmarks from file or return empty
+    pub fn load() -> Self {
+        let path = Self::path();
+
+        if !path.exists() {
+            return Self::default();
+        }
+
+        match fs::read_to_string(&path) {
+            Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
+            Err(_) => Self::default(),
+        }
+    }
+
+    /// Save bookmarks to file
+    pub fn save(&self) {
+        let path = Self::path();
+
+        tracing::debug!(path = %path.display(), count = self.items.len(), "Saving bookmarks");
+
+        if let Some(parent) = path.parent() {
+            if let Err(e) = fs::create_dir_all(parent) {
+                tracing::error!(?e, "Failed to create bookmarks directory");
+                return;
+            }
+        }
+
+        match serde_json::to_string_pretty(self) {
+            Ok(content) => {
+                if let Err(e) = fs::write(&path, content) {
+                    tracing::error!(?e, "Failed to save bookmarks");
+                }
+            }
+            Err(e) => {
+                tracing::error!(?e, "Failed to serialize bookmarks");
+            }
+        }
+    }
+
+    /// Remove a bookmark by path
+    pub fn remove(&mut self, path: &Path) {
+        self.items.retain(|b| b.path != path);
+    }
+
+    /// Toggle bookmark (add if not present, remove if present)
+    ///
+    /// Returns `true` if the path is now bookmarked, `false` if removed.
+    pub fn toggle(&mut self, path: impl Into<PathBuf>) -> bool {
+        let path = path.into();
+        if self.contains(&path) {
+            self.remove(&path);
+            false
+        } else {
+            self.items.push(Bookmark::new(path));
+            true
+        }
+    }
+
+    /// Check if a path is already bookmarked
+    pub fn contains(&self, path: &Path) -> bool {
+        self.items.iter().any(|b| b.path == path)
+    }
+
+    /// Move a bookmark from one index to another
+    ///
+    /// Returns `true` if the move was successful.
+    pub fn reorder(&mut self, from_index: usize, to_index: usize) -> bool {
+        if from_index >= self.items.len() || to_index >= self.items.len() {
+            return false;
+        }
+        if from_index == to_index {
+            return true;
+        }
+
+        let item = self.items.remove(from_index);
+        // After removing, indices shift: if from < to, we need to insert at to - 1
+        let insert_at = if from_index < to_index {
+            to_index - 1
+        } else {
+            to_index
+        };
+        self.items.insert(insert_at, item);
+        true
+    }
+
+    // Test-only methods
+    #[cfg(test)]
+    pub fn add(&mut self, path: impl Into<PathBuf>) {
+        let path = path.into();
+        if !self.contains(&path) {
+            self.items.push(Bookmark::new(path));
+        }
+    }
+
+    #[cfg(test)]
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+}
+
+/// Global bookmarks instance
+pub static BOOKMARKS: LazyLock<RwLock<Bookmarks>> =
+    LazyLock::new(|| RwLock::new(Bookmarks::load()));
+
+/// Broadcast channel for bookmark changes
+///
+/// All windows subscribe to this to update their UI when bookmarks change.
+/// The payload is empty since subscribers should read from BOOKMARKS directly.
+pub static BOOKMARKS_CHANGED: LazyLock<broadcast::Sender<()>> =
+    LazyLock::new(|| broadcast::channel(10).0);
+
+/// Toggle a bookmark and broadcast the change
+///
+/// This is a convenience function that handles the common pattern of:
+/// 1. Toggle the bookmark in BOOKMARKS
+/// 2. Save to disk
+/// 3. Broadcast the change to all windows
+///
+/// Returns `true` if the path is now bookmarked, `false` if removed.
+pub fn toggle_bookmark(path: impl AsRef<Path>) -> bool {
+    let result = {
+        let mut bookmarks = BOOKMARKS.write();
+        let result = bookmarks.toggle(path.as_ref().to_path_buf());
+        bookmarks.save();
+        result
+    };
+    BOOKMARKS_CHANGED.send(()).ok();
+    result
+}
+
+/// Reorder bookmarks and broadcast the change
+///
+/// Moves a bookmark from `from_index` to `to_index`.
+/// Returns `true` if the reorder was successful.
+pub fn reorder_bookmark(from_index: usize, to_index: usize) -> bool {
+    let result = {
+        let mut bookmarks = BOOKMARKS.write();
+        let result = bookmarks.reorder(from_index, to_index);
+        if result {
+            bookmarks.save();
+        }
+        result
+    };
+    if result {
+        BOOKMARKS_CHANGED.send(()).ok();
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_bookmark_display_name() {
+        let bookmark = Bookmark::new("/path/to/file.md");
+        assert_eq!(bookmark.display_name(), "file.md");
+
+        let bookmark_with_name = Bookmark {
+            path: PathBuf::from("/path/to/file.md"),
+            name: Some("My Notes".to_string()),
+        };
+        assert_eq!(bookmark_with_name.display_name(), "My Notes");
+    }
+
+    #[test]
+    fn test_bookmark_exists() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("test.md");
+        std::fs::write(&file_path, "test").unwrap();
+
+        let existing = Bookmark::new(&file_path);
+        assert!(existing.exists());
+
+        let non_existing = Bookmark::new("/non/existent/path.md");
+        assert!(!non_existing.exists());
+    }
+
+    #[test]
+    fn test_bookmarks_add_remove() {
+        let mut bookmarks = Bookmarks::default();
+
+        bookmarks.add("/path/to/file1.md");
+        assert_eq!(bookmarks.len(), 1);
+        assert!(bookmarks.contains(Path::new("/path/to/file1.md")));
+
+        // Adding same path again should not duplicate
+        bookmarks.add("/path/to/file1.md");
+        assert_eq!(bookmarks.len(), 1);
+
+        bookmarks.add("/path/to/file2.md");
+        assert_eq!(bookmarks.len(), 2);
+
+        bookmarks.remove(Path::new("/path/to/file1.md"));
+        assert_eq!(bookmarks.len(), 1);
+        assert!(!bookmarks.contains(Path::new("/path/to/file1.md")));
+    }
+
+    #[test]
+    fn test_bookmarks_toggle() {
+        let mut bookmarks = Bookmarks::default();
+
+        // Toggle on
+        let result = bookmarks.toggle("/path/to/file.md");
+        assert!(result);
+        assert!(bookmarks.contains(Path::new("/path/to/file.md")));
+
+        // Toggle off
+        let result = bookmarks.toggle("/path/to/file.md");
+        assert!(!result);
+        assert!(!bookmarks.contains(Path::new("/path/to/file.md")));
+    }
+
+    #[test]
+    fn test_bookmarks_reorder_forward() {
+        // Drag from earlier to later position
+        let mut bookmarks = Bookmarks::default();
+        bookmarks.add("/a");
+        bookmarks.add("/b");
+        bookmarks.add("/c");
+        bookmarks.add("/d");
+        // [A, B, C, D] -> drag A(0) to C(2)'s drop zone -> [B, A, C, D]
+        assert!(bookmarks.reorder(0, 2));
+        assert_eq!(
+            bookmarks
+                .items
+                .iter()
+                .map(|b| b.path.to_str().unwrap())
+                .collect::<Vec<_>>(),
+            vec!["/b", "/a", "/c", "/d"]
+        );
+    }
+
+    #[test]
+    fn test_bookmarks_reorder_backward() {
+        // Drag from later to earlier position
+        let mut bookmarks = Bookmarks::default();
+        bookmarks.add("/a");
+        bookmarks.add("/b");
+        bookmarks.add("/c");
+        bookmarks.add("/d");
+        // [A, B, C, D] -> drag D(3) to B(1)'s drop zone -> [A, D, B, C]
+        assert!(bookmarks.reorder(3, 1));
+        assert_eq!(
+            bookmarks
+                .items
+                .iter()
+                .map(|b| b.path.to_str().unwrap())
+                .collect::<Vec<_>>(),
+            vec!["/a", "/d", "/b", "/c"]
+        );
+    }
+
+    #[test]
+    fn test_bookmarks_reorder_same_index() {
+        let mut bookmarks = Bookmarks::default();
+        bookmarks.add("/a");
+        bookmarks.add("/b");
+        // Same index should return true but not change order
+        assert!(bookmarks.reorder(1, 1));
+        assert_eq!(
+            bookmarks
+                .items
+                .iter()
+                .map(|b| b.path.to_str().unwrap())
+                .collect::<Vec<_>>(),
+            vec!["/a", "/b"]
+        );
+    }
+
+    #[test]
+    fn test_bookmarks_reorder_invalid_index() {
+        let mut bookmarks = Bookmarks::default();
+        bookmarks.add("/a");
+        // Invalid indices should return false
+        assert!(!bookmarks.reorder(0, 5));
+        assert!(!bookmarks.reorder(5, 0));
+    }
+
+    #[test]
+    fn test_bookmarks_serialization() {
+        let mut bookmarks = Bookmarks::default();
+        bookmarks.add("/path/to/file.md");
+        bookmarks.items[0].name = Some("My File".to_string());
+
+        let json = serde_json::to_string_pretty(&bookmarks).unwrap();
+        let parsed: Bookmarks = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed.items.len(), 1);
+        assert_eq!(parsed.items[0].path, PathBuf::from("/path/to/file.md"));
+        assert_eq!(parsed.items[0].name, Some("My File".to_string()));
+    }
+}

--- a/desktop/src/components.rs
+++ b/desktop/src/components.rs
@@ -1,4 +1,5 @@
 pub mod app;
+pub mod bookmark_button;
 pub mod content;
 pub mod header;
 pub mod icon;

--- a/desktop/src/components/bookmark_button.rs
+++ b/desktop/src/components/bookmark_button.rs
@@ -1,0 +1,68 @@
+//! Reusable bookmark toggle button component for Quick Access feature.
+
+use dioxus::prelude::*;
+use std::path::PathBuf;
+
+use crate::bookmarks::{toggle_bookmark, BOOKMARKS, BOOKMARKS_CHANGED};
+use crate::components::icon::{Icon, IconName};
+
+/// Reusable bookmark toggle button
+#[component]
+pub fn BookmarkButton(
+    /// Path to bookmark/unbookmark
+    path: PathBuf,
+    /// Icon size in pixels (default: 14)
+    #[props(default = 14)]
+    size: u32,
+) -> Element {
+    let path_for_check = path.clone();
+    let mut is_bookmarked = use_signal(move || BOOKMARKS.read().contains(&path_for_check));
+
+    // Subscribe to bookmark changes from other windows/components
+    let path_for_subscription = path.clone();
+    use_future(move || {
+        let path = path_for_subscription.clone();
+        async move {
+            let mut rx = BOOKMARKS_CHANGED.subscribe();
+            while rx.recv().await.is_ok() {
+                is_bookmarked.set(BOOKMARKS.read().contains(&path));
+            }
+        }
+    });
+
+    let handle_click = {
+        let path = path.clone();
+        move |evt: Event<MouseData>| {
+            evt.stop_propagation();
+            toggle_bookmark(&path);
+        }
+    };
+
+    let icon_name = if *is_bookmarked.read() {
+        IconName::StarFilled
+    } else {
+        IconName::Star
+    };
+
+    let title = if *is_bookmarked.read() {
+        "Remove from Quick Access"
+    } else {
+        "Add to Quick Access"
+    };
+
+    let bookmarked_class = if *is_bookmarked.read() {
+        "bookmarked"
+    } else {
+        ""
+    };
+
+    rsx! {
+        button {
+            class: "bookmark-button {bookmarked_class}",
+            title: "{title}",
+            draggable: false,
+            onclick: handle_click,
+            Icon { name: icon_name, size }
+        }
+    }
+}

--- a/desktop/src/components/header.rs
+++ b/desktop/src/components/header.rs
@@ -1,5 +1,6 @@
 use dioxus::prelude::*;
 
+use crate::components::bookmark_button::BookmarkButton;
 use crate::components::icon::{Icon, IconName};
 use crate::components::theme_selector::ThemeSelector;
 use crate::state::AppState;
@@ -115,8 +116,11 @@ pub fn Header() -> Element {
                 div {
                     class: "file-action-buttons",
 
-                    // Copy path button and reload button (shown on hover)
+                    // Bookmark, copy path, and reload buttons (shown on hover)
                     if let Some(path) = file_path {
+                        // Bookmark button
+                        BookmarkButton { path: path.to_path_buf() }
+
                         button {
                             class: "nav-button copy-button",
                             class: if *is_copied.read() { "copied" },

--- a/desktop/src/components/icon.rs
+++ b/desktop/src/components/icon.rs
@@ -39,6 +39,8 @@ pub enum IconName {
     SelectAll,
     Server,
     Sidebar,
+    Star,
+    StarFilled,
     Sun,
     SunMoon,
 }
@@ -80,6 +82,8 @@ impl fmt::Display for IconName {
             IconName::SelectAll => "select-all",
             IconName::Server => "server",
             IconName::Sidebar => "layout-sidebar",
+            IconName::Star => "star",
+            IconName::StarFilled => "star-filled",
             IconName::Sun => "sun",
             IconName::SunMoon => "sun-moon",
         };

--- a/desktop/src/components/sidebar.rs
+++ b/desktop/src/components/sidebar.rs
@@ -1,5 +1,6 @@
 pub mod context_menu;
 pub mod file_explorer;
+pub mod quick_access;
 
 use dioxus::document;
 use dioxus::prelude::*;

--- a/desktop/src/components/sidebar/context_menu.rs
+++ b/desktop/src/components/sidebar/context_menu.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use dioxus::desktop::tao::window::WindowId;
 use dioxus::prelude::*;
 
+use crate::bookmarks::BOOKMARKS;
 use crate::components::icon::{Icon, IconName};
 
 #[derive(Clone, Copy, PartialEq)]
@@ -20,6 +21,7 @@ pub fn SidebarContextMenu(
     on_open: EventHandler<()>,
     on_open_in_new_window: EventHandler<()>,
     on_move_to_window: EventHandler<WindowId>,
+    on_toggle_bookmark: EventHandler<()>,
     on_copy_path: EventHandler<()>,
     on_reveal_in_finder: EventHandler<()>,
     on_reload: EventHandler<()>,
@@ -28,6 +30,7 @@ pub fn SidebarContextMenu(
     let mut show_submenu = use_signal(|| false);
 
     let is_file = kind == SidebarItemKind::File;
+    let is_bookmarked = BOOKMARKS.read().contains(&path);
 
     // Dynamic labels based on item kind
     let open_label = if is_file {
@@ -104,7 +107,26 @@ pub fn SidebarContextMenu(
                 }
             }
 
-            // === Section 2: File operations ===
+            // === Section 2: Quick Access ===
+            ContextMenuSeparator {}
+
+            div {
+                class: "context-menu-item",
+                onclick: move |_| on_toggle_bookmark.call(()),
+
+                Icon {
+                    name: if is_bookmarked { IconName::StarFilled } else { IconName::Star },
+                    size: 14,
+                    class: "context-menu-icon",
+                }
+
+                span {
+                    class: "context-menu-label",
+                    if is_bookmarked { "Remove from Quick Access" } else { "Add to Quick Access" }
+                }
+            }
+
+            // === Section 3: File operations ===
             ContextMenuSeparator {}
 
             ContextMenuItem {
@@ -119,7 +141,7 @@ pub fn SidebarContextMenu(
                 on_click: move |_| on_reveal_in_finder.call(()),
             }
 
-            // === Section 3: Reload ===
+            // === Section 4: Reload ===
             ContextMenuSeparator {}
 
             ContextMenuItem {

--- a/desktop/src/components/sidebar/file_explorer.rs
+++ b/desktop/src/components/sidebar/file_explorer.rs
@@ -5,6 +5,8 @@ use std::fs;
 use std::path::PathBuf;
 
 use super::context_menu::{SidebarContextMenu, SidebarItemKind};
+use super::quick_access::QuickAccess;
+use crate::components::bookmark_button::BookmarkButton;
 use crate::components::icon::{Icon, IconName};
 use crate::state::AppState;
 use crate::utils::{file::is_markdown_file, file_operations};
@@ -64,6 +66,9 @@ pub fn FileExplorer() -> Element {
                     "No directory open"
                 }
             }
+
+            // Quick Access section (fixed at bottom)
+            QuickAccess {}
         }
     }
 }
@@ -168,9 +173,12 @@ fn DirectoryNavigation(current_dir: PathBuf, mut refresh_counter: Signal<u32>) -
                             "{dir_name}"
                         }
 
-                        // Action buttons (copy & reload) - shown on hover
+                        // Action buttons (bookmark, copy & reload) - shown on hover
                         div {
                             class: "sidebar-header-actions",
+
+                            // Bookmark button
+                            BookmarkButton { path: current_dir.clone() }
 
                             // Copy path button
                             button {
@@ -226,9 +234,12 @@ fn DirectoryNavigation(current_dir: PathBuf, mut refresh_counter: Signal<u32>) -
                             "/"
                         }
 
-                        // Action buttons (copy & reload) - shown on hover
+                        // Action buttons (bookmark, copy & reload) - shown on hover
                         div {
                             class: "sidebar-header-actions",
+
+                            // Bookmark button
+                            BookmarkButton { path: current_dir.clone() }
 
                             // Copy path button
                             button {
@@ -457,6 +468,15 @@ fn FileTreeNode(path: PathBuf, depth: usize, mut refresh_counter: Signal<u32>) -
         show_context_menu.set(false);
     };
 
+    // Handler for "Toggle Bookmark"
+    let handle_toggle_bookmark = {
+        let path = path.clone();
+        move |_| {
+            crate::bookmarks::toggle_bookmark(&path);
+            show_context_menu.set(false);
+        }
+    };
+
     rsx! {
         div {
             class: "sidebar-tree-node",
@@ -548,6 +568,9 @@ fn FileTreeNode(path: PathBuf, depth: usize, mut refresh_counter: Signal<u32>) -
                     }
                 }
 
+                // Bookmark button
+                BookmarkButton { path: path.clone(), size: 12 }
+
                 // Copy path button
                 button {
                     class: "sidebar-tree-copy-button",
@@ -596,6 +619,7 @@ fn FileTreeNode(path: PathBuf, depth: usize, mut refresh_counter: Signal<u32>) -
                 on_open: handle_open,
                 on_open_in_new_window: handle_open_in_new_window,
                 on_move_to_window: handle_open_in_window,
+                on_toggle_bookmark: handle_toggle_bookmark,
                 on_copy_path: handle_copy_path,
                 on_reveal_in_finder: handle_reveal_in_finder,
                 on_reload: handle_reload,

--- a/desktop/src/components/sidebar/quick_access.rs
+++ b/desktop/src/components/sidebar/quick_access.rs
@@ -1,0 +1,238 @@
+//! Quick Access section component for the sidebar.
+//!
+//! Displays bookmarked files and directories for quick navigation.
+//! Supports drag-and-drop reordering of bookmarks.
+
+use dioxus::prelude::*;
+
+use crate::bookmarks::{reorder_bookmark, Bookmark, BOOKMARKS, BOOKMARKS_CHANGED};
+use crate::components::bookmark_button::BookmarkButton;
+use crate::components::icon::{Icon, IconName};
+use crate::state::AppState;
+
+/// Bookmark with cached filesystem status to avoid filesystem calls during render
+#[derive(Clone)]
+struct CachedBookmark {
+    bookmark: Bookmark,
+    exists: bool,
+    is_dir: bool,
+}
+
+impl CachedBookmark {
+    fn from_bookmark(bookmark: Bookmark) -> Self {
+        let exists = bookmark.exists();
+        let is_dir = bookmark.is_dir();
+        Self {
+            bookmark,
+            exists,
+            is_dir,
+        }
+    }
+}
+
+/// Load bookmarks with cached exists status
+fn load_cached_bookmarks() -> Vec<CachedBookmark> {
+    BOOKMARKS
+        .read()
+        .items
+        .iter()
+        .map(|b| CachedBookmark::from_bookmark(b.clone()))
+        .collect()
+}
+
+/// Quick Access section in the sidebar
+#[component]
+pub fn QuickAccess() -> Element {
+    let mut state = use_context::<AppState>();
+
+    // Local signal to track bookmark items with cached exists status
+    let mut bookmarks = use_signal(load_cached_bookmarks);
+
+    // Drag state
+    let mut dragging_index = use_signal(|| None::<usize>);
+    let mut drop_target_index = use_signal(|| None::<usize>);
+
+    // Subscribe to bookmark changes and refresh exists status
+    use_future(move || async move {
+        let mut rx = BOOKMARKS_CHANGED.subscribe();
+        while rx.recv().await.is_ok() {
+            bookmarks.set(load_cached_bookmarks());
+        }
+    });
+
+    let items = bookmarks.read();
+
+    // Don't render if no bookmarks
+    if items.is_empty() {
+        return rsx! {};
+    }
+
+    rsx! {
+        div {
+            class: "quick-access",
+
+            // Header
+            div {
+                class: "quick-access-header",
+                Icon {
+                    name: IconName::StarFilled,
+                    size: 14,
+                    class: "quick-access-header-icon",
+                }
+                span { class: "quick-access-title", "QUICK ACCESS" }
+            }
+
+            // Bookmark items
+            div {
+                class: "quick-access-list",
+                ondragover: move |evt| {
+                    evt.stop_propagation();
+                    evt.prevent_default();
+                },
+                for (index, cached) in items.iter().enumerate() {
+                    QuickAccessItem {
+                        key: "{cached.bookmark.path.display()}",
+                        index,
+                        bookmark: cached.bookmark.clone(),
+                        exists: cached.exists,
+                        item_is_directory: cached.is_dir,
+                        is_dragging: *dragging_index.read() == Some(index),
+                        is_drop_target: *drop_target_index.read() == Some(index),
+                        on_click: move |(bookmark, is_directory): (Bookmark, bool)| {
+                            if is_directory {
+                                state.set_root_directory(&bookmark.path);
+                            } else {
+                                state.open_file(&bookmark.path);
+                            }
+                        },
+                        on_drag_start: move |idx| {
+                            dragging_index.set(Some(idx));
+                        },
+                        on_drag_over: move |idx| {
+                            if dragging_index.read().is_some() {
+                                drop_target_index.set(Some(idx));
+                            }
+                        },
+                        on_drag_leave: move |_| {
+                            drop_target_index.set(None);
+                        },
+                        on_drag_end: move |_| {
+                            // Perform the reorder if we have valid indices
+                            if let (Some(from), Some(to)) = (*dragging_index.read(), *drop_target_index.read()) {
+                                if from != to {
+                                    reorder_bookmark(from, to);
+                                }
+                            }
+                            dragging_index.set(None);
+                            drop_target_index.set(None);
+                        },
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// A single bookmark item in the Quick Access list
+#[component]
+fn QuickAccessItem(
+    index: usize,
+    bookmark: Bookmark,
+    /// Cached exists status (computed when bookmarks change, not on every render)
+    exists: bool,
+    /// Cached directory status (computed when bookmarks change, not on every render)
+    item_is_directory: bool,
+    is_dragging: bool,
+    is_drop_target: bool,
+    on_click: EventHandler<(Bookmark, bool)>,
+    on_drag_start: EventHandler<usize>,
+    on_drag_over: EventHandler<usize>,
+    on_drag_leave: EventHandler<()>,
+    on_drag_end: EventHandler<()>,
+) -> Element {
+    let path = bookmark.path.clone();
+    let display_name = bookmark.display_name().to_string();
+
+    let icon_name = if item_is_directory {
+        IconName::Folder
+    } else {
+        IconName::File
+    };
+
+    let mut classes = vec!["quick-access-item"];
+    if !exists {
+        classes.push("missing");
+    }
+    if is_dragging {
+        classes.push("dragging");
+    }
+    if is_drop_target && !is_dragging {
+        classes.push("drop-target");
+    }
+    let class_str = classes.join(" ");
+
+    let title = if exists {
+        path.to_string_lossy().to_string()
+    } else {
+        format!("{} (not found)", path.to_string_lossy())
+    };
+
+    rsx! {
+        div {
+            class: "{class_str}",
+            title: "{title}",
+            draggable: "true",
+            ondragstart: move |evt| {
+                evt.stop_propagation();
+                on_drag_start.call(index);
+            },
+            ondragover: move |evt| {
+                evt.stop_propagation();
+                evt.prevent_default();
+                on_drag_over.call(index);
+            },
+            ondragleave: move |evt| {
+                evt.stop_propagation();
+                on_drag_leave.call(());
+            },
+            ondragend: move |evt| {
+                evt.stop_propagation();
+                on_drag_end.call(());
+            },
+            onclick: {
+                let bookmark = bookmark.clone();
+                move |_| {
+                    if exists {
+                        on_click.call((bookmark.clone(), item_is_directory));
+                    }
+                }
+            },
+
+            // Drag handle indicator (visual only, drag is on parent)
+            span {
+                class: "quick-access-item-drag-handle",
+                draggable: false,
+                Icon {
+                    name: IconName::ArrowsMove,
+                    size: 12,
+                }
+            }
+
+            // Icon
+            Icon {
+                name: icon_name,
+                size: 14,
+                class: "quick-access-item-icon",
+            }
+
+            // Name
+            span {
+                class: "quick-access-item-name",
+                "{display_name}"
+            }
+
+            // Remove button
+            BookmarkButton { path: path.clone(), size: 12 }
+        }
+    }
+}

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -1,4 +1,5 @@
 mod assets;
+mod bookmarks;
 mod components;
 mod config;
 mod drag;

--- a/renderer/icons.json
+++ b/renderer/icons.json
@@ -32,6 +32,8 @@
   "select-all",
   "server",
   "settings",
+  "star",
+  "star-filled",
   "sun",
   "sun-moon",
   "x"

--- a/renderer/style/components/quick-access.css
+++ b/renderer/style/components/quick-access.css
@@ -1,0 +1,241 @@
+/* ========================================
+   Quick Access Section
+   ======================================== */
+
+.quick-access {
+  flex-shrink: 0;
+  border-top: 1px solid var(--border-color);
+  max-height: 300px; /* ~10 items (26px each) + header */
+  overflow-y: auto;
+  padding: 8px 0;
+}
+
+/* Webkit scrollbar for quick-access */
+.quick-access::-webkit-scrollbar {
+  width: 2px;
+  height: 2px;
+}
+
+/* Header */
+.quick-access-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px 8px 8px;
+  opacity: 0.5;
+}
+
+.quick-access-header-icon {
+  color: var(--text-secondary);
+  flex-shrink: 0;
+}
+
+.quick-access-title {
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  color: var(--text-secondary);
+}
+
+/* List container */
+.quick-access-list {
+  display: flex;
+  flex-direction: column;
+}
+
+/* Individual item */
+.quick-access-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  height: 26px;
+  box-sizing: border-box;
+  cursor: pointer;
+  border-radius: 4px;
+  white-space: nowrap;
+  overflow: hidden;
+  opacity: 0.6;
+  transition:
+    background-color 0.15s ease,
+    opacity 0.2s ease;
+  /* Enable drag in webkit-based webviews */
+  -webkit-user-drag: element;
+}
+
+/* Prevent child elements from blocking parent drag */
+.quick-access-item > * {
+  -webkit-user-drag: none;
+  pointer-events: auto;
+}
+
+.quick-access-item:hover {
+  background-color: var(--hover-bg);
+  opacity: 1;
+}
+
+/* Missing file/directory state */
+.quick-access-item.missing {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+.quick-access-item.missing:hover {
+  background-color: transparent;
+  opacity: 0.4;
+}
+
+/* Dragging state */
+.quick-access-item.dragging {
+  opacity: 0.4;
+  background-color: var(--hover-bg);
+}
+
+/* Drop target indicator */
+.quick-access-item.drop-target {
+  background-color: color-mix(in srgb, var(--accent-bg) 15%, transparent);
+  border-top: 2px solid var(--accent-bg);
+  margin-top: -2px;
+}
+
+/* Drag handle - only visible on hover */
+.quick-access-item-drag-handle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  opacity: 0;
+  color: var(--text-secondary);
+  cursor: grab;
+  transition: opacity 0.15s ease;
+}
+
+.quick-access-item:hover .quick-access-item-drag-handle {
+  opacity: 0.4;
+}
+
+.quick-access-item-drag-handle:hover {
+  opacity: 0.8 !important;
+}
+
+/* Item icon */
+.quick-access-item-icon {
+  flex-shrink: 0;
+  color: var(--text-secondary);
+}
+
+/* Item name */
+.quick-access-item-name {
+  flex: 1;
+  font-size: 0.85rem;
+  line-height: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--text-color);
+}
+
+/* Remove button - only visible on hover */
+.quick-access-item .bookmark-button {
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+.quick-access-item:hover .bookmark-button {
+  opacity: 0.6;
+}
+
+.quick-access-item .bookmark-button:hover {
+  opacity: 1 !important;
+}
+
+/* ========================================
+   Bookmark Button (Reusable)
+   ======================================== */
+
+.bookmark-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 3px;
+  width: 22px;
+  height: 22px;
+  flex-shrink: 0;
+  opacity: 0.5;
+  transition:
+    opacity 0.2s,
+    color 0.2s,
+    background-color 0.15s ease;
+}
+
+.bookmark-button:hover {
+  background-color: var(--hover-bg);
+  opacity: 1;
+}
+
+/* Bookmarked state - filled star */
+.bookmark-button.bookmarked {
+  opacity: 0.8;
+  color: var(--accent-bg);
+}
+
+.bookmark-button.bookmarked:hover {
+  opacity: 1;
+}
+
+/* Sidebar tree bookmark button - smaller, matches copy button */
+.sidebar-tree-node-content .bookmark-button {
+  padding: 2px 4px;
+  width: auto;
+  height: auto;
+  margin-left: auto;
+  opacity: 0;
+}
+
+.sidebar-tree-node-content:hover .bookmark-button {
+  opacity: 0.6;
+}
+
+.sidebar-tree-node-content .bookmark-button:hover {
+  opacity: 1 !important;
+}
+
+.sidebar-tree-node-content .bookmark-button.bookmarked {
+  opacity: 0.8;
+}
+
+/* Sidebar header bookmark button */
+.sidebar-header-actions .bookmark-button {
+  opacity: 0.5;
+}
+
+.sidebar-header-actions .bookmark-button:hover {
+  opacity: 1;
+}
+
+.sidebar-header-actions .bookmark-button.bookmarked {
+  opacity: 0.8;
+  color: var(--accent-bg);
+}
+
+/* Header bookmark button */
+.file-action-buttons .bookmark-button {
+  opacity: 0;
+}
+
+.header-left:hover .file-action-buttons .bookmark-button {
+  opacity: 0.5;
+}
+
+.file-action-buttons .bookmark-button:hover {
+  opacity: 1 !important;
+}
+
+.file-action-buttons .bookmark-button.bookmarked {
+  opacity: 0.8;
+  color: var(--accent-bg);
+}

--- a/renderer/style/components/sidebar.css
+++ b/renderer/style/components/sidebar.css
@@ -272,6 +272,8 @@
 .sidebar-tree {
   display: flex;
   flex-direction: column;
+  flex: 1;
+  min-height: 0; /* Allow shrinking in flex container */
   overflow: hidden auto;
 }
 

--- a/renderer/style/main.css
+++ b/renderer/style/main.css
@@ -3,6 +3,7 @@
 @import url("./components/app.css");
 @import url("./components/icon.css");
 @import url("./components/sidebar.css");
+@import url("./components/quick-access.css");
 @import url("./components/header.css");
 @import url("./components/search-bar.css");
 @import url("./components/tab-bar.css");

--- a/renderer/vite.config.ts
+++ b/renderer/vite.config.ts
@@ -8,15 +8,24 @@ function iconSpritePlugin(): Plugin {
   return {
     name: "icon-sprite-generator",
     buildStart() {
-      const iconsDir = path.join(
+      const outlineDir = path.join(
         __dirname,
         "node_modules/@tabler/icons/icons/outline",
+      );
+      const filledDir = path.join(
+        __dirname,
+        "node_modules/@tabler/icons/icons/filled",
       );
 
       const outputPath = path.join(__dirname, "public/icons/tabler-sprite.svg");
       const symbols = icons
         .map((name) => {
-          const svgPath = path.join(iconsDir, `${name}.svg`);
+          // Check if this is a filled icon (e.g., "star-filled" -> filled/star.svg)
+          const isFilled = name.endsWith("-filled");
+          const iconName = isFilled ? name.replace(/-filled$/, "") : name;
+          const iconsDir = isFilled ? filledDir : outlineDir;
+
+          const svgPath = path.join(iconsDir, `${iconName}.svg`);
           const svg = fs.readFileSync(svgPath, "utf-8");
           const content = svg
             .replace(/<svg[^>]*>/, "")


### PR DESCRIPTION
## Summary
- Add bookmark system for frequently accessed files and directories
- Introduce Quick Access section in sidebar with star icons
- Support bookmark management from header, file explorer, and context menus
- Implement drag-and-drop reordering of bookmarks
- Add cross-window synchronization via broadcast channels

## Why
Users need quick access to frequently used files and directories without navigating the entire file tree each time. This feature improves workflow efficiency by:

- Reducing repetitive navigation steps
- Keeping important resources easily accessible
- Supporting drag-and-drop for personalized ordering
- Syncing bookmarks across all windows for consistency

Technical decisions:
- Persistent storage in `bookmarks.json` ensures bookmarks survive app restarts
- Broadcast channels enable real-time updates across multiple windows
- Filesystem status caching (exists, is_dir) prevents I/O operations during render loops
- `AsRef<Path>` API pattern avoids unnecessary allocations when working with paths

## Test Plan
- [x] All unit tests pass (131 tests including bookmark operations)
- [x] Code formatting and linting pass
- [ ] Manual testing: Add/remove bookmarks from header, sidebar, context menu
- [ ] Manual testing: Drag-and-drop reordering works correctly
- [ ] Manual testing: Bookmarks sync across multiple windows
- [ ] Manual testing: Missing files display with "missing" indicator
- [ ] Manual testing: Bookmarks persist after app restart