### PR TITLE
fix(ipc): use CGWindowList and overlap ratio to correctly detect Aerospace-hidden windows

### DIFF
--- a/desktop/Cargo.lock
+++ b/desktop/Cargo.lock
@@ -159,6 +159,8 @@ dependencies = [
  "chrono",
  "clap",
  "compile-time",
+ "core-foundation 0.10.1",
+ "core-graphics 0.24.0",
  "dark-light",
  "dioxus",
  "dioxus-desktop",

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -50,6 +50,8 @@ libc = "0.2.180"
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6.3"
 objc2-app-kit = "0.3.2"
+core-graphics = "0.24"
+core-foundation = "0.10"
 tracing-oslog = "0.3.0"
 
 [dev-dependencies]

--- a/desktop/src/cli.rs
+++ b/desktop/src/cli.rs
@@ -2,17 +2,20 @@ use std::path::PathBuf;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CliOpenMode {
+    /// Use the behavior from config.json (fileOpen setting).
+    Config,
     LastFocused,
     CurrentScreen,
     NewWindow,
 }
 
 impl CliOpenMode {
-    pub(crate) fn to_file_open_behavior(self) -> crate::config::FileOpenBehavior {
+    pub(crate) fn to_file_open_behavior(self) -> Option<crate::config::FileOpenBehavior> {
         match self {
-            Self::LastFocused => crate::config::FileOpenBehavior::LastFocused,
-            Self::CurrentScreen => crate::config::FileOpenBehavior::CurrentScreen,
-            Self::NewWindow => crate::config::FileOpenBehavior::NewWindow,
+            Self::Config => None,
+            Self::LastFocused => Some(crate::config::FileOpenBehavior::LastFocused),
+            Self::CurrentScreen => Some(crate::config::FileOpenBehavior::CurrentScreen),
+            Self::NewWindow => Some(crate::config::FileOpenBehavior::NewWindow),
         }
     }
 }

--- a/desktop/src/ipc.rs
+++ b/desktop/src/ipc.rs
@@ -245,7 +245,7 @@ mod tests {
     use indoc::indoc;
     use std::path::{Path, PathBuf};
     use window_selection::{
-        choose_open_target, is_window_on_display, OpenTarget, WindowSelectionInput,
+        choose_open_target, is_window_on_display, OpenTarget, WindowBounds, WindowSelectionInput,
     };
 
     // Re-import protocol types used by tests
@@ -543,20 +543,68 @@ mod tests {
     }
 
     #[test]
-    fn test_is_window_on_display_detects_overlap() {
+    fn test_is_window_on_display_fully_inside() {
         let display = (LogicalPosition::new(0, 0), LogicalSize::new(1920, 1080));
-        let window_position = LogicalPosition::new(1800, 900);
-        let window_size = LogicalSize::new(400, 300);
-
-        assert!(is_window_on_display(display, window_position, window_size));
+        let bounds = WindowBounds {
+            x: 300,
+            y: 250,
+            width: 400,
+            height: 300,
+        };
+        assert!(is_window_on_display(display, bounds));
     }
 
     #[test]
-    fn test_is_window_on_display_returns_false_without_overlap() {
+    fn test_is_window_on_display_spanning_two_monitors() {
         let display = (LogicalPosition::new(0, 0), LogicalSize::new(1920, 1080));
-        let window_position = LogicalPosition::new(1921, 0);
-        let window_size = LogicalSize::new(400, 300);
+        // Window straddles the right edge: 50% on left monitor
+        let bounds = WindowBounds {
+            x: 1720,
+            y: 200,
+            width: 400,
+            height: 300,
+        };
+        // overlap = 200*300 = 60000, window = 400*300 = 120000 → 50% > 10%
+        assert!(is_window_on_display(display, bounds));
+    }
 
-        assert!(!is_window_on_display(display, window_position, window_size));
+    #[test]
+    fn test_is_window_on_display_minor_overlap_rejected() {
+        let display = (LogicalPosition::new(0, 0), LogicalSize::new(1920, 1080));
+        // Only 20px overlap on a 400px-wide window → 5% < 10%
+        let bounds = WindowBounds {
+            x: 1900,
+            y: 200,
+            width: 400,
+            height: 300,
+        };
+        // overlap = 20*300 = 6000, window = 400*300 = 120000 → 5% < 10%
+        assert!(!is_window_on_display(display, bounds));
+    }
+
+    #[test]
+    fn test_is_window_on_display_completely_outside() {
+        let display = (LogicalPosition::new(0, 0), LogicalSize::new(1920, 1080));
+        let bounds = WindowBounds {
+            x: 1921,
+            y: 0,
+            width: 400,
+            height: 300,
+        };
+        assert!(!is_window_on_display(display, bounds));
+    }
+
+    #[test]
+    fn test_is_window_on_display_hidden_in_corner() {
+        let display = (LogicalPosition::new(0, 0), LogicalSize::new(1920, 1080));
+        // Simulates Aerospace hideInCorner: window at bottom-right with 1px overlap
+        // overlap = 1*1 = 1, window = 1265*2109 → ~0.00004% < 10%
+        let bounds = WindowBounds {
+            x: 5119,
+            y: 2132,
+            width: 1265,
+            height: 2109,
+        };
+        assert!(!is_window_on_display(display, bounds));
     }
 }

--- a/desktop/src/ipc/client.rs
+++ b/desktop/src/ipc/client.rs
@@ -48,7 +48,7 @@ fn send_messages_to_primary(
         IpcMessage::from_open_request(request)
     } else {
         IpcMessage::Reopen {
-            behavior: Some(invocation.open_mode.to_file_open_behavior()),
+            behavior: invocation.open_mode.to_file_open_behavior(),
         }
     };
 

--- a/desktop/src/ipc/protocol.rs
+++ b/desktop/src/ipc/protocol.rs
@@ -117,7 +117,7 @@ pub fn build_open_request(invocation: &crate::cli::CliInvocation) -> Option<Open
     Some(OpenRequest {
         files,
         directory,
-        behavior: Some(invocation.open_mode.to_file_open_behavior()),
+        behavior: invocation.open_mode.to_file_open_behavior(),
     })
 }
 
@@ -255,6 +255,22 @@ mod tests {
             request.behavior,
             Some(crate::config::FileOpenBehavior::CurrentScreen)
         );
+    }
+
+    #[test]
+    fn build_open_request_maps_config_mode_to_none_behavior() {
+        let temp = tempfile::tempdir().unwrap();
+        let file = temp.path().join("README.md");
+        std::fs::write(&file, "# test").unwrap();
+
+        let invocation = CliInvocation {
+            paths: vec![file],
+            directory: None,
+            open_mode: CliOpenMode::Config,
+        };
+
+        let request = build_open_request(&invocation).unwrap();
+        assert_eq!(request.behavior, None);
     }
 
     #[test]

--- a/desktop/src/ipc/window_selection.rs
+++ b/desktop/src/ipc/window_selection.rs
@@ -74,23 +74,19 @@ pub(super) fn select_target_window_with_behavior(
 fn collect_visible_window_selection_inputs(
     current_display_bounds: Option<(LogicalPosition<i32>, LogicalSize<u32>)>,
 ) -> Vec<WindowSelectionInput<WindowId>> {
+    let on_screen_bounds = get_on_screen_window_bounds();
+
     crate::window::main::list_visible_main_windows()
         .into_iter()
         .map(|ctx| {
-            let scale_factor = ctx.window.scale_factor();
-            // Use consistent outer bounds (outer_position + outer_size) for display overlap detection
-            let window_position = ctx
-                .window
-                .outer_position()
-                .map(|p| LogicalPosition::from_physical(p, scale_factor))
-                .unwrap_or_else(|_| {
-                    let metrics = crate::window::metrics::capture_window_metrics(&ctx.window);
-                    LogicalPosition::new(metrics.position.x, metrics.position.y)
-                });
-            let window_size = ctx.window.outer_size().to_logical(scale_factor);
-            let is_on_current_screen = current_display_bounds
-                .map(|display| is_window_on_display(display, window_position, window_size))
-                .unwrap_or(false);
+            let window_number = get_window_number(&ctx.window);
+            let is_on_current_screen = match (window_number, current_display_bounds) {
+                (Some(wn), Some(display)) => on_screen_bounds
+                    .get(&wn)
+                    .map(|bounds| is_window_on_display(display, *bounds))
+                    .unwrap_or(false),
+                _ => false,
+            };
             WindowSelectionInput {
                 window_id: ctx.window.id(),
                 is_on_current_screen,
@@ -99,10 +95,165 @@ fn collect_visible_window_selection_inputs(
         .collect()
 }
 
+/// Window bounds as reported by the window server (actual compositor position).
+#[derive(Debug, Clone, Copy)]
+pub(super) struct WindowBounds {
+    pub(super) x: i32,
+    pub(super) y: i32,
+    pub(super) width: u32,
+    pub(super) height: u32,
+}
+
+/// Get the NSWindow.windowNumber for a Tao window.
+#[cfg(target_os = "macos")]
+fn get_window_number(window: &dioxus::desktop::tao::window::Window) -> Option<i64> {
+    use dioxus::desktop::tao::platform::macos::WindowExtMacOS;
+    use objc2_app_kit::NSWindow;
+
+    let ns_window_ptr = window.ns_window() as *const NSWindow;
+    if ns_window_ptr.is_null() {
+        return None;
+    }
+    // SAFETY: ns_window_ptr is checked for null and ns_window() returns
+    // a valid NSWindow pointer for the lifetime of the Window.
+    let ns_window: &NSWindow = unsafe { &*ns_window_ptr };
+    Some(ns_window.windowNumber() as i64)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn get_window_number(_window: &dioxus::desktop::tao::window::Window) -> Option<i64> {
+    None
+}
+
+/// Query the window server for actual on-screen window bounds.
+///
+/// Uses `CGWindowListCopyWindowInfo(kCGWindowListOptionOnScreenOnly)` to get the
+/// real compositor-level bounds. This reflects positions set by external tools
+/// (e.g. Aerospace tiling WM) that move windows via the Accessibility API,
+/// which may not be reflected in Tao's `outer_position()`.
+#[cfg(target_os = "macos")]
+fn get_on_screen_window_bounds() -> std::collections::HashMap<i64, WindowBounds> {
+    use core_foundation::base::TCFType;
+    use core_foundation::number::CFNumber;
+    use core_foundation::string::CFString;
+    use core_graphics::window::{
+        copy_window_info, kCGNullWindowID, kCGWindowBounds, kCGWindowListOptionOnScreenOnly,
+        kCGWindowNumber,
+    };
+
+    let mut result = std::collections::HashMap::new();
+
+    let Some(info) = copy_window_info(kCGWindowListOptionOnScreenOnly, kCGNullWindowID) else {
+        return result;
+    };
+
+    let wn_key = unsafe { CFString::wrap_under_get_rule(kCGWindowNumber) };
+    let bounds_key = unsafe { CFString::wrap_under_get_rule(kCGWindowBounds) };
+
+    for i in 0..info.len() {
+        let dict_ptr = unsafe {
+            core_foundation::array::CFArrayGetValueAtIndex(info.as_concrete_TypeRef(), i)
+        };
+        if dict_ptr.is_null() {
+            continue;
+        }
+
+        // Get window number
+        let wn_cfnum = unsafe {
+            cf_dict_get_value(
+                dict_ptr as core_foundation::dictionary::CFDictionaryRef,
+                &wn_key,
+            )
+        };
+        let Some(wn_cfnum) = wn_cfnum else {
+            continue;
+        };
+        let wn_cfnum = unsafe {
+            CFNumber::wrap_under_get_rule(wn_cfnum as core_foundation::number::CFNumberRef)
+        };
+        let Some(window_number) = wn_cfnum.to_i64() else {
+            continue;
+        };
+
+        // Get window bounds (CGRect stored as CFDictionary with X, Y, Width, Height)
+        let bounds_ptr = unsafe {
+            cf_dict_get_value(
+                dict_ptr as core_foundation::dictionary::CFDictionaryRef,
+                &bounds_key,
+            )
+        };
+        let Some(bounds_ptr) = bounds_ptr else {
+            continue;
+        };
+        let bounds_dict = bounds_ptr as core_foundation::dictionary::CFDictionaryRef;
+
+        let get_f64 = |key: &str| -> f64 {
+            let cf_key = CFString::new(key);
+            let val = unsafe { cf_dict_get_value(bounds_dict, &cf_key) };
+            val.and_then(|v| {
+                let num = unsafe {
+                    CFNumber::wrap_under_get_rule(v as core_foundation::number::CFNumberRef)
+                };
+                num.to_f64()
+            })
+            .unwrap_or(0.0)
+        };
+
+        result.insert(
+            window_number,
+            WindowBounds {
+                x: get_f64("X") as i32,
+                y: get_f64("Y") as i32,
+                width: get_f64("Width") as u32,
+                height: get_f64("Height") as u32,
+            },
+        );
+    }
+
+    result
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn cf_dict_get_value(
+    dict: core_foundation::dictionary::CFDictionaryRef,
+    key: &core_foundation::string::CFString,
+) -> Option<*const std::ffi::c_void> {
+    use core_foundation::base::TCFType;
+
+    let mut val: *const std::ffi::c_void = std::ptr::null();
+    let found = core_foundation::dictionary::CFDictionaryGetValueIfPresent(
+        dict,
+        key.as_concrete_TypeRef() as *const _,
+        &mut val,
+    );
+    if found != 0 && !val.is_null() {
+        Some(val)
+    } else {
+        None
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn get_on_screen_window_bounds() -> std::collections::HashMap<i64, WindowBounds> {
+    std::collections::HashMap::new()
+}
+
+/// Minimum overlap ratio (0.0–1.0) for a window to be considered "on" a display.
+///
+/// Aerospace hides windows by moving them to a corner with only ~1px inside the
+/// display. A threshold of 10% rejects those hidden windows while still accepting
+/// windows that legitimately span two monitors.
+const MIN_OVERLAP_RATIO: f64 = 0.1;
+
+/// Check if a window has significant overlap with a display.
+///
+/// Returns true when at least [`MIN_OVERLAP_RATIO`] of the window's area overlaps
+/// the display. This correctly handles:
+/// - Aerospace hiding windows in corners with ~1px overlap → rejected
+/// - Windows spanning two monitors → accepted on whichever display they overlap
 pub(super) fn is_window_on_display(
     display_bounds: (LogicalPosition<i32>, LogicalSize<u32>),
-    window_position: LogicalPosition<i32>,
-    window_size: LogicalSize<u32>,
+    bounds: WindowBounds,
 ) -> bool {
     let (display_origin, display_size) = display_bounds;
     let display_left = display_origin.x;
@@ -110,13 +261,27 @@ pub(super) fn is_window_on_display(
     let display_right = display_left + display_size.width as i32;
     let display_bottom = display_top + display_size.height as i32;
 
-    let window_left = window_position.x;
-    let window_top = window_position.y;
-    let window_right = window_left + window_size.width as i32;
-    let window_bottom = window_top + window_size.height as i32;
+    let window_left = bounds.x;
+    let window_top = bounds.y;
+    let window_right = bounds.x + bounds.width as i32;
+    let window_bottom = bounds.y + bounds.height as i32;
 
-    window_left < display_right
-        && display_left < window_right
-        && window_top < display_bottom
-        && display_top < window_bottom
+    let overlap_left = window_left.max(display_left);
+    let overlap_top = window_top.max(display_top);
+    let overlap_right = window_right.min(display_right);
+    let overlap_bottom = window_bottom.min(display_bottom);
+
+    if overlap_left >= overlap_right || overlap_top >= overlap_bottom {
+        return false;
+    }
+
+    let overlap_area =
+        (overlap_right - overlap_left) as f64 * (overlap_bottom - overlap_top) as f64;
+    let window_area = bounds.width as f64 * bounds.height as f64;
+
+    if window_area == 0.0 {
+        return false;
+    }
+
+    overlap_area / window_area >= MIN_OVERLAP_RATIO
 }

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -37,7 +37,7 @@ enum OpenModeArg {
         \x20 arto file1.md file2.md   Open multiple files in tabs"
 )]
 struct Cli {
-    /// Open target selection mode (default: reuse last focused visible window)
+    /// Open target selection mode (default: use fileOpen setting from config.json)
     #[arg(long, value_enum)]
     open: Option<OpenModeArg>,
     /// Root directory for the file explorer sidebar
@@ -84,7 +84,7 @@ fn main() {
     let open_mode = match cli.open {
         Some(OpenModeArg::Screen) => CliOpenMode::CurrentScreen,
         Some(OpenModeArg::New) => CliOpenMode::NewWindow,
-        None => CliOpenMode::LastFocused,
+        None => CliOpenMode::Config,
     };
 
     let invocation = CliInvocation {


### PR DESCRIPTION
## Summary

- Aerospace (tiling window manager) hides inactive-space windows by moving them to an off-screen corner via the Accessibility API. Tao's `outer_position()` reflects the app-side position, not the real compositor position, so Arto was incorrectly treating those hidden windows as "on the current screen" and routing new files to them.
- Replace `outer_position()` / `outer_size()` with `CGWindowListCopyWindowInfo(kCGWindowListOptionOnScreenOnly)` to get the actual window bounds as reported by the macOS window server.
- Replace the simple "any overlap" check with an overlap-ratio check (`>= 10%` of window area). This correctly rejects windows that Aerospace hides with only ~1 px inside the display, while still accepting legitimately multi-monitor-spanning windows.
- Add a `Config` variant to `CliOpenMode` so that running `arto` without `--open` respects the `fileOpen` setting in `config.json` instead of hardcoding a fallback behavior.

## Why

When Aerospace switches to a different space it moves the previous space's windows to a far corner (e.g., 5119, 2132) with only 1 px visible. The old overlap logic (any intersection) matched those hidden windows, causing Arto to open files in an invisible window. The CGWindowList API returns the true on-screen positions already filtered by the window server, and the 10% overlap ratio provides a robust threshold that handles both the "hidden in corner" case and the common "window straddles two monitors" case.

## Test Plan

- [ ] Open Arto on space 1 in Aerospace, switch to space 2, run `arto somefile.md` from the CLI — file should open in a new window on space 2, not be routed to the hidden space-1 window.
- [ ] With a window spanning two monitors, running `arto somefile.md` from the screen with the larger portion of the window should target that window.
- [ ] Running `arto somefile.md` without `--open` should respect the `fileOpen` value in `config.json`.
- [ ] All existing unit tests pass (`just fmt check test`).