### PR TITLE
feat(mermaid): close Mermaid window with Cmd+W

### DIFF
--- a/desktop/src/components/mermaid_window.rs
+++ b/desktop/src/components/mermaid_window.rs
@@ -1,3 +1,4 @@
+use dioxus::desktop::{use_muda_event_handler, window};
 use dioxus::prelude::*;
 use sha2::{Digest, Sha256};
 
@@ -37,6 +38,16 @@ pub fn MermaidWindow(props: MermaidWindowProps) -> Element {
 
     // Setup zoom update handler
     use_zoom_update_handler(zoom_level);
+
+    // Handle Cmd+W and Cmd+Shift+W to close this child window
+    use_muda_event_handler(move |event| {
+        if !window().is_focused() {
+            return;
+        }
+        if crate::menu::is_close_action(event) {
+            window().close();
+        }
+    });
 
     rsx! {
         div {

--- a/desktop/src/menu.rs
+++ b/desktop/src/menu.rs
@@ -281,6 +281,14 @@ fn get_cmd_or_ctrl(code: Code, additional: Option<Modifiers>) -> Accelerator {
     Accelerator::new(Some(modifiers), code)
 }
 
+/// Check if a menu event is a close action (Close Tab or Close Window)
+pub fn is_close_action(event: &MenuEvent) -> bool {
+    matches!(
+        MenuId::from_str(event.id().0.as_ref()),
+        Some(MenuId::CloseTab | MenuId::CloseWindow)
+    )
+}
+
 /// Handle menu events that don't require app state
 pub fn handle_menu_event_global(event: &MenuEvent) -> bool {
     let menu_id = event.id().0.as_ref();


### PR DESCRIPTION
## Summary

- Add menu event handler to Mermaid child windows for Cmd+W (Close Tab) and Cmd+Shift+W (Close Window)
- Extract `is_close_action()` helper in `menu.rs` to detect close menu events without exposing `MenuId` enum
- Implement `window().is_focused()` guard pattern consistent with main window handlers

## Why

Previously, pressing Cmd+W when a Mermaid diagram window was focused did nothing. The menu event was dispatched to all registered handlers, but:

1. Main window handlers correctly skipped the event via `is_focused()` guard (the main window wasn't focused)
2. No handler existed in the child window to receive the event
3. The event was silently dropped, breaking macOS UX conventions

This frustrated users who expected Cmd+W to universally close the current window/tab across all macOS applications. The fix adds a handler to Mermaid windows that closes them when they receive close menu events, matching standard macOS behavior.

## Test Plan

- [x] `just fmt check test` passes (172 tests, 0 errors)
- [ ] Open a Markdown file with a Mermaid diagram
- [ ] Click the viewer button to open Mermaid child window
- [ ] Focus the Mermaid window, press Cmd+W → window closes
- [ ] Reopen Mermaid window, press Cmd+Shift+W → window closes
- [ ] Verify main window remains open after closing Mermaid window
- [ ] Focus main window with Mermaid window open, press Cmd+W → tab closes, Mermaid window unaffected
- [ ] Open multiple Mermaid windows → Cmd+W closes only the focused one

Closes #101