### PR TITLE
chore(nix): use fetchPnpmDeps instead of pnpm_9.fetchDeps

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -52,8 +52,9 @@
               pkgs.pnpmConfigHook
             ];
 
-            pnpmDeps = pkgs.pnpm_9.fetchDeps {
+            pnpmDeps = pkgs.fetchPnpmDeps {
               inherit (finalAttrs) pname version src;
+              pnpm = pkgs.pnpm_9;
               # To update this hash when renderer dependencies change:
               # 1. Change hash to: lib.fakeHash or ""
               # 2. Run: nix build .#renderer-assets


### PR DESCRIPTION
## Summary

Migrate from deprecated `pnpm_9.fetchDeps` to the new top-level `fetchPnpmDeps` API in Nixpkgs.

## Background

Installing Arto via home-manager produced the following warning:

```
evaluation warning: pnpm.fetchDeps: The package attribute is deprecated. Use the top-level fetchPnpmDeps attribute instead
```

