### PR TITLE
fix: eliminate tokio dependency from window creation to prevent App Nap suspension

### DIFF
--- a/desktop/src/components/app.rs
+++ b/desktop/src/components/app.rs
@@ -33,7 +33,7 @@ const MOUSE_BUTTON_LEFT: u32 = 0;
 #[component]
 pub fn App(
     tab: Tab,           // Initial tab (always provided, preserves history)
-    directory: PathBuf, // Directory (resolved in create_new_main_window)
+    directory: PathBuf, // Directory (resolved in create_main_window or MainApp)
     theme: Theme,       // The enum: Auto/Light/Dark
     sidebar_open: bool,
     sidebar_width: f64,
@@ -69,6 +69,10 @@ pub fn App(
         let metrics = crate::window::metrics::capture_window_metrics(&window().window);
         *app_state.position.write() = LogicalPosition::new(metrics.position.x, metrics.position.y);
         *app_state.size.write() = LogicalSize::new(metrics.size.width, metrics.size.height);
+
+        // Register this window in MAIN_WINDOWS list for cross-window access.
+        // This enables fire-and-forget window creation (no need to await new_window()).
+        crate::window::register_main_window(std::rc::Rc::downgrade(&window()));
 
         // Register this window's state for cross-window access
         crate::window::register_window_state(window().id(), app_state);

--- a/desktop/src/components/sidebar/file_explorer.rs
+++ b/desktop/src/components/sidebar/file_explorer.rs
@@ -412,7 +412,7 @@ fn FileTreeNode(path: PathBuf, depth: usize, mut refresh_counter: Signal<u32>) -
                     directory,
                     ..Default::default()
                 };
-                crate::window::main::create_new_main_window(tab, params).await;
+                crate::window::main::create_main_window(tab, params).await;
             });
             show_context_menu.set(false);
         }

--- a/desktop/src/components/tab/tab_item.rs
+++ b/desktop/src/components/tab/tab_item.rs
@@ -106,7 +106,7 @@ pub fn TabItem(
                     directory,
                     ..Default::default()
                 };
-                crate::window::main::create_new_main_window(tab, params).await;
+                crate::window::main::create_main_window(tab, params).await;
 
                 // Close tab in source window after new window is created
                 state.close_tab(index);

--- a/desktop/src/ipc.rs
+++ b/desktop/src/ipc.rs
@@ -12,7 +12,9 @@
 //!                                                 ↓
 //!                                           accept connections
 //!                                                 ↓
-//!                                           recv JSON Lines → OPEN_EVENT_RECEIVER
+//!                                           recv JSON Lines → IPC_EVENT_QUEUE
+//!                                                 ↓
+//!                                           GCD wake → process_pending_events()
 //!
 //! 2nd Instance (Secondary):
 //!   main() → try_send_to_existing() succeeds → exit(0)
@@ -28,14 +30,169 @@
 //! {"type":"reopen"}
 //! ```
 
-use crate::components::main_app::OpenEvent;
 use interprocess::local_socket::{prelude::*, GenericFilePath, ListenerOptions, Stream, ToFsName};
 use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::sync::mpsc;
+use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
-use tokio::sync::mpsc::Sender;
+
+// ============================================================================
+// OpenEvent definition
+// ============================================================================
+
+/// Open event types for distinguishing files, directories, and reopen events.
+///
+/// Used to communicate between OS event handlers (main.rs custom_event_handler),
+/// IPC server (secondary instance), and the initial window setup (MainApp).
+#[derive(Debug, Clone)]
+pub enum OpenEvent {
+    /// File opened from Finder/CLI
+    File(PathBuf),
+    /// Directory opened from Finder/CLI (should set sidebar root)
+    Directory(PathBuf),
+    /// App icon clicked (reopen event)
+    Reopen,
+}
+
+// ============================================================================
+// IPC Event Queue — thread-safe queue for IPC → main thread communication
+// ============================================================================
+
+/// Global event queue for IPC messages.
+///
+/// IPC threads push events here via `push_event()`.
+/// The main thread drains them via `process_pending_events()`, which is called
+/// from the GCD wake callback or the custom_event_handler.
+static IPC_EVENT_QUEUE: OnceLock<Mutex<VecDeque<OpenEvent>>> = OnceLock::new();
+
+fn get_event_queue() -> &'static Mutex<VecDeque<OpenEvent>> {
+    IPC_EVENT_QUEUE.get_or_init(|| Mutex::new(VecDeque::new()))
+}
+
+/// Push an event to the IPC queue. Thread-safe.
+pub fn push_event(event: OpenEvent) {
+    get_event_queue()
+        .lock()
+        .expect("IPC event queue poisoned")
+        .push_back(event);
+}
+
+/// Pop the first event from the queue (for initial event in MainApp).
+pub fn try_pop_first_event() -> Option<OpenEvent> {
+    get_event_queue()
+        .lock()
+        .expect("IPC event queue poisoned")
+        .pop_front()
+}
+
+/// Drain all pending events from the IPC queue.
+fn drain_events() -> VecDeque<OpenEvent> {
+    std::mem::take(&mut *get_event_queue().lock().expect("IPC event queue poisoned"))
+}
+
+// ============================================================================
+// Main thread event processing — called from GCD callback or event handler
+// ============================================================================
+
+/// Process pending IPC events on the main thread.
+///
+/// MUST be called on the main thread (accesses MAIN_WINDOWS thread_local).
+/// Called from:
+/// - GCD wake callback (after IPC thread pushes events)
+/// - custom_event_handler (defense in depth)
+pub fn process_pending_events() {
+    let Some(desktop) = crate::window::get_any_main_window() else {
+        // No window available yet; events stay in queue for later processing
+        return;
+    };
+
+    let events = drain_events();
+    for event in events {
+        handle_event_on_main_thread(&desktop, event);
+    }
+}
+
+/// Handle a single event by creating/showing windows. Runs on main thread.
+fn handle_event_on_main_thread(
+    desktop: &std::rc::Rc<dioxus::desktop::DesktopService>,
+    event: OpenEvent,
+) {
+    match event {
+        OpenEvent::File(path) => {
+            tracing::debug!(?path, "Processing file open event");
+            crate::window::create_main_window_sync(
+                desktop,
+                crate::state::Tab::new(path),
+                crate::window::CreateMainWindowConfigParams::default(),
+            );
+        }
+        OpenEvent::Directory(dir) => {
+            tracing::debug!(?dir, "Processing directory open event");
+            let params = crate::window::CreateMainWindowConfigParams {
+                directory: Some(dir),
+                ..Default::default()
+            };
+            crate::window::create_main_window_sync(desktop, crate::state::Tab::default(), params);
+        }
+        OpenEvent::Reopen => {
+            tracing::debug!("Processing reopen event");
+            if crate::window::is_main_app_window_visible() {
+                crate::window::create_main_window_sync(
+                    desktop,
+                    crate::state::Tab::default(),
+                    crate::window::CreateMainWindowConfigParams::default(),
+                );
+            } else {
+                crate::window::show_main_app_window();
+            }
+        }
+    }
+}
+
+// ============================================================================
+// GCD wake mechanism — wake main thread from IPC background thread
+// ============================================================================
+
+/// Wake the main thread to process pending IPC events.
+///
+/// Uses macOS GCD to dispatch a callback to the main queue, which wakes
+/// CFRunLoop even when App Nap has suspended the process. The callback
+/// calls `process_pending_events()` on the main thread.
+#[cfg(target_os = "macos")]
+fn wake_main_thread() {
+    extern "C" {
+        // _dispatch_main_q is the GCD main dispatch queue (static symbol in libdispatch).
+        // dispatch_get_main_queue() is a C macro that expands to &_dispatch_main_q,
+        // so we reference the symbol directly for FFI.
+        static _dispatch_main_q: u8;
+        fn dispatch_async_f(
+            queue: *const u8,
+            context: *mut std::ffi::c_void,
+            work: extern "C" fn(*mut std::ffi::c_void),
+        );
+    }
+
+    extern "C" fn ipc_wake_callback(_context: *mut std::ffi::c_void) {
+        // Runs on the main thread via GCD — safe to access MAIN_WINDOWS thread_local
+        process_pending_events();
+    }
+
+    // SAFETY: _dispatch_main_q is a valid static symbol in libdispatch.
+    // dispatch_async_f schedules the callback on the main thread.
+    unsafe {
+        let main_queue = std::ptr::addr_of!(_dispatch_main_q);
+        dispatch_async_f(main_queue, std::ptr::null_mut(), ipc_wake_callback);
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn wake_main_thread() {
+    // On non-macOS platforms, rely on custom_event_handler to drain the IPC queue.
+    // Events will be processed on the next event loop iteration.
+}
 
 /// Socket name for IPC communication.
 const SOCKET_NAME: &str = "com.lambdalisue.arto.sock";
@@ -274,8 +431,7 @@ impl IpcMessage {
 ///
 /// ```no_run
 /// use std::path::Path;
-/// # use arto::components::main_app::OpenEvent;
-/// # use arto::ipc::validate_path;
+/// # use arto::ipc::{OpenEvent, validate_path};
 ///
 /// let event: Option<OpenEvent> = validate_path(Path::new("/path/to/file.md"));
 /// ```
@@ -354,8 +510,9 @@ fn send_messages_to_primary(mut stream: Stream, paths: &[PathBuf]) -> std::io::R
 
 /// Start the IPC server to listen for connections from new instances.
 ///
-/// This function spawns a background thread that accepts connections and forwards
-/// received paths to the given sender channel.
+/// This function spawns a background thread that accepts connections. Received
+/// events are pushed to the global IPC event queue and the main thread is woken
+/// via GCD to process them.
 ///
 /// # Thread Lifecycle
 ///
@@ -367,15 +524,12 @@ fn send_messages_to_primary(mut stream: Stream, paths: &[PathBuf]) -> std::io::R
 ///
 /// This design trade-off avoids the complexity of coordinating graceful shutdown
 /// with Dioxus's lifecycle. Any leftover socket file is harmless and cleaned up on next launch.
-///
-/// # Arguments
-/// * `tx` - Channel sender to forward received paths as OpenEvents
-pub fn start_ipc_server(tx: Sender<OpenEvent>) {
+pub fn start_ipc_server() {
     // Register cleanup handler for graceful shutdown
     register_cleanup_handler();
 
     std::thread::spawn(move || {
-        if let Err(e) = run_ipc_server_sync(tx) {
+        if let Err(e) = run_ipc_server_sync() {
             tracing::error!(
                 ?e,
                 "IPC server failed to start or encountered a fatal error; \
@@ -461,7 +615,7 @@ fn register_cleanup_handler() {
 }
 
 /// Internal sync IPC server implementation.
-fn run_ipc_server_sync(tx: Sender<OpenEvent>) -> anyhow::Result<()> {
+fn run_ipc_server_sync() -> anyhow::Result<()> {
     let socket_path = get_socket_path();
 
     // Ensure parent directory exists (for user-isolated paths like /tmp/arto-{uid}/)
@@ -498,11 +652,10 @@ fn run_ipc_server_sync(tx: Sender<OpenEvent>) -> anyhow::Result<()> {
     for conn in listener.incoming() {
         match conn {
             Ok(stream) => {
-                let tx = tx.clone();
                 if let Err(e) = std::thread::Builder::new()
                     .name("ipc-client-handler".into())
                     .spawn(move || {
-                        handle_client_connection(stream, tx);
+                        handle_client_connection(stream);
                     })
                 {
                     tracing::error!(?e, "Failed to spawn IPC client handler thread");
@@ -603,11 +756,15 @@ fn try_create_listener_once(
 }
 
 /// Handle a single client connection.
-fn handle_client_connection(stream: Stream, tx: Sender<OpenEvent>) {
+///
+/// Parses JSON Lines messages, pushes events to the global queue,
+/// and wakes the main thread via GCD to process them.
+fn handle_client_connection(stream: Stream) {
     // Set read timeout to avoid blocking forever
     set_socket_timeout(&stream, IPC_TIMEOUT);
 
     let reader = BufReader::new(stream);
+    let mut received_events = false;
 
     for line in reader.lines() {
         let line = match line {
@@ -632,12 +789,16 @@ fn handle_client_connection(stream: Stream, tx: Sender<OpenEvent>) {
             }
         };
 
-        tracing::info!(?message, "IPC: Received message from client");
+        tracing::debug!(?message, "Received IPC message");
 
         let event = message.into_open_event();
-        if let Err(e) = tx.blocking_send(event) {
-            tracing::warn!(?e, "IPC: Failed to send event to channel");
-        }
+        push_event(event);
+        received_events = true;
+    }
+
+    // Wake main thread once after processing all messages from this client
+    if received_events {
+        wake_main_thread();
     }
 }
 
@@ -781,5 +942,29 @@ mod tests {
     fn test_is_address_in_use_for_non_matching_error() {
         let err = std::io::Error::new(std::io::ErrorKind::NotFound, "not found");
         assert!(!is_address_in_use(&err));
+    }
+
+    #[test]
+    fn test_event_queue_fifo_ordering() {
+        // Drain any leftover events from other tests (global static is shared)
+        drain_events();
+
+        push_event(OpenEvent::File(PathBuf::from("/first.md")));
+        push_event(OpenEvent::Directory(PathBuf::from("/second")));
+        push_event(OpenEvent::Reopen);
+
+        // try_pop_first_event returns FIFO order
+        let first = try_pop_first_event();
+        assert!(matches!(first, Some(OpenEvent::File(p)) if p == Path::new("/first.md")));
+
+        // drain_events returns remaining in FIFO order
+        let remaining = drain_events();
+        assert_eq!(remaining.len(), 2);
+        assert!(matches!(&remaining[0], OpenEvent::Directory(p) if p == Path::new("/second")));
+        assert!(matches!(&remaining[1], OpenEvent::Reopen));
+
+        // Queue is empty after drain
+        assert!(try_pop_first_event().is_none());
+        assert!(drain_events().is_empty());
     }
 }

--- a/desktop/src/menu.rs
+++ b/desktop/src/menu.rs
@@ -1,4 +1,4 @@
-use dioxus::prelude::{spawn, ReadableExt, WritableExt};
+use dioxus::prelude::{ReadableExt, WritableExt};
 use dioxus_desktop::muda::accelerator::{Accelerator, Code, Modifiers};
 use dioxus_desktop::muda::{Menu, MenuEvent, MenuItem, PredefinedMenuItem, Submenu};
 use dioxus_desktop::window;
@@ -292,25 +292,25 @@ pub fn handle_menu_event_global(event: &MenuEvent) -> bool {
 
     match id {
         MenuId::NewWindow => {
-            spawn(async move {
-                window::create_new_main_window_with_empty(CreateMainWindowConfigParams::default())
-                    .await;
-            });
+            window::create_main_window_sync(
+                &window(),
+                crate::state::Tab::default(),
+                CreateMainWindowConfigParams::default(),
+            );
         }
         MenuId::NewTab => {
             if !window::has_any_main_windows() {
-                spawn(async move {
-                    window::create_new_main_window_with_empty(
-                        CreateMainWindowConfigParams::default(),
-                    )
-                    .await;
-                });
+                window::create_main_window_sync(
+                    &window(),
+                    crate::state::Tab::default(),
+                    CreateMainWindowConfigParams::default(),
+                );
                 return true;
             }
             return false;
         }
         MenuId::Preferences => {
-            // Preferences is now handled by state-based handler
+            // Declined here; requires per-window AppState access
             return false;
         }
         MenuId::CloseAllChildWindows => {

--- a/desktop/src/window.rs
+++ b/desktop/src/window.rs
@@ -52,9 +52,9 @@ pub use child::{
     open_or_focus_mermaid_window,
 };
 pub use main::{
-    close_all_main_windows, create_main_window_config, create_new_main_window_with_empty,
-    create_new_main_window_with_file, has_any_main_windows, is_main_app_window_visible,
-    register_main_window, register_window_state, show_main_app_window, unregister_window_state,
+    close_all_main_windows, create_main_window_config, create_main_window_sync,
+    get_any_main_window, has_any_main_windows, is_main_app_window_visible, register_main_window,
+    register_window_state, show_main_app_window, unregister_window_state,
     update_last_focused_window, CreateMainWindowConfigParams,
 };
 pub use preview::{

--- a/desktop/src/window/preview.rs
+++ b/desktop/src/window/preview.rs
@@ -11,7 +11,7 @@ use dioxus::desktop::tao::dpi::LogicalPosition;
 use dioxus::desktop::tao::window::WindowId;
 use dioxus::desktop::{window, DesktopService};
 
-use super::main::{create_new_main_window, CreateMainWindowConfigParams};
+use super::main::{create_main_window, CreateMainWindowConfigParams};
 use crate::state::Tab;
 
 // Thread-local state for the preview window
@@ -91,7 +91,7 @@ async fn create_new_preview_window(
     params.skip_position_shift = true;
 
     // Create the window and get handle directly
-    let window_handle = create_new_main_window(tab, params).await;
+    let window_handle = create_main_window(tab, params).await;
     let window_id = window_handle.window.id();
 
     // Set always on top so preview stays visible during drag


### PR DESCRIPTION
## Summary

macOS App Nap suspends the tokio runtime when all windows are hidden, causing window creation to hang indefinitely when triggered by external events (IPC, Finder, Dock). This PR eliminates tokio dependency from all externally-triggered window creation paths.

- Replace tokio channels with a global event queue + GCD (Grand Central Dispatch) wake mechanism
- Split window creation into sync fire-and-forget (`create_main_window_sync`) and async (`create_main_window`) paths
- Move event processing from Dioxus components to the Tao event loop
- Implement self-registration pattern in App component for cross-window access

## Problem

macOS App Nap suppresses CPU activity for processes with no visible windows. Before this change, the tokio runtime handled all event delivery, so when App Nap suspended it, `rx.recv().await` in `MainApp` never executed — creating a deadlock where only a visible window could wake the runtime, but creating that window required the runtime to be awake.

| Scenario | Before | After |
|----------|--------|-------|
| All windows hidden → `arto file.md` from CLI | Window not created (tokio suspended) | Window created reliably (GCD wakes CFRunLoop) |
| All windows hidden → Open file from Finder | Window not created | Window created reliably |
| All windows hidden → Click Dock icon | No response | Immediate response |

## Solution Architecture

### Before: tokio channel-based event delivery

```mermaid
graph LR
    IPC["IPC thread"] -->|tx.blocking_send| CH["tokio mpsc channel"]
    FINDER["Event::Opened"] -->|tx.try_send| CH
    DOCK["Event::Reopen"] -->|tx.try_send| CH
    CH -->|rx.recv.await| SF["spawn_forever loop
    (MainApp)"]
    SF -->|"spawn(async)"| CW["create_new_main_window
    .await"]
    CW --> W["Window created"]
```

### After: Global queue + GCD wake

```mermaid
graph LR
    IPC["IPC thread"] -->|push_event| Q["IPC_EVENT_QUEUE
    Mutex&lt;VecDeque&gt;"]
    FINDER["Event::Opened"] -->|push_event| Q
    DOCK["Event::Reopen"] -->|push_event| Q
    IPC -->|wake_main_thread| GCD["GCD
    dispatch_async_f"]
    FINDER -->|direct call| PP["process_pending_events"]
    DOCK -->|direct call| PP
    GCD -->|"callback (main thread)"| PP
    MEL["MainEventsCleared"] -->|"defense in depth"| PP
    PP -->|drain_events| Q
    PP -->|create_main_window_sync| W["Window created"]
```

The 4-layer async scheduling (channel → tokio scheduler → spawn → await) is replaced by a direct GCD → function call path.

### GCD wake mechanism

`dispatch_async_f` with `_dispatch_main_q` directly wakes the CFRunLoop at the OS level, bypassing the suspended tokio runtime entirely.

```rust
extern "C" {
    // dispatch_get_main_queue() is a C macro expanding to &_dispatch_main_q.
    // Macros can't be called via FFI, so we reference the static symbol directly.
    static _dispatch_main_q: u8;
    fn dispatch_async_f(
        queue: *const u8,
        context: *mut std::ffi::c_void,
        work: extern "C" fn(*mut std::ffi::c_void),
    );
}
```

On non-macOS platforms, `wake_main_thread()` is a no-op; events are drained by the Tao event loop's `MainEventsCleared` handler as a cross-platform defense-in-depth fallback.

### Fire-and-forget window creation

`create_main_window_sync()` drops the `PendingDesktopContext` immediately. This is safe because `new_window()` synchronously sends a `NewWindow` event via `EventLoopProxy` — the window is created when the event loop processes it, regardless of whether the Future is awaited. The App component self-registers in `MAIN_WINDOWS`, eliminating the need to await the window handle.

### IPC batch processing

Multiple paths from a single IPC client (e.g., `arto file1.md file2.md file3.md`) are queued first, then a single `wake_main_thread()` call is made — reducing GCD dispatches from N to 1.

## Architecture Changes

| Aspect | Before | After |
|--------|--------|-------|
| Event delivery | `tokio::sync::mpsc` channel | `OnceLock<Mutex<VecDeque<OpenEvent>>>` + GCD |
| Main thread wake | tokio task scheduler | macOS `dispatch_async_f` |
| Event processing | Dioxus component (`spawn_forever`) | Tao event loop (`custom_event_handler`) |
| Window creation (external) | `spawn(async { new_window.await })` | `create_main_window_sync()` (fire-and-forget) |
| Window registration | Caller responsibility | Self-registration in App component |
| OpenEvent definition | `components/main_app.rs` | `ipc.rs` |

## New Code

| Component | Location | Purpose |
|-----------|----------|---------|
| `IPC_EVENT_QUEUE` | `ipc.rs` | Global event queue (`OnceLock<Mutex<VecDeque<OpenEvent>>>`) |
| `push_event()` | `ipc.rs` | Thread-safe event queuing |
| `try_pop_first_event()` | `ipc.rs` | Initial event retrieval (for MainApp) |
| `process_pending_events()` | `ipc.rs` | Main thread event drain → window creation |
| `wake_main_thread()` | `ipc.rs` | macOS GCD wake via `dispatch_async_f` |
| `create_main_window_sync()` | `window/main.rs` | Tokio-free synchronous window creation |
| `get_any_main_window()` | `window/main.rs` | DesktopService access outside component context |
| `build_window_dom_and_config()` | `window/main.rs` | Shared window construction (sync + async) |

## Removed Code

| Component | Location | Reason |
|-----------|----------|--------|
| `OPEN_EVENT_RECEIVER` | `main_app.rs` | Replaced by global queue |
| `spawn_forever` loop | `main_app.rs` | Moved to Tao event handler |
| 60s heartbeat timer | `main_app.rs` | Root cause fixed, no longer needed |
| `create_new_main_window_with_file/empty()` | `window/main.rs` | Consolidated into shared helpers |
| `tokio::sync::mpsc::channel` | `main.rs` | Replaced by global queue |
| `Sender<OpenEvent>` arguments | `ipc.rs` | Replaced by `push_event()` |

## Edge Cases

- **GCD callback before MainApp registration**: `get_any_main_window()` returns `None`; events remain in queue and are processed on the next event loop cycle.
- **Concurrent IPC clients**: `push_event()` is `Mutex`-protected; each client calls `wake_main_thread()` independently, which is safe (GCD dispatch is idempotent).

## Unchanged Behavior

- Drag & drop preview windows (still async — drag presence prevents App Nap)
- Tab transfers between windows (broadcast channel)
- Configuration persistence (`PersistedState`, `Config`)
- File watcher behavior
- WebView cache handling

## Test plan

- [x] All 162 tests pass
- [x] `just fmt check test` clean
- [ ] Close all windows → `arto README.md` from CLI → window appears
- [ ] Close all windows → Click Dock icon → window appears
- [ ] Open file from Finder → window appears
- [ ] Repeat above after App Nap activation (wait several minutes with no visible windows)
