### PR TITLE
Fix file reload mechanism through centralized trigger pattern

### DIFF
--- a/desktop/src/components/content/file_viewer.rs
+++ b/desktop/src/components/content/file_viewer.rs
@@ -26,7 +26,6 @@ const MIDDLE_CLICK: u32 = 1;
 pub fn FileViewer(file: PathBuf) -> Element {
     let state = use_context::<AppState>();
     let html = use_signal(String::new);
-    let reload_trigger = use_signal(|| 0usize);
 
     // Get base directory for link resolution
     let base_dir = file
@@ -35,8 +34,8 @@ pub fn FileViewer(file: PathBuf) -> Element {
         .unwrap_or_else(|| PathBuf::from("."));
 
     // Setup component hooks
-    use_file_loader(file.clone(), html, reload_trigger, state);
-    use_file_watcher(file.clone(), reload_trigger, state);
+    use_file_loader(file.clone(), html, state);
+    use_file_watcher(file.clone(), state);
     use_link_click_handler(file.clone(), state);
     use_mermaid_window_handler();
     use_context_menu_handler(file.clone(), base_dir);
@@ -54,15 +53,16 @@ pub fn FileViewer(file: PathBuf) -> Element {
 }
 
 /// Hook to load and render file content
-fn use_file_loader(
-    file: PathBuf,
-    html: Signal<String>,
-    reload_trigger: Signal<usize>,
-    mut state: AppState,
-) {
-    use_effect(use_reactive!(|file, reload_trigger| {
+fn use_file_loader(file: PathBuf, html: Signal<String>, mut state: AppState) {
+    use_effect(use_reactive!(|file| {
         let mut html = html;
-        let _ = reload_trigger();
+        // Subscribe to reload_trigger via Dioxus auto-subscription so this
+        // effect re-runs when the counter changes (manual reload or file watcher).
+        // NOTE: We intentionally read() here instead of adding reload_trigger to the
+        // use_reactive!(|...|) argument list, because use_reactive! compares Signal
+        // by pointer identity — the same Signal object is always "equal" to itself,
+        // so value changes would never be detected.
+        let _ = state.reload_trigger.read();
         let file = file.clone();
 
         // Handle scroll position SYNCHRONOUSLY before spawning async task.
@@ -266,9 +266,8 @@ async fn reapply_search() {
 }
 
 /// Hook to watch file for changes and trigger reload
-fn use_file_watcher(file: PathBuf, reload_trigger: Signal<usize>, mut state: AppState) {
+fn use_file_watcher(file: PathBuf, mut state: AppState) {
     use_effect(use_reactive!(|file| {
-        let mut reload_trigger = reload_trigger;
         let file = file.clone();
 
         spawn(async move {
@@ -287,11 +286,7 @@ fn use_file_watcher(file: PathBuf, reload_trigger: Signal<usize>, mut state: App
 
             while watcher.recv().await.is_some() {
                 tracing::info!("File change detected, reloading: {:?}", file_path);
-                // Save current scroll position before reloading so it can be restored
-                // after the content re-renders (reuses the back/forward restoration mechanism)
-                let scroll = *state.current_scroll_position.read();
-                state.pending_scroll_position.set(Some(scroll));
-                reload_trigger.set(reload_trigger() + 1);
+                state.reload_current_tab();
             }
 
             if let Err(e) = FILE_WATCHER.unwatch(file_path.clone()).await {

--- a/desktop/src/components/header.rs
+++ b/desktop/src/components/header.rs
@@ -45,12 +45,7 @@ pub fn Header() -> Element {
         // Set reloading state
         is_reloading_write.set(true);
 
-        state.update_current_tab(|tab| {
-            if let Some(path) = tab.file() {
-                // Reload by reassigning the same file path
-                tab.content = crate::state::TabContent::File(path.to_owned());
-            }
-        });
+        state.reload_current_tab();
 
         // Reset reloading state after animation
         spawn(async move {

--- a/desktop/src/state/app_state.rs
+++ b/desktop/src/state/app_state.rs
@@ -83,6 +83,10 @@ pub struct AppState {
     /// Current scroll position of the content area.
     /// Updated by scroll events, used to save position before back/forward navigation.
     pub current_scroll_position: Signal<f64>,
+    /// Reload trigger counter. Incrementing this forces FileViewer to re-read the file
+    /// from disk without going through the use_memo PartialEq gate in content.rs.
+    /// Used by manual reload (header button, tab context menu) and file watcher.
+    pub reload_trigger: Signal<usize>,
 }
 
 impl AppState {
@@ -112,6 +116,7 @@ impl AppState {
             pinned_matches: Signal::new(HashMap::new()),
             pending_scroll_position: Signal::new(None),
             current_scroll_position: Signal::new(0.0),
+            reload_trigger: Signal::new(0),
         }
     }
 }

--- a/desktop/src/state/app_state/tabs/state_ext.rs
+++ b/desktop/src/state/app_state/tabs/state_ext.rs
@@ -500,30 +500,33 @@ impl AppState {
         }
     }
 
-    /// Reload the current tab.
-    /// For file tabs, this re-reads the file from disk.
-    /// For other tab types, this forces a re-render.
+    /// Reload the current tab's file from disk, preserving scroll position.
+    ///
+    /// Increments the `reload_trigger` counter which FileViewer subscribes to
+    /// via Dioxus auto-subscription. This bypasses the `use_memo` `PartialEq`
+    /// gate in `content.rs` that would otherwise block re-renders when the
+    /// `PathBuf` hasn't changed.
+    ///
+    /// For `TabContent::FileError` tabs, switches back to `TabContent::File`
+    /// to allow retrying the load (without pushing to history).
+    ///
+    /// No-op for non-file tabs (Preferences, Inline, NoFile, etc.).
     pub fn reload_current_tab(&mut self) {
-        // Get the current file path if it's a file tab
-        let file_path = self
-            .current_tab()
-            .and_then(|tab| tab.file().map(|p| p.to_path_buf()));
-
-        if let Some(path) = file_path {
-            // Re-navigate to the same file to force reload
+        if self.current_tab().is_some_and(|tab| tab.file().is_some()) {
+            // If current tab is FileError, switch back to File to allow retry
             self.update_current_tab(|tab| {
-                tab.navigate_to(path);
+                if let TabContent::FileError(path, _) = &tab.content {
+                    tab.content = TabContent::File(path.clone());
+                }
             });
+
+            // Save current scroll position so it can be restored after reload
+            let scroll = *self.current_scroll_position.read();
+            self.pending_scroll_position.set(Some(scroll));
+            let current = *self.reload_trigger.read();
+            self.reload_trigger.set(current + 1);
         } else {
-            // For non-file tabs, trigger a reactive update by touching the tabs signal
-            // This forces components watching the signal to re-render
-            let mut tabs = self.tabs.write();
-            let active_index = *self.active_tab.read();
-            if let Some(tab) = tabs.get_mut(active_index) {
-                // Touch the tab to trigger change detection
-                let content = tab.content.clone();
-                tab.content = content;
-            }
+            tracing::debug!("Reload requested but current tab is not a file tab");
         }
     }
 }


### PR DESCRIPTION
## Summary

- Unified manual reload (header button) and file-watcher reload into a single centralized mechanism using `AppState.reload_trigger`
- Eliminated duplicate scroll position handling logic between file-watcher and manual reload
- Fixed architectural issue where file-watcher was incrementing a component-local signal instead of using centralized state

## Why

Before this change, file reloading was handled through two different mechanisms:

1. **Manual reload (header button)**: Reassigned `tab.content = TabContent::File(path)` to trigger the `use_memo` PartialEq gate in `content.rs`, forcing FileViewer re-creation
2. **File-watcher**: Incremented a component-local `reload_trigger` signal directly in `file_viewer.rs`

This created several problems:

- Duplicate scroll position preservation logic (file-watcher had its own implementation)
- Architectural violation: file-watcher reached into component-local state instead of going through AppState
- Manual reload changed tab content identity, which could disrupt other reactive dependencies

The new design introduces a centralized `reload_trigger` counter in `AppState` that both mechanisms increment. FileViewer subscribes to this counter via Dioxus auto-subscription, bypassing the `use_memo` PartialEq gate without changing tab content identity.

## Test Plan

- [ ] Manual reload via header button preserves scroll position
- [ ] File-watcher reload preserves scroll position when file changes externally
- [ ] Reload button animation works correctly
- [ ] Reloading non-file tabs (Preferences, NoFile) is a no-op
- [ ] Multiple rapid reloads don't cause race conditions