### PR TITLE
docs: replace README screenshots with official website link

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,9 @@ Launch the application to see the welcome screen with keyboard shortcuts and usa
 [nix-darwin]: https://github.com/nix-darwin/nix-darwin
 [home-manager]: https://github.com/nix-community/home-manager
 
-## Screenshots
+## Official Website
 
-<img alt="CleanShot 2025-10-26 at 16 24 54" src="https://github.com/user-attachments/assets/675b9a2f-9e1d-4355-bd05-f475b77e62e6" />
-<img alt="CleanShot 2025-10-26 at 16 25 13" src="https://github.com/user-attachments/assets/5012a3ce-9741-4b2e-9fb2-e8c5868638f8" />
-<img alt="CleanShot 2025-10-26 at 16 25 31" src="https://github.com/user-attachments/assets/84fc6c60-4166-4330-a83b-370d5e2fa534" />
+Visit [arto-app.github.io](https://arto-app.github.io) for screenshots, feature highlights, and more.
 
 ## Contributing
 


### PR DESCRIPTION
Removed three embedded screenshots from README and replaced the Screenshots section with a link to the official website. This keeps the README concise while directing users to arto-app.github.io for visual content and feature highlights.