### PR TITLE
[1/3] fix(desktop): Windows platform support and WebView2 normalization

### DIFF
--- a/desktop/src/assets.rs
+++ b/desktop/src/assets.rs
@@ -1,8 +1,30 @@
 use dioxus::asset_resolver::asset_path;
 use dioxus::prelude::*;
-
 pub static MAIN_SCRIPT: Asset = asset!("/assets/dist/main.js");
 pub static MAIN_STYLE: Asset = asset!("/assets/dist/main.css");
+
+#[cfg(windows)]
+pub fn windows_safe_asset_url(asset: &dioxus::prelude::Asset) -> String {
+    let mut path = asset.to_string().replace('\\', "/");
+    if !path.starts_with('/') && !path.starts_with("http") {
+        path = format!("/{}", path);
+    }
+    path
+}
+
+pub fn get_main_script_path() -> String {
+    #[cfg(windows)]
+    return windows_safe_asset_url(&MAIN_SCRIPT);
+    #[cfg(not(windows))]
+    return MAIN_SCRIPT.to_string();
+}
+
+pub fn get_main_style_path() -> String {
+    #[cfg(windows)]
+    return windows_safe_asset_url(&MAIN_STYLE);
+    #[cfg(not(windows))]
+    return MAIN_STYLE.to_string();
+}
 
 static ARTO_HEADER_IMAGE: Asset = asset!("/assets/arto-header-welcome.png");
 static WELCOME_TEMPLATE: Asset = asset!("/assets/welcome.md");
@@ -15,9 +37,16 @@ pub fn get_default_markdown_content() -> String {
     let header_path = asset_path(ARTO_HEADER_IMAGE).expect("Failed to resolve ARTO_HEADER_IMAGE");
     let header_str = header_path
         .to_str()
-        .expect("Failed to convert ARTO_HEADER_IMAGE path to str");
+        .expect("Failed to convert ARTO_HEADER_IMAGE path to str")
+        .replace('\\', "/");
+
+    let final_header_str = if cfg!(windows) && !header_str.starts_with('/') {
+        format!("/{}", header_str)
+    } else {
+        header_str
+    };
 
     // Replace relative image path with data URL
     //template.replace("../assets/arto-header-welcome.png", &header_data_url)
-    template.replace("../assets/arto-header-welcome.png", header_str)
+    template.replace("../assets/arto-header-welcome.png", &final_header_str)
 }

--- a/desktop/src/components/app.rs
+++ b/desktop/src/components/app.rs
@@ -22,7 +22,7 @@ use super::right_sidebar::RightSidebarTab;
 use super::search_bar::SearchBar;
 use super::sidebar::Sidebar;
 use super::tab::TabBar;
-use crate::assets::MAIN_SCRIPT;
+use crate::assets::get_main_script_path;
 use crate::drag;
 use crate::events::{ActiveDragUpdate, ACTIVE_DRAG_UPDATE};
 use crate::menu;
@@ -120,13 +120,14 @@ pub fn App(
                 r#"
                 (async () => {{
                     try {{
-                        const {{ init }} = await import("{MAIN_SCRIPT}");
+                        const {{ init }} = await import("{}");
                         init();
                     }} catch (error) {{
                         console.error("Failed to load main module:", error);
                     }}
                 }})();
-                "#
+                "#,
+                get_main_script_path()
             ))
             .await;
         });

--- a/desktop/src/components/icon.rs
+++ b/desktop/src/components/icon.rs
@@ -110,7 +110,11 @@ pub struct IconProps {
 
 #[component]
 pub fn Icon(props: IconProps) -> Element {
+    #[cfg(windows)]
+    let sprite_url = crate::assets::windows_safe_asset_url(&TABLER_SPRITE);
+    #[cfg(not(windows))]
     let sprite_url = TABLER_SPRITE.to_string();
+
     let icon_id = format!("tabler-{}", props.name);
 
     rsx! {

--- a/desktop/src/components/image_window.rs
+++ b/desktop/src/components/image_window.rs
@@ -1,7 +1,7 @@
 use dioxus::prelude::*;
 use sha2::{Digest, Sha256};
 
-use crate::assets::MAIN_SCRIPT;
+use crate::assets::get_main_script_path;
 use crate::components::theme_selector::ThemeSelector;
 use crate::hooks::{
     use_clipboard_image_handler, use_theme_dispatch, use_window_close_handler, use_zoom_sync,
@@ -76,16 +76,19 @@ pub fn ImageWindow(props: ImageWindowProps) -> Element {
         let image_id_json = serde_json::to_string(&props.image_id).unwrap_or_default();
 
         spawn(async move {
-            let eval_result = document::eval(&indoc::formatdoc! {r#"
+            let eval_result = document::eval(&indoc::formatdoc!(
+                r#"
                 (async () => {{
                     try {{
-                        const {{ initImageWindow }} = await import("{MAIN_SCRIPT}");
+                        const {{ initImageWindow }} = await import("{}");
                         await initImageWindow({src_json}, {image_id_json});
                     }} catch (error) {{
                         console.error("Failed to load image window module:", error);
                     }}
                 }})();
-            "#});
+                "#,
+                get_main_script_path()
+            ));
 
             if let Err(e) = eval_result.await {
                 tracing::error!("Failed to initialize image window: {}", e);

--- a/desktop/src/components/math_window.rs
+++ b/desktop/src/components/math_window.rs
@@ -1,7 +1,7 @@
 use dioxus::prelude::*;
 use sha2::{Digest, Sha256};
 
-use crate::assets::MAIN_SCRIPT;
+use crate::assets::get_main_script_path;
 use crate::components::theme_selector::ThemeSelector;
 use crate::hooks::{
     use_clipboard_image_handler, use_theme_dispatch, use_window_close_handler, use_zoom_sync,
@@ -63,16 +63,19 @@ pub fn MathWindow(props: MathWindowProps) -> Element {
         };
 
         spawn(async move {
-            let eval_result = document::eval(&indoc::formatdoc! {r#"
+            let eval_result = document::eval(&indoc::formatdoc!(
+                r#"
                 (async () => {{
                     try {{
-                        const {{ initMathWindow }} = await import("{MAIN_SCRIPT}");
+                        const {{ initMathWindow }} = await import("{}");
                         await initMathWindow({source_json}, {math_id_json}, "{theme_str}");
                     }} catch (error) {{
                         console.error("Failed to load math window module:", error);
                     }}
                 }})();
-            "#});
+                "#,
+                get_main_script_path()
+            ));
 
             if let Err(e) = eval_result.await {
                 tracing::error!("Failed to initialize math window: {}", e);

--- a/desktop/src/components/mermaid_window.rs
+++ b/desktop/src/components/mermaid_window.rs
@@ -1,7 +1,7 @@
 use dioxus::prelude::*;
 use sha2::{Digest, Sha256};
 
-use crate::assets::MAIN_SCRIPT;
+use crate::assets::get_main_script_path;
 use crate::components::icon::{Icon, IconName};
 use crate::components::theme_selector::ThemeSelector;
 use crate::hooks::{use_theme_dispatch, use_window_close_handler, use_zoom_sync, CopyStatus};
@@ -44,16 +44,19 @@ pub fn MermaidWindow(props: MermaidWindowProps) -> Element {
         let diagram_id_json = serde_json::to_string(&props.diagram_id).unwrap_or_default();
 
         spawn(async move {
-            let eval_result = document::eval(&indoc::formatdoc! {r#"
+            let eval_result = document::eval(&indoc::formatdoc!(
+                r#"
                 (async () => {{
                     try {{
-                        const {{ initMermaidWindow }} = await import("{MAIN_SCRIPT}");
+                        const {{ initMermaidWindow }} = await import("{}");
                         await initMermaidWindow({source_json}, {diagram_id_json});
                     }} catch (error) {{
                         console.error("Failed to load mermaid window module:", error);
                     }}
                 }})();
-            "#});
+                "#,
+                get_main_script_path()
+            ));
 
             if let Err(e) = eval_result.await {
                 tracing::error!("Failed to initialize mermaid window: {}", e);

--- a/desktop/src/components/sidebar/context_menu.rs
+++ b/desktop/src/components/sidebar/context_menu.rs
@@ -149,7 +149,7 @@ pub fn SidebarContextMenu(
             }
 
             ContextMenuItem {
-                label: "Reveal in Finder",
+                label: if cfg!(windows) { "Reveal in File Explorer" } else { "Reveal in Finder" },
                 shortcut: shortcut("file.reveal_in_finder"),
                 icon: Some(IconName::Folder),
                 on_click: move |_| on_reveal_in_finder.call(()),
@@ -174,7 +174,8 @@ pub fn SidebarContextMenu(
 
 #[derive(Props, Clone, PartialEq)]
 struct ContextMenuItemProps {
-    label: &'static str,
+    #[props(into)]
+    label: String,
     #[props(default)]
     shortcut: Option<String>,
     #[props(default)]

--- a/desktop/src/components/tab/context_menu.rs
+++ b/desktop/src/components/tab/context_menu.rs
@@ -137,7 +137,7 @@ pub fn TabContextMenu(
             }
 
             ContextMenuItem {
-                label: "Reveal in Finder",
+                label: if cfg!(windows) { "Reveal in File Explorer" } else { "Reveal in Finder" },
                 shortcut: shortcut("file.reveal_in_finder"),
                 icon: Some(IconName::Folder),
                 disabled: !has_file,

--- a/desktop/src/hooks/viewer_window.rs
+++ b/desktop/src/hooks/viewer_window.rs
@@ -3,7 +3,7 @@
 use dioxus::desktop::{use_muda_event_handler, window};
 use dioxus::prelude::*;
 
-use crate::assets::MAIN_SCRIPT;
+use crate::assets::get_main_script_path;
 use crate::components::icon::{Icon, IconName};
 
 #[derive(serde::Deserialize)]
@@ -150,9 +150,10 @@ pub fn CopyImageButton(props: CopyImageButtonProps) -> Element {
         spawn(async move {
             copy_status.set(CopyStatus::Copying);
 
-            let mut eval = document::eval(&indoc::formatdoc! {r#"
+            let mut eval = document::eval(&indoc::formatdoc!(
+                r#"
                 (async () => {{
-                    const {{ {js_function} }} = await import("{MAIN_SCRIPT}");
+                    const {{ {js_function} }} = await import("{}");
                     try {{
                         await {js_function}();
                         dioxus.send(true);
@@ -161,7 +162,9 @@ pub fn CopyImageButton(props: CopyImageButtonProps) -> Element {
                         dioxus.send(false);
                     }}
                 }})();
-            "#});
+                "#,
+                get_main_script_path()
+            ));
 
             let result =
                 tokio::time::timeout(std::time::Duration::from_secs(5), eval.recv::<bool>()).await;

--- a/desktop/src/keybindings/hint.rs
+++ b/desktop/src/keybindings/hint.rs
@@ -71,16 +71,45 @@ fn format_chord_hint(chord: &str) -> String {
 
     let key_part = parts.pop().unwrap();
     let mut out = String::new();
+
+    let is_macos = cfg!(target_os = "macos");
+
     for modifier in parts {
-        match modifier.to_ascii_lowercase().as_str() {
-            "cmd" | "command" | "meta" => out.push('⌘'),
-            "ctrl" | "control" => out.push('⌃'),
-            "shift" => out.push('⇧'),
-            "alt" | "option" => out.push('⌥'),
-            other => {
-                out.push_str(other);
-                out.push('+');
+        let modifier_lower = modifier.to_ascii_lowercase();
+        let label = match modifier_lower.as_str() {
+            "cmd" | "command" | "meta" => {
+                if is_macos {
+                    "⌘"
+                } else {
+                    "Ctrl"
+                }
             }
+            "ctrl" | "control" => {
+                if is_macos {
+                    "⌃"
+                } else {
+                    "Win"
+                }
+            }
+            "shift" => {
+                if is_macos {
+                    "⇧"
+                } else {
+                    "Shift"
+                }
+            }
+            "alt" | "option" => {
+                if is_macos {
+                    "⌥"
+                } else {
+                    "Alt"
+                }
+            }
+            other => other,
+        };
+        out.push_str(label);
+        if !is_macos {
+            out.push('+');
         }
     }
     out.push_str(&format_key_name_hint(key_part));
@@ -112,14 +141,23 @@ mod tests {
 
     #[test]
     fn format_shortcut_hint_uses_menu_style_symbols() {
-        assert_eq!(format_shortcut_hint("Cmd+Shift+o"), "⌘⇧O");
-        assert_eq!(format_shortcut_hint("Ctrl+w h"), "⌃W H");
+        if cfg!(target_os = "macos") {
+            assert_eq!(format_shortcut_hint("Cmd+Shift+o"), "⌘⇧O");
+            assert_eq!(format_shortcut_hint("Ctrl+w h"), "⌃W H");
+        } else {
+            assert_eq!(format_shortcut_hint("Cmd+Shift+o"), "Ctrl+Shift+O");
+            assert_eq!(format_shortcut_hint("Ctrl+w h"), "Win+W H");
+        }
     }
 
     #[test]
     fn format_shortcut_hint_formats_arrow_keys() {
         assert_eq!(format_shortcut_hint("ArrowDown"), "↓");
-        assert_eq!(format_shortcut_hint("Cmd+ArrowLeft"), "⌘←");
+        if cfg!(target_os = "macos") {
+            assert_eq!(format_shortcut_hint("Cmd+ArrowLeft"), "⌘←");
+        } else {
+            assert_eq!(format_shortcut_hint("Cmd+ArrowLeft"), "Ctrl+←");
+        }
     }
 
     #[test]

--- a/desktop/src/menu.rs
+++ b/desktop/src/menu.rs
@@ -177,9 +177,19 @@ fn add_app_menu(menu: &Menu) {
 
     arto_menu
         .append_items(&[
-            &create_menu_item(MenuId::About, if cfg!(windows) { "About" } else { "About Arto" }),
+            &create_menu_item(
+                MenuId::About,
+                if cfg!(windows) { "About" } else { "About Arto" },
+            ),
             &PredefinedMenuItem::separator(),
-            &create_menu_item(MenuId::Preferences, if cfg!(windows) { "Settings" } else { "Preferences..." }),
+            &create_menu_item(
+                MenuId::Preferences,
+                if cfg!(windows) {
+                    "Settings"
+                } else {
+                    "Preferences..."
+                },
+            ),
             &PredefinedMenuItem::separator(),
             &PredefinedMenuItem::quit(Some(if cfg!(windows) { "Exit" } else { "Quit" })),
         ])
@@ -200,7 +210,14 @@ fn add_file_menu(menu: &Menu) {
             &create_menu_item(MenuId::OpenDirectory, "Open Directory..."),
             &PredefinedMenuItem::separator(),
             &create_menu_item(MenuId::CopyFilePath, "Copy File Path"),
-            &create_menu_item(MenuId::RevealInFinder, if cfg!(windows) { "Reveal in File Explorer" } else { "Reveal in Finder" }),
+            &create_menu_item(
+                MenuId::RevealInFinder,
+                if cfg!(windows) {
+                    "Reveal in File Explorer"
+                } else {
+                    "Reveal in Finder"
+                },
+            ),
             &PredefinedMenuItem::separator(),
             &create_menu_item(MenuId::CloseTab, "Close Tab"),
             &create_menu_item(MenuId::CloseAllTabs, "Close All Tabs"),

--- a/desktop/src/menu.rs
+++ b/desktop/src/menu.rs
@@ -177,11 +177,11 @@ fn add_app_menu(menu: &Menu) {
 
     arto_menu
         .append_items(&[
-            &create_menu_item(MenuId::About, "About Arto"),
+            &create_menu_item(MenuId::About, if cfg!(windows) { "About" } else { "About Arto" }),
             &PredefinedMenuItem::separator(),
-            &create_menu_item(MenuId::Preferences, "Preferences..."),
+            &create_menu_item(MenuId::Preferences, if cfg!(windows) { "Settings" } else { "Preferences..." }),
             &PredefinedMenuItem::separator(),
-            &PredefinedMenuItem::quit(Some("Quit")),
+            &PredefinedMenuItem::quit(Some(if cfg!(windows) { "Exit" } else { "Quit" })),
         ])
         .unwrap();
 
@@ -200,7 +200,7 @@ fn add_file_menu(menu: &Menu) {
             &create_menu_item(MenuId::OpenDirectory, "Open Directory..."),
             &PredefinedMenuItem::separator(),
             &create_menu_item(MenuId::CopyFilePath, "Copy File Path"),
-            &create_menu_item(MenuId::RevealInFinder, "Reveal in Finder"),
+            &create_menu_item(MenuId::RevealInFinder, if cfg!(windows) { "Reveal in File Explorer" } else { "Reveal in Finder" }),
             &PredefinedMenuItem::separator(),
             &create_menu_item(MenuId::CloseTab, "Close Tab"),
             &create_menu_item(MenuId::CloseAllTabs, "Close All Tabs"),

--- a/desktop/src/shortcut.rs
+++ b/desktop/src/shortcut.rs
@@ -195,7 +195,11 @@ impl fmt::Display for KeyChord {
             write!(f, "Shift+")?;
         }
         if self.modifiers.contains(Modifiers::META) {
-            write!(f, "Cmd+")?;
+            if cfg!(target_os = "macos") {
+                write!(f, "Cmd+")?;
+            } else {
+                write!(f, "Win+")?;
+            }
         }
         match &self.key {
             Key::Character(c) => write!(f, "{c}"),
@@ -251,10 +255,22 @@ fn parse_chord(token: &str) -> Result<KeyChord, ShortcutParseError> {
         }
 
         match part.to_ascii_lowercase().as_str() {
-            "ctrl" | "control" => modifiers.insert(Modifiers::CONTROL),
+            "ctrl" | "control" => {
+                if cfg!(target_os = "macos") {
+                    modifiers.insert(Modifiers::CONTROL);
+                } else {
+                    modifiers.insert(Modifiers::META);
+                }
+            }
             "shift" => modifiers.insert(Modifiers::SHIFT),
             "alt" | "option" => modifiers.insert(Modifiers::ALT),
-            "meta" | "cmd" | "command" => modifiers.insert(Modifiers::META),
+            "meta" | "cmd" | "command" => {
+                if cfg!(target_os = "macos") {
+                    modifiers.insert(Modifiers::META);
+                } else {
+                    modifiers.insert(Modifiers::CONTROL);
+                }
+            }
             _ => {
                 if key_part.is_some() {
                     return Err(ShortcutParseError::UnknownModifier(part.to_string()));
@@ -400,11 +416,12 @@ mod tests {
     #[test]
     fn parse_with_modifiers() {
         let seq = ShortcutSequence::from_str("Ctrl+Shift+g").unwrap();
+        let expected_ctrl = if cfg!(target_os = "macos") { Modifiers::CONTROL } else { Modifiers::META };
         assert_eq!(
             seq.chords,
             vec![KeyChord {
                 key: Key::Character("g".to_string()),
-                modifiers: Modifiers::CONTROL | Modifiers::SHIFT
+                modifiers: expected_ctrl | Modifiers::SHIFT
             }]
         );
     }
@@ -412,6 +429,7 @@ mod tests {
     #[test]
     fn parse_sequence() {
         let seq = ShortcutSequence::from_str("g Ctrl+g").unwrap();
+        let expected_ctrl = if cfg!(target_os = "macos") { Modifiers::CONTROL } else { Modifiers::META };
         assert_eq!(
             seq.chords,
             vec![
@@ -421,7 +439,7 @@ mod tests {
                 },
                 KeyChord {
                     key: Key::Character("g".to_string()),
-                    modifiers: Modifiers::CONTROL
+                    modifiers: expected_ctrl
                 }
             ]
         );
@@ -452,11 +470,12 @@ mod tests {
     #[test]
     fn parse_cmd_key() {
         let seq = ShortcutSequence::from_str("Cmd+n").unwrap();
+        let expected_mod = if cfg!(target_os = "macos") { Modifiers::META } else { Modifiers::CONTROL };
         assert_eq!(
             seq.chords,
             vec![KeyChord {
                 key: Key::Character("n".to_string()),
-                modifiers: Modifiers::META
+                modifiers: expected_mod
             }]
         );
     }
@@ -482,11 +501,12 @@ mod tests {
     #[test]
     fn parse_symbol_alias() {
         let seq = ShortcutSequence::from_str("Cmd+Equal").unwrap();
+        let expected_mod = if cfg!(target_os = "macos") { Modifiers::META } else { Modifiers::CONTROL };
         assert_eq!(
             seq.chords,
             vec![KeyChord {
                 key: Key::Character("=".to_string()),
-                modifiers: Modifiers::META
+                modifiers: expected_mod
             }]
         );
     }
@@ -560,7 +580,11 @@ mod tests {
             key: Key::Enter,
             modifiers: Modifiers::META,
         };
-        assert_eq!(chord.to_string(), "Cmd+Enter");
+        if cfg!(target_os = "macos") {
+            assert_eq!(chord.to_string(), "Cmd+Enter");
+        } else {
+            assert_eq!(chord.to_string(), "Win+Enter");
+        }
     }
 
     #[test]

--- a/desktop/src/shortcut.rs
+++ b/desktop/src/shortcut.rs
@@ -416,7 +416,11 @@ mod tests {
     #[test]
     fn parse_with_modifiers() {
         let seq = ShortcutSequence::from_str("Ctrl+Shift+g").unwrap();
-        let expected_ctrl = if cfg!(target_os = "macos") { Modifiers::CONTROL } else { Modifiers::META };
+        let expected_ctrl = if cfg!(target_os = "macos") {
+            Modifiers::CONTROL
+        } else {
+            Modifiers::META
+        };
         assert_eq!(
             seq.chords,
             vec![KeyChord {
@@ -429,7 +433,11 @@ mod tests {
     #[test]
     fn parse_sequence() {
         let seq = ShortcutSequence::from_str("g Ctrl+g").unwrap();
-        let expected_ctrl = if cfg!(target_os = "macos") { Modifiers::CONTROL } else { Modifiers::META };
+        let expected_ctrl = if cfg!(target_os = "macos") {
+            Modifiers::CONTROL
+        } else {
+            Modifiers::META
+        };
         assert_eq!(
             seq.chords,
             vec![
@@ -470,7 +478,11 @@ mod tests {
     #[test]
     fn parse_cmd_key() {
         let seq = ShortcutSequence::from_str("Cmd+n").unwrap();
-        let expected_mod = if cfg!(target_os = "macos") { Modifiers::META } else { Modifiers::CONTROL };
+        let expected_mod = if cfg!(target_os = "macos") {
+            Modifiers::META
+        } else {
+            Modifiers::CONTROL
+        };
         assert_eq!(
             seq.chords,
             vec![KeyChord {
@@ -501,7 +513,11 @@ mod tests {
     #[test]
     fn parse_symbol_alias() {
         let seq = ShortcutSequence::from_str("Cmd+Equal").unwrap();
-        let expected_mod = if cfg!(target_os = "macos") { Modifiers::META } else { Modifiers::CONTROL };
+        let expected_mod = if cfg!(target_os = "macos") {
+            Modifiers::META
+        } else {
+            Modifiers::CONTROL
+        };
         assert_eq!(
             seq.chords,
             vec![KeyChord {

--- a/desktop/src/window/child.rs
+++ b/desktop/src/window/child.rs
@@ -5,7 +5,7 @@ use dioxus::prelude::*;
 use std::cell::RefCell;
 use std::collections::HashMap;
 
-use crate::assets::MAIN_STYLE;
+use crate::assets::get_main_style_path;
 use crate::components::image_window::{generate_image_id, ImageWindow, ImageWindowProps};
 use crate::components::math_window::{generate_math_id, MathWindow, MathWindowProps};
 use crate::components::mermaid_window::{generate_diagram_id, MermaidWindow, MermaidWindowProps};
@@ -13,6 +13,17 @@ use crate::theme::Theme;
 
 use super::index::{build_image_window_index, build_math_window_index, build_mermaid_window_index};
 use super::main::get_last_focused_window;
+
+fn get_child_window_builder(title: &str) -> WindowBuilder {
+    #[cfg(windows)]
+    return WindowBuilder::new()
+        .with_title(title)
+        .with_decorations(true)
+        .with_transparent(false);
+
+    #[cfg(not(windows))]
+    return WindowBuilder::new().with_title(title);
+}
 
 struct ChildWindowEntry {
     handle: WeakDesktopContext,
@@ -180,8 +191,11 @@ pub fn open_or_focus_mermaid_window(source: String, theme: Theme) {
         );
         let config = Config::new()
             .with_menu(None)
-            .with_window(WindowBuilder::new().with_title("Mermaid Viewer"))
-            .with_custom_head(indoc::formatdoc! {r#"<link rel="stylesheet" href="{MAIN_STYLE}">"#})
+            .with_window(get_child_window_builder("Mermaid Viewer"))
+            .with_custom_head(indoc::formatdoc!(
+                r#"<link rel="stylesheet" href="{}">"#,
+                get_main_style_path()
+            ))
             .with_custom_index(build_mermaid_window_index(theme));
 
         dioxus_core::spawn(create_and_register_child_window(
@@ -205,8 +219,11 @@ pub fn open_or_focus_math_window(source: String, theme: Theme) {
         );
         let config = Config::new()
             .with_menu(None)
-            .with_window(WindowBuilder::new().with_title("Math Viewer"))
-            .with_custom_head(indoc::formatdoc! {r#"<link rel="stylesheet" href="{MAIN_STYLE}">"#})
+            .with_window(get_child_window_builder("Math Viewer"))
+            .with_custom_head(indoc::formatdoc!(
+                r#"<link rel="stylesheet" href="{}">"#,
+                get_main_style_path()
+            ))
             .with_custom_index(build_math_window_index(theme));
 
         dioxus_core::spawn(create_and_register_child_window(
@@ -231,8 +248,11 @@ pub fn open_or_focus_image_window(src: String, alt: Option<String>, theme: Theme
         );
         let config = Config::new()
             .with_menu(None)
-            .with_window(WindowBuilder::new().with_title("Image Viewer"))
-            .with_custom_head(indoc::formatdoc! {r#"<link rel="stylesheet" href="{MAIN_STYLE}">"#})
+            .with_window(get_child_window_builder("Image Viewer"))
+            .with_custom_head(indoc::formatdoc!(
+                r#"<link rel="stylesheet" href="{}">"#,
+                get_main_style_path()
+            ))
             .with_custom_index(build_image_window_index(theme));
 
         dioxus_core::spawn(create_and_register_child_window(

--- a/desktop/src/window/main.rs
+++ b/desktop/src/window/main.rs
@@ -12,7 +12,7 @@ use std::rc::Rc;
 
 use crate::state::AppState;
 
-use crate::assets::MAIN_STYLE;
+use crate::assets::get_main_style_path;
 use crate::components::app::{App, AppProps};
 use crate::components::right_sidebar::RightSidebarTab;
 use crate::config::{WindowPositionOffset, CONFIG};
@@ -29,16 +29,28 @@ const MAX_POSITION_SHIFT_ATTEMPTS: usize = 20;
 /// Create base window config from parameters
 /// This config can be further customized with .with_menu(), .with_custom_event_handler(), etc.
 pub fn create_main_window_config(params: &CreateMainWindowConfigParams) -> Config {
+    #[cfg(windows)]
+    let window_builder = WindowBuilder::new()
+        .with_title("Arto")
+        .with_position(params.position)
+        .with_inner_size(params.size)
+        .with_decorations(true)
+        .with_transparent(false);
+
+    #[cfg(not(windows))]
+    let window_builder = WindowBuilder::new()
+        .with_title("Arto")
+        .with_position(params.position)
+        .with_inner_size(params.size);
+
     Config::new()
-        .with_window(
-            WindowBuilder::new()
-                .with_title("Arto")
-                .with_position(params.position)
-                .with_inner_size(params.size),
-        )
+        .with_window(window_builder)
         // Add main style in config. Otherwise the style takes time to load and
         // the window appears unstyled for a brief moment.
-        .with_custom_head(indoc::formatdoc! {r#"<link rel="stylesheet" href="{MAIN_STYLE}">"#})
+        .with_custom_head(indoc::formatdoc!(
+            r#"<link rel="stylesheet" href="{}">"#,
+            get_main_style_path()
+        ))
         // Use a custom index to set the initial theme correctly
         .with_custom_index(build_custom_index(params.theme))
 }


### PR DESCRIPTION
# Intent
This PR addresses several Windows-specific issues to ensure a consistent and stable experience on the platform. It focuses on asset path normalization for WebView2 and aligns keyboard interactions with Windows standards.

# Key Changes

- Asset Loading: Normalized asset paths to be compatible with Windows WebView2, fixing issues where CSS/JS files would fail to load.
- Window Decorations: Fixed transparency and decoration handling for the main window on Windows.
- Key Modifiers: Swapped Cmd/Meta with Ctrl for keyboard shortcuts on Windows to follow platform-appropriate mappings.
- Localization: Localized shortcut hints and menu labels for a better Windows native feel.

# Arto Windows Comprehensive Test Suite 
This  test suite is designed to detect bugs common when porting Arto to Windows, such as path resolution issues and JavaScript escape panics. It also serves as a benchmark to ensure all standard Markdown and GFM (GitHub Flavored Markdown) features render correctly in a WebView2 environment. It's start with UTF-8 BOM.

[Arto Windows Comprehensive Test Suite.md](https://github.com/user-attachments/files/26228994/Arto.Windows.Comprehensive.Test.Suite.md)

# Benefits

- Prevents white-screen or broken styling issues on initial launch in Windows environments.
- Improves user productivity by providing expected keyboard shortcut behavior.
# Breaking Changes / Removals

None. This is a non-breaking refinement for platform compatibility.

# Dependency 

**PR 2 depends on PR 1, and PR 3 depends on PR 2.**  
