### PR TITLE
fix(nix): add CLI symlink for home-manager compatibility

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -160,6 +160,10 @@
 
                 mkdir -p $out/Applications
                 cp -r "$app_path" $out/Applications/
+
+                # Create symlink for CLI usage (enables `arto` command in PATH)
+                mkdir -p $out/bin
+                ln -s "$out/Applications/${appBundleName}/Contents/MacOS/${appExecutableName}" "$out/bin/${appExecutableName}"
               '';
             }
           );


### PR DESCRIPTION
## Summary

- Fix CLI functionality not being available when installed via Nix/home-manager

## Problem

PR #66 added CLI support allowing users to open files via `arto file.md`. However, `flake.nix` was not updated to reflect this.

The current `installPhaseCommand` only copies the `.app` bundle to `$out/Applications/`, without placing any binary in `$out/bin/`. Since home-manager adds binaries from `$out/bin/` to PATH, the `arto` command was unavailable for CLI usage.

## Solution

Add symlink creation to `installPhaseCommand`.

Build output:

```
result/
├── Applications/
│   └── Arto.app/           # GUI app (unchanged)
└── bin/
    └── arto → ../Applications/Arto.app/Contents/MacOS/arto  # NEW
```

🤖 Generated with https://claude.com/claude-code