### PR TITLE
feat(preferences): add default tab setting for right sidebar

### DIFF
--- a/desktop/src/components/app.rs
+++ b/desktop/src/components/app.rs
@@ -14,6 +14,7 @@ use super::content::{
 use super::header::Header;
 use super::icon::{Icon, IconName};
 use super::right_sidebar::RightSidebar;
+use super::right_sidebar::RightSidebarTab;
 use super::search_bar::SearchBar;
 use super::sidebar::Sidebar;
 use super::tab::TabBar;
@@ -39,6 +40,7 @@ pub fn App(
     sidebar_show_all_files: bool,
     toc_open: bool,
     toc_width: f64,
+    toc_tab: RightSidebarTab,
 ) -> Element {
     // Initialize application state with the provided tab
     let mut state = use_context_provider(|| {
@@ -61,6 +63,7 @@ pub fn App(
         {
             app_state.right_sidebar_open.set(toc_open);
             app_state.right_sidebar_width.set(toc_width);
+            app_state.right_sidebar_tab.set(toc_tab);
         }
 
         let metrics = crate::window::metrics::capture_window_metrics(&window().window);

--- a/desktop/src/components/content/preferences_view/tabs/right_sidebar_tab.rs
+++ b/desktop/src/components/content/preferences_view/tabs/right_sidebar_tab.rs
@@ -1,4 +1,5 @@
 use super::super::form_controls::{OptionCardItem, OptionCards, SliderInput};
+use crate::components::right_sidebar::RightSidebarTab as RightSidebarTabKind;
 use crate::config::{Config, NewWindowBehavior, StartupBehavior};
 use dioxus::prelude::*;
 
@@ -43,6 +44,37 @@ pub fn RightSidebarTab(
                     selected: right_sidebar.default_open,
                     on_change: move |new_state| {
                         config.write().right_sidebar.default_open = new_state;
+                        has_changes.set(true);
+                    },
+                }
+            }
+
+            div {
+                class: "preference-item",
+                div {
+                    class: "preference-item-header",
+                    label { "Default Tab" }
+                    p { class: "preference-description", "Which tab is active when the right sidebar opens." }
+                }
+                OptionCards {
+                    name: "right-sidebar-default-tab".to_string(),
+                    options: vec![
+                        OptionCardItem {
+                            icon: None,
+                            value: RightSidebarTabKind::Contents,
+                            title: "Contents".to_string(),
+                            description: Some("Show table of contents".to_string()),
+                        },
+                        OptionCardItem {
+                            icon: None,
+                            value: RightSidebarTabKind::Search,
+                            title: "Search".to_string(),
+                            description: Some("Show document search".to_string()),
+                        },
+                    ],
+                    selected: right_sidebar.default_tab,
+                    on_change: move |new_tab| {
+                        config.write().right_sidebar.default_tab = new_tab;
                         has_changes.set(true);
                     },
                 }

--- a/desktop/src/components/main_app.rs
+++ b/desktop/src/components/main_app.rs
@@ -171,6 +171,7 @@ pub fn MainApp() -> Element {
             sidebar_show_all_files: sidebar_pref.show_all_files,
             toc_open: toc_pref.open,
             toc_width: toc_pref.width,
+            toc_tab: toc_pref.tab,
         }
     }
 }

--- a/desktop/src/config/app_config/right_sidebar_config.rs
+++ b/desktop/src/config/app_config/right_sidebar_config.rs
@@ -19,6 +19,7 @@ pub struct RightSidebarConfig {
     #[serde(default = "default_right_sidebar_width")]
     pub default_width: f64,
     /// Default active tab
+    #[serde(default)]
     pub default_tab: RightSidebarTab,
     /// Behavior on app startup: "default" or "last_closed"
     pub on_startup: StartupBehavior,

--- a/desktop/src/window/main.rs
+++ b/desktop/src/window/main.rs
@@ -12,6 +12,7 @@ use crate::state::AppState;
 
 use crate::assets::MAIN_STYLE;
 use crate::components::app::{App, AppProps};
+use crate::components::right_sidebar::RightSidebarTab;
 use crate::config::{WindowPositionOffset, CONFIG};
 use crate::state::Tab;
 use crate::theme::Theme;
@@ -49,6 +50,7 @@ pub struct CreateMainWindowConfigParams {
     pub sidebar_show_all_files: bool,
     pub toc_open: bool,
     pub toc_width: f64,
+    pub toc_tab: RightSidebarTab,
     pub size: LogicalSize<u32>,
     pub position: LogicalPosition<i32>,
     /// Skip position shifting for overlap avoidance.
@@ -75,6 +77,7 @@ impl CreateMainWindowConfigParams {
             sidebar_show_all_files: sidebar_pref.show_all_files,
             toc_open: toc_pref.open,
             toc_width: toc_pref.width,
+            toc_tab: toc_pref.tab,
             size: size_pref.size,
             position: position_pref.position,
             skip_position_shift: false,
@@ -254,6 +257,7 @@ pub(crate) async fn create_new_main_window(
             sidebar_show_all_files: params.sidebar_show_all_files,
             toc_open: params.toc_open,
             toc_width: params.toc_width,
+            toc_tab: params.toc_tab,
         },
     );
 

--- a/desktop/src/window/settings.rs
+++ b/desktop/src/window/settings.rs
@@ -3,6 +3,7 @@ use dioxus::prelude::*;
 use mouse_position::mouse_position::Mouse;
 use std::path::PathBuf;
 
+use crate::components::right_sidebar::RightSidebarTab;
 use crate::config::{
     NewWindowBehavior, StartupBehavior, WindowDimension, WindowDimensionUnit, WindowPosition,
     WindowPositionMode, WindowSize, CONFIG,
@@ -35,6 +36,7 @@ pub struct SidebarPreference {
 pub struct TocPreference {
     pub open: bool,
     pub width: f64,
+    pub tab: RightSidebarTab,
 }
 
 pub struct WindowSizePreference {
@@ -292,18 +294,21 @@ pub fn get_toc_preference(is_first_window: bool) -> TocPreference {
         || TocPreference {
             open: cfg.right_sidebar.default_open,
             width: cfg.right_sidebar.default_width,
+            tab: cfg.right_sidebar.default_tab,
         },
         || {
             if let Some(state) = get_last_focused_window_state() {
                 TocPreference {
                     open: *state.right_sidebar_open.read(),
                     width: *state.right_sidebar_width.read(),
+                    tab: *state.right_sidebar_tab.read(),
                 }
             } else {
                 let persisted = PersistedState::load();
                 TocPreference {
                     open: persisted.right_sidebar_open,
                     width: persisted.right_sidebar_width,
+                    tab: persisted.right_sidebar_tab,
                 }
             }
         },
@@ -396,6 +401,10 @@ mod tests {
         let result = get_toc_preference(true);
         // Should return a TocPreference
         assert!(result.width > 0.0);
+        assert!(matches!(
+            result.tab,
+            RightSidebarTab::Contents | RightSidebarTab::Search
+        ));
     }
 
     #[test]
@@ -403,6 +412,10 @@ mod tests {
         let result = get_toc_preference(false);
         // Should return a TocPreference
         assert!(result.width > 0.0);
+        assert!(matches!(
+            result.tab,
+            RightSidebarTab::Contents | RightSidebarTab::Search
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add "Default Tab" preference for right sidebar (Contents / Search)
- Thread the setting through the preference resolution pipeline: `RightSidebarConfig.default_tab` → `TocPreference.tab` → `CreateMainWindowConfigParams.toc_tab` → `AppState.right_sidebar_tab`
- Add UI control in Preferences > Right Sidebar with Contents/Search option cards
- Add `#[serde(default)]` on `default_tab` for backward compatibility with existing config files

## Test Plan
- [x] `just fmt check test` passes
- [ ] Manual: Set `"defaultTab": "search"` in config.json → restart → verify right sidebar opens on Search tab
- [ ] Manual: Change tab in Preferences UI → save → restart → verify persistence
- [ ] Manual: Remove `defaultTab` from config.json → restart → verify no config reset (backward compat)