### PR TITLE
fix(just): add setup recipe to root justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -5,6 +5,8 @@ mod renderer
 default:
   @just --list
 
+setup: renderer::setup
+
 fmt: desktop::fmt renderer::fmt
 
 check: renderer::assets desktop::check renderer::check


### PR DESCRIPTION
## Summary

- Add a root-level `setup` recipe in `justfile`
- Wire the new recipe to `renderer::setup` so `just setup` runs `pnpm install`
- Align executable setup flow with `CONTRIBUTING.md`

## Why

`CONTRIBUTING.md` documents `just setup` as the manual setup entry point, but the root `justfile` previously had no `setup` recipe. This mismatch caused an immediate command failure for contributors following the documented flow.

## Implementation

- Updated `justfile`:
  - Added `setup: renderer::setup`
- No behavior changes to existing recipes (`fmt`, `check`, `test`, `build`, etc.)
- Scope is limited to a single file: `justfile`

## Test Plan

- [x] `just setup` succeeds
- [x] `just --list` shows `setup`
- [x] `just fmt check test` succeeds