### PR TITLE
[2/3] fix(desktop): improve context menu reliability and async task stability

### DIFF
--- a/desktop/src/assets.rs
+++ b/desktop/src/assets.rs
@@ -1,8 +1,30 @@
 use dioxus::asset_resolver::asset_path;
 use dioxus::prelude::*;
-
 pub static MAIN_SCRIPT: Asset = asset!("/assets/dist/main.js");
 pub static MAIN_STYLE: Asset = asset!("/assets/dist/main.css");
+
+#[cfg(windows)]
+pub fn windows_safe_asset_url(asset: &dioxus::prelude::Asset) -> String {
+    let mut path = asset.to_string().replace('\\', "/");
+    if !path.starts_with('/') && !path.starts_with("http") {
+        path = format!("/{}", path);
+    }
+    path
+}
+
+pub fn get_main_script_path() -> String {
+    #[cfg(windows)]
+    return windows_safe_asset_url(&MAIN_SCRIPT);
+    #[cfg(not(windows))]
+    return MAIN_SCRIPT.to_string();
+}
+
+pub fn get_main_style_path() -> String {
+    #[cfg(windows)]
+    return windows_safe_asset_url(&MAIN_STYLE);
+    #[cfg(not(windows))]
+    return MAIN_STYLE.to_string();
+}
 
 static ARTO_HEADER_IMAGE: Asset = asset!("/assets/arto-header-welcome.png");
 static WELCOME_TEMPLATE: Asset = asset!("/assets/welcome.md");
@@ -15,9 +37,16 @@ pub fn get_default_markdown_content() -> String {
     let header_path = asset_path(ARTO_HEADER_IMAGE).expect("Failed to resolve ARTO_HEADER_IMAGE");
     let header_str = header_path
         .to_str()
-        .expect("Failed to convert ARTO_HEADER_IMAGE path to str");
+        .expect("Failed to convert ARTO_HEADER_IMAGE path to str")
+        .replace('\\', "/");
+
+    let final_header_str = if cfg!(windows) && !header_str.starts_with('/') {
+        format!("/{}", header_str)
+    } else {
+        header_str
+    };
 
     // Replace relative image path with data URL
     //template.replace("../assets/arto-header-welcome.png", &header_data_url)
-    template.replace("../assets/arto-header-welcome.png", header_str)
+    template.replace("../assets/arto-header-welcome.png", &final_header_str)
 }

--- a/desktop/src/components/app.rs
+++ b/desktop/src/components/app.rs
@@ -119,7 +119,7 @@ pub fn App(
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_millis();
-        
+
         spawn(async move {
             let _ = document::eval(&format!(
                 r#"
@@ -569,6 +569,9 @@ pub fn App(
                     },
                 }
             }
+
+            // Left Sidebar context menu (hoisted to App level to avoid overflow clipping)
+            crate::components::sidebar::context_menu::SidebarContextMenuRoot {}
         }
     }
 }

--- a/desktop/src/components/app.rs
+++ b/desktop/src/components/app.rs
@@ -22,7 +22,7 @@ use super::right_sidebar::RightSidebarTab;
 use super::search_bar::SearchBar;
 use super::sidebar::Sidebar;
 use super::tab::TabBar;
-use crate::assets::MAIN_SCRIPT;
+use crate::assets::get_main_script_path;
 use crate::drag;
 use crate::events::{ActiveDragUpdate, ACTIVE_DRAG_UPDATE};
 use crate::menu;
@@ -120,13 +120,14 @@ pub fn App(
                 r#"
                 (async () => {{
                     try {{
-                        const {{ init }} = await import("{MAIN_SCRIPT}");
+                        const {{ init }} = await import("{}");
                         init();
                     }} catch (error) {{
                         console.error("Failed to load main module:", error);
                     }}
                 }})();
-                "#
+                "#,
+                get_main_script_path()
             ))
             .await;
         });

--- a/desktop/src/components/app.rs
+++ b/desktop/src/components/app.rs
@@ -115,19 +115,25 @@ pub fn App(
 
     // Initialize JavaScript main module (theme listeners, etc.)
     use_hook(|| {
+        let cache_buster = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis();
+        
         spawn(async move {
             let _ = document::eval(&format!(
                 r#"
                 (async () => {{
                     try {{
-                        const {{ init }} = await import("{}");
+                        const {{ init }} = await import("{}?t={}");
                         init();
                     }} catch (error) {{
                         console.error("Failed to load main module:", error);
                     }}
                 }})();
                 "#,
-                get_main_script_path()
+                get_main_script_path(),
+                cache_buster
             ))
             .await;
         });
@@ -429,6 +435,10 @@ pub fn App(
                         left_mouse_inside.set(false);
                         // Don't auto-hide while mouse button is held (e.g., resize drag)
                         if evt.data().held_buttons().contains(dioxus::html::input_data::MouseButton::Primary) {
+                            return;
+                        }
+                        // Don't auto-hide if a context menu is open
+                        if state.sidebar.read().context_menu_active {
                             return;
                         }
                         let gen = left_hide_gen() + 1;

--- a/desktop/src/components/content/context_menu.rs
+++ b/desktop/src/components/content/context_menu.rs
@@ -111,8 +111,6 @@ pub fn ContentContextMenu(props: ContentContextMenuProps) -> Element {
         // Backdrop to close menu on outside click
         div {
             class: "context-menu-backdrop",
-            // Prevent mousedown from clearing text selection
-            onmousedown: move |evt| evt.prevent_default(),
             onclick: move |_| {
                 props.on_close.call(());
             },
@@ -122,8 +120,6 @@ pub fn ContentContextMenu(props: ContentContextMenuProps) -> Element {
         div {
             class: "context-menu content-context-menu",
             style: "left: {props.position.0}px; top: {props.position.1}px;",
-            // Prevent mousedown from clearing text selection
-            onmousedown: move |evt| evt.prevent_default(),
             onclick: move |evt| evt.stop_propagation(),
 
             // === Section 1: Smart default copy operations ===
@@ -188,8 +184,9 @@ pub fn ContentContextMenu(props: ContentContextMenuProps) -> Element {
                             let src = src.clone();
                             spawn(async move {
                                 crate::keybindings::dispatcher::copy_image_from_src(src, false).await;
+                                crate::keybindings::dispatcher::show_action_feedback("Copied");
+                                on_close.call(());
                             });
-                            on_close.call(());
                         }
                     },
                 }
@@ -204,8 +201,7 @@ pub fn ContentContextMenu(props: ContentContextMenuProps) -> Element {
                     on_click: {
                         let on_close = props.on_close;
                         move |_| {
-                            copy_special_block_image(is_mermaid, false);
-                            on_close.call(());
+                            copy_special_block_image(is_mermaid, false, on_close);
                         }
                     },
                 }
@@ -237,8 +233,18 @@ pub fn ContentContextMenu(props: ContentContextMenuProps) -> Element {
                 on_click: {
                     let on_close = props.on_close;
                     move |_| {
-                        exec_edit_command("selectAll");
-                        on_close.call(());
+                        spawn(async move {
+                            let js = r#"
+                                const selection = window.getSelection();
+                                const range = document.createRange();
+                                const content = document.querySelector('.markdown-body') || document.body;
+                                range.selectNodeContents(content);
+                                selection.removeAllRanges();
+                                selection.addRange(range);
+                            "#;
+                            let _ = document::eval(js).await;
+                            on_close.call(());
+                        });
                     }
                 },
             }
@@ -250,8 +256,26 @@ pub fn ContentContextMenu(props: ContentContextMenuProps) -> Element {
                 on_click: {
                     let on_close = props.on_close;
                     move |_| {
-                        dispatch_action(&Action::SearchOpen, state);
-                        on_close.call(());
+                        let mut state = state;
+                        spawn(async move {
+                            let js = r#"
+                                (() => {
+                                    const s = window.getSelection();
+                                    dioxus.send(s ? s.toString() : "");
+                                })()
+                            "#;
+                            let mut eval = document::eval(js);
+                            if let Ok(text) = eval.recv::<String>().await {
+                                if !text.trim().is_empty() {
+                                    state.open_search_with_text(Some(text));
+                                } else {
+                                    state.open_search_with_text(None);
+                                }
+                            } else {
+                                state.open_search_with_text(None);
+                            }
+                            on_close.call(());
+                        });
                     }
                 },
             }
@@ -344,7 +368,10 @@ pub fn ContentContextMenu(props: ContentContextMenuProps) -> Element {
                             let on_close = props.on_close;
                             move |_| {
                                 dispatch_action(&Action::FileSaveImageAs, state);
-                                on_close.call(());
+                                spawn(async move {
+                                    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+                                    on_close.call(());
+                                });
                             }
                         },
                     }
@@ -357,8 +384,13 @@ pub fn ContentContextMenu(props: ContentContextMenuProps) -> Element {
                         on_click: {
                             let on_close = props.on_close;
                             move |_| {
+                                // For now, special blocks don't save easily via simple dialogs,
+                                // but we invoke the same rasteriser action
                                 dispatch_action(&Action::FileSaveImageAs, state);
-                                on_close.call(());
+                                spawn(async move {
+                                    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+                                    on_close.call(());
+                                });
                             }
                         },
                     }
@@ -370,7 +402,7 @@ pub fn ContentContextMenu(props: ContentContextMenuProps) -> Element {
 }
 
 /// Copy a Mermaid or Math block as an image using saved element references.
-fn copy_special_block_image(is_mermaid: bool, opaque: bool) {
+fn copy_special_block_image(is_mermaid: bool, opaque: bool, on_close: EventHandler<()>) {
     let kind = if is_mermaid {
         "mermaidBlock"
     } else {
@@ -386,15 +418,16 @@ fn copy_special_block_image(is_mermaid: bool, opaque: bool) {
             crate::utils::clipboard::copy_image_from_data_url(&data_url);
             crate::keybindings::dispatcher::show_action_feedback("Copied");
         }
+        on_close.call(());
     });
 }
 
-/// Copy markdown source from file using pre-captured line range and selected text.
 fn copy_markdown_source_direct(
     file: std::path::PathBuf,
     source_line: u32,
     source_line_end: u32,
     selected_text: String,
+    on_close: EventHandler<()>,
 ) {
     spawn(async move {
         let handle = std::thread::spawn(move || {
@@ -421,6 +454,7 @@ fn copy_markdown_source_direct(
             }
             Err(_) => tracing::debug!("Source extraction thread panicked"),
         }
+        on_close.call(());
     });
 }
 
@@ -435,9 +469,3 @@ fn copy_path_shortcut_action_str(
     }
 }
 
-fn exec_edit_command(command: &'static str) {
-    spawn(async move {
-        let js = format!("document.execCommand('{command}');");
-        let _ = document::eval(&js).await;
-    });
-}

--- a/desktop/src/components/content/context_menu.rs
+++ b/desktop/src/components/content/context_menu.rs
@@ -468,4 +468,3 @@ fn copy_path_shortcut_action_str(
         _ => "clipboard.copy_file_path",
     }
 }
-

--- a/desktop/src/components/content/context_menu/copy_as.rs
+++ b/desktop/src/components/content/context_menu/copy_as.rs
@@ -37,15 +37,15 @@ pub(super) fn CopyAsSubmenu(
                         let file = current_file.clone().unwrap();
                         let start = source_line.unwrap();
                         let end = source_line_end.unwrap_or(start);
-                        let selected_text = selected_text.clone();
+                        let on_close = on_close;
                         move |_| {
                             super::copy_markdown_source_direct(
                                 file.clone(),
                                 start,
                                 end,
                                 selected_text.clone(),
+                                on_close,
                             );
-                            on_close.call(());
                         }
                     },
                 }

--- a/desktop/src/components/content/context_menu/copy_code_as.rs
+++ b/desktop/src/components/content/context_menu/copy_code_as.rs
@@ -46,6 +46,7 @@ pub(super) fn CopyCodeAsSubmenu(
                         let file = current_file.clone().unwrap();
                         let start = block_source_line.unwrap();
                         let end = block_source_line_end.unwrap();
+                        let on_close = on_close;
                         move |_| {
                             // Extract whole block source (no selected_text)
                             super::copy_markdown_source_direct(
@@ -53,8 +54,8 @@ pub(super) fn CopyCodeAsSubmenu(
                                 start,
                                 end,
                                 String::new(),
+                                on_close,
                             );
-                            on_close.call(());
                         }
                     },
                 }

--- a/desktop/src/components/content/context_menu/image_ops.rs
+++ b/desktop/src/components/content/context_menu/image_ops.rs
@@ -22,10 +22,11 @@ pub(super) fn CopyImageAsSubmenu(
                     let src = src.clone();
                     move |_| {
                         let src = src.clone();
+                        let on_close = on_close;
                         spawn(async move {
                             crate::keybindings::dispatcher::copy_image_from_src(src, false).await;
+                            on_close.call(());
                         });
-                        on_close.call(());
                     }
                 },
             }
@@ -37,10 +38,11 @@ pub(super) fn CopyImageAsSubmenu(
                     let src = src.clone();
                     move |_| {
                         let src = src.clone();
+                        let on_close = on_close;
                         spawn(async move {
                             crate::keybindings::dispatcher::copy_image_from_src(src, true).await;
+                            on_close.call(());
                         });
-                        on_close.call(());
                     }
                 },
             }
@@ -87,9 +89,9 @@ pub(super) fn CopySpecialBlockAsSubmenu(is_mermaid: bool, on_close: EventHandler
             ContextMenuItem {
                 label: "Image",
                 on_click: {
+                    let on_close = on_close;
                     move |_| {
-                        super::copy_special_block_image(is_mermaid, false);
-                        on_close.call(());
+                        super::copy_special_block_image(is_mermaid, false, on_close);
                     }
                 },
             }
@@ -98,9 +100,9 @@ pub(super) fn CopySpecialBlockAsSubmenu(is_mermaid: bool, on_close: EventHandler
                 label: "Image with Background",
                 shortcut: shortcut("clipboard.copy_image_with_background"),
                 on_click: {
+                    let on_close = on_close;
                     move |_| {
-                        super::copy_special_block_image(is_mermaid, true);
-                        on_close.call(());
+                        super::copy_special_block_image(is_mermaid, true, on_close);
                     }
                 },
             }

--- a/desktop/src/components/content/context_menu/menu_item.rs
+++ b/desktop/src/components/content/context_menu/menu_item.rs
@@ -20,8 +20,9 @@ pub(super) fn ContextMenuItem(props: ContextMenuItemProps) -> Element {
     rsx! {
         div {
             class: if props.disabled { "context-menu-item disabled" } else { "context-menu-item" },
-            onclick: move |_| {
+            onclick: move |evt| {
                 if !props.disabled {
+                    evt.stop_propagation();
                     props.on_click.call(());
                 }
             },

--- a/desktop/src/components/icon.rs
+++ b/desktop/src/components/icon.rs
@@ -110,7 +110,11 @@ pub struct IconProps {
 
 #[component]
 pub fn Icon(props: IconProps) -> Element {
+    #[cfg(windows)]
+    let sprite_url = crate::assets::windows_safe_asset_url(&TABLER_SPRITE);
+    #[cfg(not(windows))]
     let sprite_url = TABLER_SPRITE.to_string();
+
     let icon_id = format!("tabler-{}", props.name);
 
     rsx! {

--- a/desktop/src/components/image_window.rs
+++ b/desktop/src/components/image_window.rs
@@ -1,7 +1,7 @@
 use dioxus::prelude::*;
 use sha2::{Digest, Sha256};
 
-use crate::assets::MAIN_SCRIPT;
+use crate::assets::get_main_script_path;
 use crate::components::theme_selector::ThemeSelector;
 use crate::hooks::{
     use_clipboard_image_handler, use_theme_dispatch, use_window_close_handler, use_zoom_sync,
@@ -76,16 +76,19 @@ pub fn ImageWindow(props: ImageWindowProps) -> Element {
         let image_id_json = serde_json::to_string(&props.image_id).unwrap_or_default();
 
         spawn(async move {
-            let eval_result = document::eval(&indoc::formatdoc! {r#"
+            let eval_result = document::eval(&indoc::formatdoc!(
+                r#"
                 (async () => {{
                     try {{
-                        const {{ initImageWindow }} = await import("{MAIN_SCRIPT}");
+                        const {{ initImageWindow }} = await import("{}");
                         await initImageWindow({src_json}, {image_id_json});
                     }} catch (error) {{
                         console.error("Failed to load image window module:", error);
                     }}
                 }})();
-            "#});
+                "#,
+                get_main_script_path()
+            ));
 
             if let Err(e) = eval_result.await {
                 tracing::error!("Failed to initialize image window: {}", e);

--- a/desktop/src/components/math_window.rs
+++ b/desktop/src/components/math_window.rs
@@ -1,7 +1,7 @@
 use dioxus::prelude::*;
 use sha2::{Digest, Sha256};
 
-use crate::assets::MAIN_SCRIPT;
+use crate::assets::get_main_script_path;
 use crate::components::theme_selector::ThemeSelector;
 use crate::hooks::{
     use_clipboard_image_handler, use_theme_dispatch, use_window_close_handler, use_zoom_sync,
@@ -63,16 +63,19 @@ pub fn MathWindow(props: MathWindowProps) -> Element {
         };
 
         spawn(async move {
-            let eval_result = document::eval(&indoc::formatdoc! {r#"
+            let eval_result = document::eval(&indoc::formatdoc!(
+                r#"
                 (async () => {{
                     try {{
-                        const {{ initMathWindow }} = await import("{MAIN_SCRIPT}");
+                        const {{ initMathWindow }} = await import("{}");
                         await initMathWindow({source_json}, {math_id_json}, "{theme_str}");
                     }} catch (error) {{
                         console.error("Failed to load math window module:", error);
                     }}
                 }})();
-            "#});
+                "#,
+                get_main_script_path()
+            ));
 
             if let Err(e) = eval_result.await {
                 tracing::error!("Failed to initialize math window: {}", e);

--- a/desktop/src/components/mermaid_window.rs
+++ b/desktop/src/components/mermaid_window.rs
@@ -1,7 +1,7 @@
 use dioxus::prelude::*;
 use sha2::{Digest, Sha256};
 
-use crate::assets::MAIN_SCRIPT;
+use crate::assets::get_main_script_path;
 use crate::components::icon::{Icon, IconName};
 use crate::components::theme_selector::ThemeSelector;
 use crate::hooks::{use_theme_dispatch, use_window_close_handler, use_zoom_sync, CopyStatus};
@@ -44,16 +44,19 @@ pub fn MermaidWindow(props: MermaidWindowProps) -> Element {
         let diagram_id_json = serde_json::to_string(&props.diagram_id).unwrap_or_default();
 
         spawn(async move {
-            let eval_result = document::eval(&indoc::formatdoc! {r#"
+            let eval_result = document::eval(&indoc::formatdoc!(
+                r#"
                 (async () => {{
                     try {{
-                        const {{ initMermaidWindow }} = await import("{MAIN_SCRIPT}");
+                        const {{ initMermaidWindow }} = await import("{}");
                         await initMermaidWindow({source_json}, {diagram_id_json});
                     }} catch (error) {{
                         console.error("Failed to load mermaid window module:", error);
                     }}
                 }})();
-            "#});
+                "#,
+                get_main_script_path()
+            ));
 
             if let Err(e) = eval_result.await {
                 tracing::error!("Failed to initialize mermaid window: {}", e);

--- a/desktop/src/components/sidebar/context_menu.rs
+++ b/desktop/src/components/sidebar/context_menu.rs
@@ -7,10 +7,18 @@ use crate::bookmarks::BOOKMARKS;
 use crate::components::icon::{Icon, IconName};
 use crate::keybindings::{shortcut_hint_for_context_action, KeyContext};
 
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Debug)]
 pub enum SidebarItemKind {
     File,
     Directory,
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct SidebarContextMenuData {
+    pub position: (i32, i32),
+    pub path: PathBuf,
+    pub kind: SidebarItemKind,
+    pub refresh_counter: Signal<u32>,
 }
 
 #[component]
@@ -231,5 +239,152 @@ fn ContextMenuItem(props: ContextMenuItemProps) -> Element {
 fn ContextMenuSeparator() -> Element {
     rsx! {
         div { class: "context-menu-separator" }
+    }
+}
+
+#[component]
+pub fn SidebarContextMenuRoot() -> Element {
+    let mut state = use_context::<crate::state::AppState>();
+
+    // Evaluate other_windows on mount of the context menu.
+    // When context_menu_data becomes Some, this component will mount and evaluate this.
+    let other_windows = {
+        let windows = crate::window::main::list_visible_main_windows();
+        let current_id = dioxus::desktop::window().id();
+        windows
+            .iter()
+            .filter(|w| w.window.id() != current_id)
+            .map(|w| (w.window.id(), w.window.title()))
+            .collect::<Vec<_>>()
+    };
+
+    let menu_data = state.sidebar.read().context_menu_data.clone();
+
+    if let Some(data) = menu_data {
+        let is_dir = data.kind == SidebarItemKind::Directory;
+        let path = data.path.clone();
+
+        let on_close = move |_| {
+            state.sidebar.write().context_menu_data = None;
+        };
+
+        let on_open = {
+            let path = path.clone();
+            let mut state = state;
+            move |_| {
+                if is_dir {
+                    state.set_root_directory(&path);
+                } else {
+                    state.open_file(&path);
+                }
+                state.sidebar.write().context_menu_data = None;
+            }
+        };
+
+        let on_change_root_directory = {
+            let path = path.clone();
+            let mut state = state;
+            move |_| {
+                state.set_root_directory(&path);
+                state.sidebar.write().context_menu_data = None;
+            }
+        };
+
+        let on_open_in_new_window = {
+            let path = path.clone();
+            move |_| {
+                let path = path.clone();
+                spawn(async move {
+                    let (tab, directory) = if is_dir {
+                        (crate::state::Tab::default(), Some(path))
+                    } else {
+                        (
+                            crate::state::Tab::new(&path),
+                            path.parent().map(|p| p.to_path_buf()),
+                        )
+                    };
+                    let params = crate::window::main::CreateMainWindowConfigParams {
+                        directory,
+                        ..Default::default()
+                    };
+                    crate::window::main::create_main_window(tab, params).await;
+                });
+                state.sidebar.write().context_menu_data = None;
+            }
+        };
+
+        let on_move_to_window = {
+            let path = path.clone();
+            move |target_id: WindowId| {
+                let path = path.clone();
+                let result = if is_dir {
+                    crate::events::OPEN_DIRECTORY_IN_WINDOW.send((target_id, path))
+                } else {
+                    crate::events::OPEN_FILE_IN_WINDOW.send((target_id, path))
+                };
+                if result.is_err() {
+                    tracing::warn!(
+                        ?target_id,
+                        "Failed to open in window: target window may be closed"
+                    );
+                    state.sidebar.write().context_menu_data = None;
+                    return;
+                }
+                crate::window::main::focus_window(target_id);
+                state.sidebar.write().context_menu_data = None;
+            }
+        };
+
+        let on_copy_path = {
+            let path = path.clone();
+            move |_| {
+                crate::utils::clipboard::copy_text(path.to_string_lossy());
+                state.sidebar.write().context_menu_data = None;
+            }
+        };
+
+        let on_reveal_in_finder = {
+            let path = path.clone();
+            move |_| {
+                crate::utils::file_operations::reveal_in_finder(&path);
+                state.sidebar.write().context_menu_data = None;
+            }
+        };
+
+        let on_reload = {
+            let mut refresh_counter = data.refresh_counter;
+            move |_| {
+                refresh_counter.set(refresh_counter() + 1);
+                state.sidebar.write().context_menu_data = None;
+            }
+        };
+
+        let on_toggle_bookmark = {
+            let path = path.clone();
+            move |_| {
+                crate::bookmarks::toggle_bookmark(&path);
+                state.sidebar.write().context_menu_data = None;
+            }
+        };
+
+        rsx! {
+            SidebarContextMenu {
+                position: data.position,
+                path: data.path,
+                kind: data.kind,
+                on_close,
+                on_open,
+                on_open_in_new_window,
+                on_move_to_window,
+                on_change_root_directory,
+                on_toggle_bookmark,
+                on_copy_path,
+                on_reveal_in_finder,
+                on_reload,
+                other_windows,
+            }
+        }
+    } else {
+        rsx! { "" }
     }
 }

--- a/desktop/src/components/sidebar/context_menu.rs
+++ b/desktop/src/components/sidebar/context_menu.rs
@@ -149,7 +149,7 @@ pub fn SidebarContextMenu(
             }
 
             ContextMenuItem {
-                label: "Reveal in Finder",
+                label: if cfg!(windows) { "Reveal in File Explorer" } else { "Reveal in Finder" },
                 shortcut: shortcut("file.reveal_in_finder"),
                 icon: Some(IconName::Folder),
                 on_click: move |_| on_reveal_in_finder.call(()),
@@ -174,7 +174,8 @@ pub fn SidebarContextMenu(
 
 #[derive(Props, Clone, PartialEq)]
 struct ContextMenuItemProps {
-    label: &'static str,
+    #[props(into)]
+    label: String,
     #[props(default)]
     shortcut: Option<String>,
     #[props(default)]

--- a/desktop/src/components/sidebar/context_menu.rs
+++ b/desktop/src/components/sidebar/context_menu.rs
@@ -32,6 +32,20 @@ pub fn SidebarContextMenu(
     let mut show_submenu = use_signal(|| false);
     let shortcut = |action| shortcut_hint_for_context_action(KeyContext::Sidebar, action);
 
+    let mut state = use_context::<crate::state::AppState>();
+
+    use_hook(move || {
+        state.sidebar.write().context_menu_active = true;
+    });
+
+    use_drop(move || {
+        state.sidebar.write().context_menu_active = false;
+        // Optionally, reset hover flags if the mouse is outside
+        if !state.sidebar.read().pinned {
+            // Keep hover active momentarily so the normal onmouseleave timer can handle it if needed
+        }
+    });
+
     let is_file = kind == SidebarItemKind::File;
     let is_bookmarked = BOOKMARKS.read().contains(&path);
 
@@ -56,7 +70,7 @@ pub fn SidebarContextMenu(
 
         // Context menu
         div {
-            class: "context-menu",
+            class: "context-menu sidebar-context-menu",
             style: "left: {position.0}px; top: {position.1}px;",
             onclick: move |evt| evt.stop_propagation(),
 

--- a/desktop/src/components/sidebar/file_explorer.rs
+++ b/desktop/src/components/sidebar/file_explorer.rs
@@ -1,16 +1,15 @@
-use dioxus::desktop::window;
 use dioxus::prelude::*;
 use std::cmp::Ordering;
 use std::fs;
 use std::path::PathBuf;
 use tokio::sync::oneshot;
 
-use super::context_menu::{SidebarContextMenu, SidebarItemKind};
+use super::context_menu::SidebarItemKind;
 use super::quick_access::QuickAccess;
 use crate::components::bookmark_button::BookmarkButton;
 use crate::components::icon::{Icon, IconName};
 use crate::state::{AppState, FocusedPanel};
-use crate::utils::{file::is_markdown_file, file_operations};
+use crate::utils::file::is_markdown_file;
 use crate::watcher::FILE_WATCHER;
 
 /// A directory entry with pre-computed file type from `readdir()`.
@@ -447,10 +446,6 @@ fn FileTreeNode(
     let mut is_copied = use_signal(|| false);
 
     // Context menu state
-    let mut show_context_menu = use_signal(|| false);
-    let mut context_menu_position = use_signal(|| (0, 0));
-    let mut other_windows = use_signal(Vec::new);
-
     // Handle right-click to show context menu
     let handle_context_menu = {
         let path = path.clone();
@@ -458,130 +453,25 @@ fn FileTreeNode(
             evt.prevent_default();
             evt.stop_propagation();
             let mouse_data = evt.data();
-            context_menu_position.set((
-                mouse_data.client_coordinates().x as i32,
-                mouse_data.client_coordinates().y as i32,
-            ));
 
-            // Refresh window list
-            let windows = crate::window::main::list_visible_main_windows();
-            let current_id = window().id();
-            other_windows.set(
-                windows
-                    .iter()
-                    .filter(|w| w.window.id() != current_id)
-                    .map(|w| (w.window.id(), w.window.title()))
-                    .collect(),
+            let mut sidebar = state.sidebar.write();
+            sidebar.context_menu_data = Some(
+                crate::components::sidebar::context_menu::SidebarContextMenuData {
+                    position: (
+                        mouse_data.client_coordinates().x as i32,
+                        mouse_data.client_coordinates().y as i32,
+                    ),
+                    path: path.clone(),
+                    kind: if is_dir {
+                        SidebarItemKind::Directory
+                    } else {
+                        SidebarItemKind::File
+                    },
+                    refresh_counter,
+                },
             );
 
-            show_context_menu.set(true);
             tracing::trace!(?path, "Context menu opened");
-        }
-    };
-
-    // Handler for "Open File" or "Open Directory"
-    let handle_open = {
-        let path = path.clone();
-        move |_| {
-            if is_dir {
-                state.set_root_directory(&path);
-            } else {
-                state.open_file(&path);
-            }
-            show_context_menu.set(false);
-        }
-    };
-
-    // Handler for "Change Root Directory"
-    let handle_change_root_directory = {
-        let path = path.clone();
-        move |_| {
-            state.set_root_directory(&path);
-            show_context_menu.set(false);
-        }
-    };
-
-    // Handler for "Open in New Window"
-    let handle_open_in_new_window = {
-        let path = path.clone();
-        move |_| {
-            let path = path.clone();
-            spawn(async move {
-                let (tab, directory) = if is_dir {
-                    (crate::state::Tab::default(), Some(path))
-                } else {
-                    (
-                        crate::state::Tab::new(&path),
-                        path.parent().map(|p| p.to_path_buf()),
-                    )
-                };
-
-                let params = crate::window::main::CreateMainWindowConfigParams {
-                    directory,
-                    ..Default::default()
-                };
-                crate::window::main::create_main_window(tab, params).await;
-            });
-            show_context_menu.set(false);
-        }
-    };
-
-    // Handler for "Open in Window" (open in existing window)
-    let handle_open_in_window = {
-        let path = path.clone();
-        move |target_id: dioxus::desktop::tao::window::WindowId| {
-            let path = path.clone();
-            let result = if is_dir {
-                // For directories, broadcast to change root directory
-                crate::events::OPEN_DIRECTORY_IN_WINDOW.send((target_id, path))
-            } else {
-                // For files, broadcast to open file
-                crate::events::OPEN_FILE_IN_WINDOW.send((target_id, path))
-            };
-            if result.is_err() {
-                tracing::warn!(
-                    ?target_id,
-                    "Failed to open in window: target window may be closed"
-                );
-                show_context_menu.set(false);
-                return;
-            }
-            // Focus the target window
-            crate::window::main::focus_window(target_id);
-            show_context_menu.set(false);
-        }
-    };
-
-    // Handler for "Copy File Path" / "Copy Directory Path"
-    let handle_copy_path = {
-        let path = path.clone();
-        move |_| {
-            crate::utils::clipboard::copy_text(path.to_string_lossy());
-            show_context_menu.set(false);
-        }
-    };
-
-    // Handler for "Reveal in Finder"
-    let handle_reveal_in_finder = {
-        let path = path.clone();
-        move |_| {
-            file_operations::reveal_in_finder(&path);
-            show_context_menu.set(false);
-        }
-    };
-
-    // Handler for "Reload"
-    let handle_reload = move |_| {
-        refresh_counter.set(refresh_counter() + 1);
-        show_context_menu.set(false);
-    };
-
-    // Handler for "Toggle Bookmark"
-    let handle_toggle_bookmark = {
-        let path = path.clone();
-        move |_| {
-            crate::bookmarks::toggle_bookmark(&path);
-            show_context_menu.set(false);
         }
     };
 
@@ -715,24 +605,6 @@ fn FileTreeNode(
             }
         }
 
-        // Context menu
-        if *show_context_menu.read() {
-            SidebarContextMenu {
-                position: *context_menu_position.read(),
-                path: path.clone(),
-                kind: if is_dir { SidebarItemKind::Directory } else { SidebarItemKind::File },
-                on_close: move |_| show_context_menu.set(false),
-                on_open: handle_open,
-                on_open_in_new_window: handle_open_in_new_window,
-                on_move_to_window: handle_open_in_window,
-                on_change_root_directory: handle_change_root_directory,
-                on_toggle_bookmark: handle_toggle_bookmark,
-                on_copy_path: handle_copy_path,
-                on_reveal_in_finder: handle_reveal_in_finder,
-                on_reload: handle_reload,
-                other_windows: other_windows.read().clone(),
-            }
-        }
     }
 }
 
@@ -796,7 +668,7 @@ fn use_directory_watcher(directory: Option<PathBuf>, mut refresh_counter: Signal
 #[component]
 fn LogicalDrivesView() -> Element {
     let mut state = use_context::<AppState>();
-    
+
     // Get all valid drives
     let mut drives = Vec::new();
     for drive in b'A'..=b'Z' {

--- a/desktop/src/components/sidebar/file_explorer.rs
+++ b/desktop/src/components/sidebar/file_explorer.rs
@@ -46,6 +46,16 @@ fn read_sorted_entries(path: &PathBuf) -> Vec<FileEntry> {
                             return None;
                         }
                     };
+
+                    #[cfg(target_os = "windows")]
+                    if let Ok(metadata) = e.metadata() {
+                        use std::os::windows::fs::MetadataExt;
+                        // FILE_ATTRIBUTE_HIDDEN is 0x2
+                        if (metadata.file_attributes() & 0x2) != 0 {
+                            return None;
+                        }
+                    }
+
                     // For symlinks, follow with metadata() to resolve actual type
                     let is_dir = if file_type.is_symlink() {
                         match fs::metadata(e.path()) {
@@ -94,10 +104,7 @@ pub fn FileExplorer(on_pin_toggle: Option<EventHandler<()>>) -> Element {
                 DirectoryNavigation { current_dir: root.clone(), refresh_counter, on_pin_toggle }
                 DirectoryTree { path: root, refresh_counter }
             } else {
-                div {
-                    class: "left-sidebar-explorer-empty",
-                    "No directory open"
-                }
+                EmptySidebarView {}
             }
 
             // Quick Access section (fixed at bottom)
@@ -259,6 +266,9 @@ fn DirectoryNavigation(
                 // Show root indicator when at filesystem root
                 div {
                     class: "left-sidebar-header-nav root-indicator",
+                    onclick: move |_| {
+                        state.go_to_parent_directory();
+                    },
 
                     div {
                         class: "left-sidebar-header-content",
@@ -269,7 +279,7 @@ fn DirectoryNavigation(
                         }
                         span {
                             class: "left-sidebar-header-label",
-                            "/"
+                            "PC"
                         }
 
                         // Bookmark button - outside actions div for independent visibility
@@ -780,4 +790,85 @@ fn use_directory_watcher(directory: Option<PathBuf>, mut refresh_counter: Signal
             let _ = tx.send(());
         }
     });
+}
+
+#[cfg(target_os = "windows")]
+#[component]
+fn LogicalDrivesView() -> Element {
+    let mut state = use_context::<AppState>();
+    
+    // Get all valid drives
+    let mut drives = Vec::new();
+    for drive in b'A'..=b'Z' {
+        let drive_str = format!("{}:\\", drive as char);
+        if std::path::Path::new(&drive_str).exists() {
+            drives.push(drive_str);
+        }
+    }
+
+    rsx! {
+        div {
+            class: "left-sidebar-tree",
+            div {
+                class: "left-sidebar-header",
+                style: "padding-left: 10px; margin-bottom: 5px;",
+                div {
+                    class: "left-sidebar-header-nav root-indicator",
+                    div {
+                        class: "left-sidebar-header-content",
+                        Icon {
+                            name: IconName::Server,
+                            size: 16,
+                            class: "left-sidebar-header-icon",
+                        }
+                        span {
+                            class: "left-sidebar-header-label",
+                            "PC"
+                        }
+                    }
+                }
+            }
+            for drive in drives {
+                div {
+                    class: "left-sidebar-tree-node",
+                    div {
+                        class: "left-sidebar-tree-node-content",
+                        style: "padding-left: 15px;",
+                        onclick: {
+                            let drive = drive.clone();
+                            move |_| {
+                                state.set_root_directory(&std::path::PathBuf::from(&drive));
+                            }
+                        },
+                        span {
+                            class: "left-sidebar-tree-dir-link",
+                            Icon {
+                                name: IconName::Server,
+                                size: 16,
+                                class: "left-sidebar-tree-icon",
+                            }
+                            span {
+                                class: "left-sidebar-tree-label",
+                                "{drive}"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn EmptySidebarView() -> Element {
+    #[cfg(target_os = "windows")]
+    return rsx! { LogicalDrivesView {} };
+
+    #[cfg(not(target_os = "windows"))]
+    return rsx! {
+        div {
+            class: "left-sidebar-explorer-empty",
+            "No directory open"
+        }
+    };
 }

--- a/desktop/src/components/tab/context_menu.rs
+++ b/desktop/src/components/tab/context_menu.rs
@@ -137,7 +137,7 @@ pub fn TabContextMenu(
             }
 
             ContextMenuItem {
-                label: "Reveal in Finder",
+                label: if cfg!(windows) { "Reveal in File Explorer" } else { "Reveal in Finder" },
                 shortcut: shortcut("file.reveal_in_finder"),
                 icon: Some(IconName::Folder),
                 disabled: !has_file,

--- a/desktop/src/hooks/viewer_window.rs
+++ b/desktop/src/hooks/viewer_window.rs
@@ -3,7 +3,7 @@
 use dioxus::desktop::{use_muda_event_handler, window};
 use dioxus::prelude::*;
 
-use crate::assets::MAIN_SCRIPT;
+use crate::assets::get_main_script_path;
 use crate::components::icon::{Icon, IconName};
 
 #[derive(serde::Deserialize)]
@@ -150,9 +150,10 @@ pub fn CopyImageButton(props: CopyImageButtonProps) -> Element {
         spawn(async move {
             copy_status.set(CopyStatus::Copying);
 
-            let mut eval = document::eval(&indoc::formatdoc! {r#"
+            let mut eval = document::eval(&indoc::formatdoc!(
+                r#"
                 (async () => {{
-                    const {{ {js_function} }} = await import("{MAIN_SCRIPT}");
+                    const {{ {js_function} }} = await import("{}");
                     try {{
                         await {js_function}();
                         dioxus.send(true);
@@ -161,7 +162,9 @@ pub fn CopyImageButton(props: CopyImageButtonProps) -> Element {
                         dioxus.send(false);
                     }}
                 }})();
-            "#});
+                "#,
+                get_main_script_path()
+            ));
 
             let result =
                 tokio::time::timeout(std::time::Duration::from_secs(5), eval.recv::<bool>()).await;

--- a/desktop/src/keybindings/hint.rs
+++ b/desktop/src/keybindings/hint.rs
@@ -71,16 +71,45 @@ fn format_chord_hint(chord: &str) -> String {
 
     let key_part = parts.pop().unwrap();
     let mut out = String::new();
+
+    let is_macos = cfg!(target_os = "macos");
+
     for modifier in parts {
-        match modifier.to_ascii_lowercase().as_str() {
-            "cmd" | "command" | "meta" => out.push('⌘'),
-            "ctrl" | "control" => out.push('⌃'),
-            "shift" => out.push('⇧'),
-            "alt" | "option" => out.push('⌥'),
-            other => {
-                out.push_str(other);
-                out.push('+');
+        let modifier_lower = modifier.to_ascii_lowercase();
+        let label = match modifier_lower.as_str() {
+            "cmd" | "command" | "meta" => {
+                if is_macos {
+                    "⌘"
+                } else {
+                    "Ctrl"
+                }
             }
+            "ctrl" | "control" => {
+                if is_macos {
+                    "⌃"
+                } else {
+                    "Win"
+                }
+            }
+            "shift" => {
+                if is_macos {
+                    "⇧"
+                } else {
+                    "Shift"
+                }
+            }
+            "alt" | "option" => {
+                if is_macos {
+                    "⌥"
+                } else {
+                    "Alt"
+                }
+            }
+            other => other,
+        };
+        out.push_str(label);
+        if !is_macos {
+            out.push('+');
         }
     }
     out.push_str(&format_key_name_hint(key_part));
@@ -112,14 +141,23 @@ mod tests {
 
     #[test]
     fn format_shortcut_hint_uses_menu_style_symbols() {
-        assert_eq!(format_shortcut_hint("Cmd+Shift+o"), "⌘⇧O");
-        assert_eq!(format_shortcut_hint("Ctrl+w h"), "⌃W H");
+        if cfg!(target_os = "macos") {
+            assert_eq!(format_shortcut_hint("Cmd+Shift+o"), "⌘⇧O");
+            assert_eq!(format_shortcut_hint("Ctrl+w h"), "⌃W H");
+        } else {
+            assert_eq!(format_shortcut_hint("Cmd+Shift+o"), "Ctrl+Shift+O");
+            assert_eq!(format_shortcut_hint("Ctrl+w h"), "Win+W H");
+        }
     }
 
     #[test]
     fn format_shortcut_hint_formats_arrow_keys() {
         assert_eq!(format_shortcut_hint("ArrowDown"), "↓");
-        assert_eq!(format_shortcut_hint("Cmd+ArrowLeft"), "⌘←");
+        if cfg!(target_os = "macos") {
+            assert_eq!(format_shortcut_hint("Cmd+ArrowLeft"), "⌘←");
+        } else {
+            assert_eq!(format_shortcut_hint("Cmd+ArrowLeft"), "Ctrl+←");
+        }
     }
 
     #[test]

--- a/desktop/src/menu.rs
+++ b/desktop/src/menu.rs
@@ -177,9 +177,19 @@ fn add_app_menu(menu: &Menu) {
 
     arto_menu
         .append_items(&[
-            &create_menu_item(MenuId::About, if cfg!(windows) { "About" } else { "About Arto" }),
+            &create_menu_item(
+                MenuId::About,
+                if cfg!(windows) { "About" } else { "About Arto" },
+            ),
             &PredefinedMenuItem::separator(),
-            &create_menu_item(MenuId::Preferences, if cfg!(windows) { "Settings" } else { "Preferences..." }),
+            &create_menu_item(
+                MenuId::Preferences,
+                if cfg!(windows) {
+                    "Settings"
+                } else {
+                    "Preferences..."
+                },
+            ),
             &PredefinedMenuItem::separator(),
             &PredefinedMenuItem::quit(Some(if cfg!(windows) { "Exit" } else { "Quit" })),
         ])
@@ -200,7 +210,14 @@ fn add_file_menu(menu: &Menu) {
             &create_menu_item(MenuId::OpenDirectory, "Open Directory..."),
             &PredefinedMenuItem::separator(),
             &create_menu_item(MenuId::CopyFilePath, "Copy File Path"),
-            &create_menu_item(MenuId::RevealInFinder, if cfg!(windows) { "Reveal in File Explorer" } else { "Reveal in Finder" }),
+            &create_menu_item(
+                MenuId::RevealInFinder,
+                if cfg!(windows) {
+                    "Reveal in File Explorer"
+                } else {
+                    "Reveal in Finder"
+                },
+            ),
             &PredefinedMenuItem::separator(),
             &create_menu_item(MenuId::CloseTab, "Close Tab"),
             &create_menu_item(MenuId::CloseAllTabs, "Close All Tabs"),

--- a/desktop/src/menu.rs
+++ b/desktop/src/menu.rs
@@ -177,11 +177,11 @@ fn add_app_menu(menu: &Menu) {
 
     arto_menu
         .append_items(&[
-            &create_menu_item(MenuId::About, "About Arto"),
+            &create_menu_item(MenuId::About, if cfg!(windows) { "About" } else { "About Arto" }),
             &PredefinedMenuItem::separator(),
-            &create_menu_item(MenuId::Preferences, "Preferences..."),
+            &create_menu_item(MenuId::Preferences, if cfg!(windows) { "Settings" } else { "Preferences..." }),
             &PredefinedMenuItem::separator(),
-            &PredefinedMenuItem::quit(Some("Quit")),
+            &PredefinedMenuItem::quit(Some(if cfg!(windows) { "Exit" } else { "Quit" })),
         ])
         .unwrap();
 
@@ -200,7 +200,7 @@ fn add_file_menu(menu: &Menu) {
             &create_menu_item(MenuId::OpenDirectory, "Open Directory..."),
             &PredefinedMenuItem::separator(),
             &create_menu_item(MenuId::CopyFilePath, "Copy File Path"),
-            &create_menu_item(MenuId::RevealInFinder, "Reveal in Finder"),
+            &create_menu_item(MenuId::RevealInFinder, if cfg!(windows) { "Reveal in File Explorer" } else { "Reveal in Finder" }),
             &PredefinedMenuItem::separator(),
             &create_menu_item(MenuId::CloseTab, "Close Tab"),
             &create_menu_item(MenuId::CloseAllTabs, "Close All Tabs"),

--- a/desktop/src/shortcut.rs
+++ b/desktop/src/shortcut.rs
@@ -195,7 +195,11 @@ impl fmt::Display for KeyChord {
             write!(f, "Shift+")?;
         }
         if self.modifiers.contains(Modifiers::META) {
-            write!(f, "Cmd+")?;
+            if cfg!(target_os = "macos") {
+                write!(f, "Cmd+")?;
+            } else {
+                write!(f, "Win+")?;
+            }
         }
         match &self.key {
             Key::Character(c) => write!(f, "{c}"),
@@ -251,10 +255,22 @@ fn parse_chord(token: &str) -> Result<KeyChord, ShortcutParseError> {
         }
 
         match part.to_ascii_lowercase().as_str() {
-            "ctrl" | "control" => modifiers.insert(Modifiers::CONTROL),
+            "ctrl" | "control" => {
+                if cfg!(target_os = "macos") {
+                    modifiers.insert(Modifiers::CONTROL);
+                } else {
+                    modifiers.insert(Modifiers::META);
+                }
+            }
             "shift" => modifiers.insert(Modifiers::SHIFT),
             "alt" | "option" => modifiers.insert(Modifiers::ALT),
-            "meta" | "cmd" | "command" => modifiers.insert(Modifiers::META),
+            "meta" | "cmd" | "command" => {
+                if cfg!(target_os = "macos") {
+                    modifiers.insert(Modifiers::META);
+                } else {
+                    modifiers.insert(Modifiers::CONTROL);
+                }
+            }
             _ => {
                 if key_part.is_some() {
                     return Err(ShortcutParseError::UnknownModifier(part.to_string()));
@@ -400,11 +416,12 @@ mod tests {
     #[test]
     fn parse_with_modifiers() {
         let seq = ShortcutSequence::from_str("Ctrl+Shift+g").unwrap();
+        let expected_ctrl = if cfg!(target_os = "macos") { Modifiers::CONTROL } else { Modifiers::META };
         assert_eq!(
             seq.chords,
             vec![KeyChord {
                 key: Key::Character("g".to_string()),
-                modifiers: Modifiers::CONTROL | Modifiers::SHIFT
+                modifiers: expected_ctrl | Modifiers::SHIFT
             }]
         );
     }
@@ -412,6 +429,7 @@ mod tests {
     #[test]
     fn parse_sequence() {
         let seq = ShortcutSequence::from_str("g Ctrl+g").unwrap();
+        let expected_ctrl = if cfg!(target_os = "macos") { Modifiers::CONTROL } else { Modifiers::META };
         assert_eq!(
             seq.chords,
             vec![
@@ -421,7 +439,7 @@ mod tests {
                 },
                 KeyChord {
                     key: Key::Character("g".to_string()),
-                    modifiers: Modifiers::CONTROL
+                    modifiers: expected_ctrl
                 }
             ]
         );
@@ -452,11 +470,12 @@ mod tests {
     #[test]
     fn parse_cmd_key() {
         let seq = ShortcutSequence::from_str("Cmd+n").unwrap();
+        let expected_mod = if cfg!(target_os = "macos") { Modifiers::META } else { Modifiers::CONTROL };
         assert_eq!(
             seq.chords,
             vec![KeyChord {
                 key: Key::Character("n".to_string()),
-                modifiers: Modifiers::META
+                modifiers: expected_mod
             }]
         );
     }
@@ -482,11 +501,12 @@ mod tests {
     #[test]
     fn parse_symbol_alias() {
         let seq = ShortcutSequence::from_str("Cmd+Equal").unwrap();
+        let expected_mod = if cfg!(target_os = "macos") { Modifiers::META } else { Modifiers::CONTROL };
         assert_eq!(
             seq.chords,
             vec![KeyChord {
                 key: Key::Character("=".to_string()),
-                modifiers: Modifiers::META
+                modifiers: expected_mod
             }]
         );
     }
@@ -560,7 +580,11 @@ mod tests {
             key: Key::Enter,
             modifiers: Modifiers::META,
         };
-        assert_eq!(chord.to_string(), "Cmd+Enter");
+        if cfg!(target_os = "macos") {
+            assert_eq!(chord.to_string(), "Cmd+Enter");
+        } else {
+            assert_eq!(chord.to_string(), "Win+Enter");
+        }
     }
 
     #[test]

--- a/desktop/src/shortcut.rs
+++ b/desktop/src/shortcut.rs
@@ -416,7 +416,11 @@ mod tests {
     #[test]
     fn parse_with_modifiers() {
         let seq = ShortcutSequence::from_str("Ctrl+Shift+g").unwrap();
-        let expected_ctrl = if cfg!(target_os = "macos") { Modifiers::CONTROL } else { Modifiers::META };
+        let expected_ctrl = if cfg!(target_os = "macos") {
+            Modifiers::CONTROL
+        } else {
+            Modifiers::META
+        };
         assert_eq!(
             seq.chords,
             vec![KeyChord {
@@ -429,7 +433,11 @@ mod tests {
     #[test]
     fn parse_sequence() {
         let seq = ShortcutSequence::from_str("g Ctrl+g").unwrap();
-        let expected_ctrl = if cfg!(target_os = "macos") { Modifiers::CONTROL } else { Modifiers::META };
+        let expected_ctrl = if cfg!(target_os = "macos") {
+            Modifiers::CONTROL
+        } else {
+            Modifiers::META
+        };
         assert_eq!(
             seq.chords,
             vec![
@@ -470,7 +478,11 @@ mod tests {
     #[test]
     fn parse_cmd_key() {
         let seq = ShortcutSequence::from_str("Cmd+n").unwrap();
-        let expected_mod = if cfg!(target_os = "macos") { Modifiers::META } else { Modifiers::CONTROL };
+        let expected_mod = if cfg!(target_os = "macos") {
+            Modifiers::META
+        } else {
+            Modifiers::CONTROL
+        };
         assert_eq!(
             seq.chords,
             vec![KeyChord {
@@ -501,7 +513,11 @@ mod tests {
     #[test]
     fn parse_symbol_alias() {
         let seq = ShortcutSequence::from_str("Cmd+Equal").unwrap();
-        let expected_mod = if cfg!(target_os = "macos") { Modifiers::META } else { Modifiers::CONTROL };
+        let expected_mod = if cfg!(target_os = "macos") {
+            Modifiers::META
+        } else {
+            Modifiers::CONTROL
+        };
         assert_eq!(
             seq.chords,
             vec![KeyChord {

--- a/desktop/src/state/app_state.rs
+++ b/desktop/src/state/app_state.rs
@@ -195,6 +195,13 @@ impl AppState {
         };
         if let Some(parent) = parent {
             self.set_root_directory(parent);
+        } else {
+            #[cfg(target_os = "windows")]
+            {
+                let mut sidebar = self.sidebar.write();
+                sidebar.root_directory = None;
+                sidebar.expanded_dirs.clear();
+            }
         }
     }
 

--- a/desktop/src/state/app_state/sidebar.rs
+++ b/desktop/src/state/app_state/sidebar.rs
@@ -1,4 +1,5 @@
 use super::AppState;
+use crate::components::sidebar::context_menu::SidebarContextMenuData;
 use crate::history::HistoryManager;
 use dioxus::prelude::*;
 use std::collections::HashSet;
@@ -16,6 +17,8 @@ pub struct Sidebar {
     /// True while a context menu is open for this sidebar.
     /// When set, the auto-hide timer on the overlay sidebar is suppressed.
     pub context_menu_active: bool,
+    /// Data for the hoisted context menu. Hovered item data is placed here to render at root.
+    pub context_menu_data: Option<SidebarContextMenuData>,
     /// History of root directory navigation.
     ///
     /// This history is intentionally kept in-memory only and is not persisted
@@ -35,6 +38,7 @@ impl Default for Sidebar {
             show_all_files: false,
             zoom_level: 1.0,
             context_menu_active: false,
+            context_menu_data: None,
             dir_history: HistoryManager::new(),
         }
     }

--- a/desktop/src/state/app_state/sidebar.rs
+++ b/desktop/src/state/app_state/sidebar.rs
@@ -13,6 +13,9 @@ pub struct Sidebar {
     pub width: f64,
     pub show_all_files: bool,
     pub zoom_level: f64,
+    /// True while a context menu is open for this sidebar.
+    /// When set, the auto-hide timer on the overlay sidebar is suppressed.
+    pub context_menu_active: bool,
     /// History of root directory navigation.
     ///
     /// This history is intentionally kept in-memory only and is not persisted
@@ -31,6 +34,7 @@ impl Default for Sidebar {
             width: 280.0,
             show_all_files: false,
             zoom_level: 1.0,
+            context_menu_active: false,
             dir_history: HistoryManager::new(),
         }
     }

--- a/desktop/src/window/child.rs
+++ b/desktop/src/window/child.rs
@@ -5,7 +5,7 @@ use dioxus::prelude::*;
 use std::cell::RefCell;
 use std::collections::HashMap;
 
-use crate::assets::MAIN_STYLE;
+use crate::assets::get_main_style_path;
 use crate::components::image_window::{generate_image_id, ImageWindow, ImageWindowProps};
 use crate::components::math_window::{generate_math_id, MathWindow, MathWindowProps};
 use crate::components::mermaid_window::{generate_diagram_id, MermaidWindow, MermaidWindowProps};
@@ -13,6 +13,17 @@ use crate::theme::Theme;
 
 use super::index::{build_image_window_index, build_math_window_index, build_mermaid_window_index};
 use super::main::get_last_focused_window;
+
+fn get_child_window_builder(title: &str) -> WindowBuilder {
+    #[cfg(windows)]
+    return WindowBuilder::new()
+        .with_title(title)
+        .with_decorations(true)
+        .with_transparent(false);
+
+    #[cfg(not(windows))]
+    return WindowBuilder::new().with_title(title);
+}
 
 struct ChildWindowEntry {
     handle: WeakDesktopContext,
@@ -180,8 +191,11 @@ pub fn open_or_focus_mermaid_window(source: String, theme: Theme) {
         );
         let config = Config::new()
             .with_menu(None)
-            .with_window(WindowBuilder::new().with_title("Mermaid Viewer"))
-            .with_custom_head(indoc::formatdoc! {r#"<link rel="stylesheet" href="{MAIN_STYLE}">"#})
+            .with_window(get_child_window_builder("Mermaid Viewer"))
+            .with_custom_head(indoc::formatdoc!(
+                r#"<link rel="stylesheet" href="{}">"#,
+                get_main_style_path()
+            ))
             .with_custom_index(build_mermaid_window_index(theme));
 
         dioxus_core::spawn(create_and_register_child_window(
@@ -205,8 +219,11 @@ pub fn open_or_focus_math_window(source: String, theme: Theme) {
         );
         let config = Config::new()
             .with_menu(None)
-            .with_window(WindowBuilder::new().with_title("Math Viewer"))
-            .with_custom_head(indoc::formatdoc! {r#"<link rel="stylesheet" href="{MAIN_STYLE}">"#})
+            .with_window(get_child_window_builder("Math Viewer"))
+            .with_custom_head(indoc::formatdoc!(
+                r#"<link rel="stylesheet" href="{}">"#,
+                get_main_style_path()
+            ))
             .with_custom_index(build_math_window_index(theme));
 
         dioxus_core::spawn(create_and_register_child_window(
@@ -231,8 +248,11 @@ pub fn open_or_focus_image_window(src: String, alt: Option<String>, theme: Theme
         );
         let config = Config::new()
             .with_menu(None)
-            .with_window(WindowBuilder::new().with_title("Image Viewer"))
-            .with_custom_head(indoc::formatdoc! {r#"<link rel="stylesheet" href="{MAIN_STYLE}">"#})
+            .with_window(get_child_window_builder("Image Viewer"))
+            .with_custom_head(indoc::formatdoc!(
+                r#"<link rel="stylesheet" href="{}">"#,
+                get_main_style_path()
+            ))
             .with_custom_index(build_image_window_index(theme));
 
         dioxus_core::spawn(create_and_register_child_window(

--- a/desktop/src/window/main.rs
+++ b/desktop/src/window/main.rs
@@ -12,7 +12,7 @@ use std::rc::Rc;
 
 use crate::state::AppState;
 
-use crate::assets::MAIN_STYLE;
+use crate::assets::get_main_style_path;
 use crate::components::app::{App, AppProps};
 use crate::components::right_sidebar::RightSidebarTab;
 use crate::config::{WindowPositionOffset, CONFIG};
@@ -29,16 +29,28 @@ const MAX_POSITION_SHIFT_ATTEMPTS: usize = 20;
 /// Create base window config from parameters
 /// This config can be further customized with .with_menu(), .with_custom_event_handler(), etc.
 pub fn create_main_window_config(params: &CreateMainWindowConfigParams) -> Config {
+    #[cfg(windows)]
+    let window_builder = WindowBuilder::new()
+        .with_title("Arto")
+        .with_position(params.position)
+        .with_inner_size(params.size)
+        .with_decorations(true)
+        .with_transparent(false);
+
+    #[cfg(not(windows))]
+    let window_builder = WindowBuilder::new()
+        .with_title("Arto")
+        .with_position(params.position)
+        .with_inner_size(params.size);
+
     Config::new()
-        .with_window(
-            WindowBuilder::new()
-                .with_title("Arto")
-                .with_position(params.position)
-                .with_inner_size(params.size),
-        )
+        .with_window(window_builder)
         // Add main style in config. Otherwise the style takes time to load and
         // the window appears unstyled for a brief moment.
-        .with_custom_head(indoc::formatdoc! {r#"<link rel="stylesheet" href="{MAIN_STYLE}">"#})
+        .with_custom_head(indoc::formatdoc!(
+            r#"<link rel="stylesheet" href="{}">"#,
+            get_main_style_path()
+        ))
         // Use a custom index to set the initial theme correctly
         .with_custom_index(build_custom_index(params.theme))
 }


### PR DESCRIPTION
# Intent
This PR improves the robustness of UI interactions, specifically focusing on the sidebar context menu and the reliability of asynchronous operations triggered from the UI.

# Key Changes

- Context Menu Hoisting: Hoisted the sidebar context menu from the leaf FileTreeNode to the root  `App` component. This prevents the menu from being clipped by the sidebar's overflow: hidden boundaries.
- Task Abortion Prevention: Implemented a delay mechanism for task abortion during window reloads or menu closures. This ensures that async operations (like file I/O or clipboard actions) finish successfully even if the triggering UI element is unmounted.
- Modernized Selection API: Replaced the deprecated document.execCommand('selectAll') with the modern Selection and Range API for better compatibility.
- State Management: Refactored sidebar state to manage context menu data globally.

Context Menu before: 
<img width="276" height="315" src="https://github.com/user-attachments/assets/ba13d350-09b2-46d7-844a-f5fd6ff873b7" />
Context Menu after:
<img width="266" height="320" alt="image" src="https://github.com/user-attachments/assets/840b7e7f-4ac8-446e-88e0-6534082a6b0f" />

# Arto Windows Comprehensive Test Suite 
This  test suite is designed to detect bugs common when porting Arto to Windows, such as path resolution issues and JavaScript escape panics. It also serves as a benchmark to ensure all standard Markdown and GFM (GitHub Flavored Markdown) features render correctly in a WebView2 environment. It's start with UTF-8 BOM.

[Arto Windows Comprehensive Test Suite.md](https://github.com/user-attachments/files/26228994/Arto.Windows.Comprehensive.Test.Suite.md)

# Benefits

- UX: Context menus no longer appear cut off in narrow sidebars.
- Stability: Prevents rare race conditions where background tasks were silently killed by Dioxus's cleanup logic.

# Breaking Changes / Removals

- Internal API: The FileTreeNode no longer manages its own context menu state; it now updates the global AppState.


# Dependency 

**PR 2 depends on PR 1, and PR 3 depends on PR 2.**  