### PR TITLE
fix(nix): display correct version in nix build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,6 +142,11 @@ jobs:
           purge-created: 0
           purge-last-accessed: 604800
           purge-primary-key: never
+      - name: Apply version
+        if: ${{ github.event_name == 'release' }}
+        run: |
+          sed -i '' "s/^version = \"0.0.0\"/version = \"${{ github.event.release.tag_name }}\"/" desktop/Cargo.toml
+          sed -i '' "s/^version = \"v\(.*\)\"/version = \"\1\"/" desktop/Cargo.toml
       - run: nix build
     timeout-minutes: 30
 

--- a/flake.nix
+++ b/flake.nix
@@ -27,10 +27,12 @@
           inherit (pkgs) lib;
           craneLib = crane.mkLib pkgs;
 
-          # Package metadata - single source of truth for version and paths
+          # Package metadata - read from Cargo.toml as single source of truth
+          # CI sets the actual version via sed before building (see .github/workflows/build.yml)
+          cargoToml = builtins.fromTOML (builtins.readFile ./desktop/Cargo.toml);
           packageMeta = {
-            pname = "arto";
-            version = "0.0.0";
+            pname = cargoToml.package.name;
+            version = cargoToml.package.version;
           };
 
           # Platform detection


### PR DESCRIPTION
## Summary

- Fix version displaying as "0.0.0" when installed via Nix/home-manager

## Problem

The About screen shows "Version 0.0.0" for Nix installations because `flake.nix` had a hardcoded version, while the regular build job dynamically injects the release tag into `Cargo.toml`.

## Solution

Apply the same version injection to Nix builds:
1. `flake.nix`: Read version from `Cargo.toml` via `builtins.fromTOML`
2. `build.yml`: Add "Apply version" step to `build-nix` job (same `sed` as `build` job)

🤖 Generated with Claude Code