### PR TITLE
fix(renderer): defer DOM mutations during async render to prevent lost updates

### DIFF
--- a/renderer/src/main.ts
+++ b/renderer/src/main.ts
@@ -16,6 +16,8 @@ declare global {
       restoreSelection: typeof restoreSelection;
       /** Register a callback to be called when rendering (Mermaid, KaTeX, etc.) completes */
       onRenderComplete: (callback: () => void) => void;
+      /** Force a render pass for any content already in the DOM */
+      scheduleRender: () => void;
       search: {
         setup: typeof findInPage.setup;
         find: typeof findInPage.find;
@@ -60,6 +62,7 @@ export function init(): void {
     setupContextMenu,
     restoreSelection,
     onRenderComplete: (callback) => renderCoordinator.onRenderComplete(callback),
+    scheduleRender: () => renderCoordinator.scheduleRender(),
     search: {
       setup: findInPage.setup,
       find: findInPage.find,

--- a/renderer/src/render-coordinator.ts
+++ b/renderer/src/render-coordinator.ts
@@ -6,12 +6,22 @@ import * as codeCopy from "./code-copy";
 class RenderCoordinator {
   #rafId: number | null = null;
   #isRendering = false;
+  #hasPendingMutations = false;
+  #pendingMutationRetries = 0;
   #renderCompleteCallbacks: Array<() => void> = [];
+
+  // Safety limit to prevent infinite render loops caused by
+  // renderers modifying the DOM (e.g., Mermaid SVG insertion).
+  // In practice, data-rendered/data-highlighted guards on individual
+  // renderers terminate the cycle after 1-2 iterations.
+  static readonly #MAX_PENDING_RETRIES = 3;
 
   init(): void {
     const observer = new MutationObserver((mutations) => {
-      // Skip if currently rendering to avoid cascade
+      // Defer mutations that arrive while rendering to avoid cascade.
+      // They will be re-scheduled after the current render completes.
       if (this.#isRendering) {
+        this.#hasPendingMutations = true;
         return;
       }
 
@@ -116,6 +126,7 @@ class RenderCoordinator {
         console.error("RenderCoordinator: Error during Mermaid re-render:", error);
       } finally {
         this.#isRendering = false;
+        this.#processPendingMutations();
       }
     });
   }
@@ -126,6 +137,8 @@ class RenderCoordinator {
     const markdownBodies = document.querySelectorAll(".markdown-body");
     if (markdownBodies.length === 0) {
       this.#isRendering = false;
+      this.#fireRenderCompleteCallbacks();
+      this.#processPendingMutations();
       return;
     }
 
@@ -139,12 +152,36 @@ class RenderCoordinator {
         }),
       );
       console.debug("RenderCoordinator: Batch render completed");
-      this.#fireRenderCompleteCallbacks();
     } catch (error) {
       console.error("RenderCoordinator: Error during batch render:", error);
     } finally {
       this.#isRendering = false;
+      this.#fireRenderCompleteCallbacks();
+      this.#processPendingMutations();
     }
+  }
+
+  #processPendingMutations(): void {
+    if (!this.#hasPendingMutations) {
+      this.#pendingMutationRetries = 0;
+      return;
+    }
+
+    this.#hasPendingMutations = false;
+    this.#pendingMutationRetries++;
+
+    if (this.#pendingMutationRetries > RenderCoordinator.#MAX_PENDING_RETRIES) {
+      console.warn(
+        `RenderCoordinator: Max pending mutation retries (${RenderCoordinator.#MAX_PENDING_RETRIES}) reached, breaking potential loop`,
+      );
+      this.#pendingMutationRetries = 0;
+      return;
+    }
+
+    console.debug(
+      `RenderCoordinator: Processing deferred mutations (attempt ${this.#pendingMutationRetries})`,
+    );
+    this.scheduleRender();
   }
 }
 


### PR DESCRIPTION
## Summary

- Fixes race condition where DOM mutations arriving during async render were silently dropped
- Adds deferred mutation queue that processes changes after render completes
- Prevents lost Mermaid diagrams and KaTeX expressions when content loads quickly

## Why

The RenderCoordinator's MutationObserver previously skipped mutations that arrived while `#isRendering` was true. This worked for simple cases but created a race condition:

1. Initial HTML loads → MutationObserver fires → `scheduleRender()` queued
2. Async render starts (Mermaid/KaTeX processing) → `#isRendering = true`
3. **New mutation arrives** (e.g., user switches tabs, more content loaded) → **silently ignored**
4. Render completes → `#isRendering = false`
5. **Lost mutation never processed** → Mermaid/KaTeX blocks remain unrendered

This fix tracks pending mutations with `#hasPendingMutations` flag and re-schedules render after completion. A retry limit (3 attempts) prevents infinite loops from renderers that modify the DOM.

## Test Plan

- [x] Verify Mermaid diagrams render when switching tabs rapidly
- [x] Verify KaTeX expressions render during fast content updates
- [x] Check console for "Processing deferred mutations" debug logs
- [x] Confirm no infinite loops (max 3 retry attempts)
- [x] Test with multiple markdown files loaded simultaneously