### PR TITLE
fix(desktop): re-exec with canonical path when launched via macOS symlink

### DIFF
--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -31,6 +31,37 @@ struct Cli {
 }
 
 fn main() {
+    // Re-exec with the canonical path if launched via a symlink.
+    //
+    // On macOS, `current_exe()` uses `_NSGetExecutablePath` which may return the
+    // symlink path (e.g., /opt/homebrew/bin/arto) instead of the real binary
+    // inside the .app bundle. Dioxus's asset resolver (`get_asset_root()`) then
+    // computes the wrong Resources directory, causing CSS/JS to fail to load.
+    //
+    // Linux is unaffected because `current_exe()` reads `/proc/self/exe` which
+    // always resolves symlinks.
+    //
+    // See: https://github.com/arto-app/Arto/issues/121
+    #[cfg(target_os = "macos")]
+    {
+        use std::os::unix::process::CommandExt;
+        if let Ok(exe) = std::env::current_exe() {
+            if let Ok(canonical) = exe.canonicalize() {
+                if exe != canonical {
+                    let err = std::process::Command::new(&canonical)
+                        .args(std::env::args_os().skip(1))
+                        .exec();
+                    eprintln!(
+                        "Failed to re-exec with canonical path (from {} to {}): {err}",
+                        exe.display(),
+                        canonical.display(),
+                    );
+                    std::process::exit(1);
+                }
+            }
+        }
+    }
+
     let cli = Cli::parse();
     if let arto::RunResult::SentToExistingInstance = arto::run(cli.paths) {
         std::process::exit(0);


### PR DESCRIPTION
## Summary
- Fixes broken styling when Arto is launched via symlink on macOS (e.g., `/opt/homebrew/bin/arto`)
- Detects symlink launch and re-executes with canonical path to .app bundle
- Ensures Dioxus asset resolver finds correct Resources directory

## Why

On macOS, when Arto is launched via a Homebrew symlink (`/opt/homebrew/bin/arto`), `std::env::current_exe()` returns the symlink path instead of the actual binary inside the `.app` bundle. This causes Dioxus's `get_asset_root()` to compute the wrong path to the `Resources` directory, resulting in CSS and JavaScript files failing to load.

The fix detects this scenario at startup and re-executes the process with the canonicalized path, ensuring the asset resolver works correctly.

Linux is unaffected because its `/proc/self/exe` always resolves symlinks automatically.

## Test Plan
- [ ] Build and install via `cargo install --path desktop`
- [ ] Launch via symlink: `/opt/homebrew/bin/arto`
- [ ] Verify styling loads correctly
- [ ] Verify no infinite re-exec loop occurs
- [ ] Test on macOS with both symlink and direct `.app` launch