### PR TITLE
fix(window): preserve LAST_FOCUSED_WINDOW for restoration

### DIFF
--- a/desktop/src/components/app.rs
+++ b/desktop/src/components/app.rs
@@ -293,10 +293,6 @@ pub fn App(
             }
         }
 
-        // Clear last focused window if this window was the last focused
-        // Prevents stale WindowId references in find_window_at_point
-        crate::window::clear_last_focused_if_matches(window_id);
-
         // Save last used state from this window
         // Read directly from state signals instead of global statics
         // to ensure we get the current window's values, not the global last-modified values

--- a/desktop/src/window.rs
+++ b/desktop/src/window.rs
@@ -52,10 +52,9 @@ pub use child::{
     open_or_focus_mermaid_window,
 };
 pub use main::{
-    clear_last_focused_if_matches, close_all_main_windows, create_main_window_config,
-    create_new_main_window_with_empty, create_new_main_window_with_file,
-    focus_last_focused_main_window, has_any_main_windows, register_main_window,
-    update_last_focused_window, CreateMainWindowConfigParams,
+    close_all_main_windows, create_main_window_config, create_new_main_window_with_empty,
+    create_new_main_window_with_file, focus_last_focused_main_window, has_any_main_windows,
+    register_main_window, update_last_focused_window, CreateMainWindowConfigParams,
 };
 pub use preview::{
     close_preview_window, commit_preview_window, create_preview_window, discard_preview_window,

--- a/desktop/src/window/main.rs
+++ b/desktop/src/window/main.rs
@@ -286,17 +286,6 @@ pub(crate) fn get_last_focused_window() -> Option<WindowId> {
     LAST_FOCUSED_WINDOW.with(|last| *last.borrow())
 }
 
-/// Clear the last focused window if it matches the given window ID.
-/// Called when a window is closed to prevent stale references.
-pub fn clear_last_focused_if_matches(window_id: WindowId) {
-    LAST_FOCUSED_WINDOW.with(|last| {
-        let mut last = last.borrow_mut();
-        if *last == Some(window_id) {
-            *last = None;
-        }
-    });
-}
-
 fn find_window_metrics(window_id: WindowId) -> Option<WindowMetrics> {
     list_main_windows()
         .into_iter()


### PR DESCRIPTION
## Summary
- Remove premature clearing of `LAST_FOCUSED_WINDOW` on window close
- Remove unused `clear_last_focused_if_matches` function
- Export `list_visible_main_windows` instead of removed function

## Why
Arto uses `WindowHides` behavior on macOS, meaning the last window hides instead of closing when user clicks the close button. When the app is later restored (via Dock click or Cmd+Tab), the system needs to know which window to restore.

Previously, we cleared `LAST_FOCUSED_WINDOW` immediately on window close to prevent stale references in `find_window_at_point`. However, this caused a bug: when the last window was hidden and the user restored the app, there was no window ID to restore, leaving the app in a hidden state with no visible windows.

The fix is simple: preserve `LAST_FOCUSED_WINDOW` even after window close. The window hasn't actually been destroyed—it's just hidden. This allows the restoration logic to correctly bring back the last focused window when the app is unhidden.

## Test Plan
- [x] Open Arto, close the last window (it should hide)
- [x] Restore the app via Dock click or Cmd+Tab
- [x] Verify the window reappears correctly
- [x] Test with multiple windows to ensure `LAST_FOCUSED_WINDOW` tracks correctly