### PR TITLE
ci: improve build workflow with version sync and Nix caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,6 +128,20 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: nixbuild/nix-quick-install-action@v34
+        with:
+          nix_conf: |
+            keep-env-derivations = true
+            keep-outputs = true
+      - uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-macos: 5G
+          purge: true
+          purge-prefixes: cache-nix-${{ runner.os }}-
+          purge-created: 0
+          purge-last-accessed: 604800
+          purge-primary-key: never
       - run: nix build
     timeout-minutes: 30
 


### PR DESCRIPTION
## Summary

- Align dioxus-cli version with Cargo.lock to prevent version mismatches
- Add Nix store caching to speed up subsequent builds

## Why

**Version Alignment:**
Previously, the CI workflow hardcoded `dioxus-cli@0.7`, which could fall out of sync with the actual Dioxus version specified in `Cargo.lock`. This PR dynamically extracts the Dioxus version from `Cargo.lock` and installs the matching dioxus-cli version, ensuring consistency between the library and CLI tool across all CI jobs (check, test, build).

**Nix Caching:**
The Nix build job was rebuilding the entire store on every run, which is time-consuming. This PR adds `cache-nix-action` to cache the Nix store between workflow runs, significantly reducing build times for subsequent runs. The cache is keyed by `flake.lock` hash and includes cleanup policies to prevent unbounded growth.

## Test Plan

- [ ] Check job completes successfully with version extracted from Cargo.lock
- [ ] Test job runs with correct dioxus-cli version
- [ ] Build job produces artifacts with aligned tooling
- [ ] Nix build job completes faster on cache hit
- [ ] Verify cache cleanup policies prevent excessive storage usage