### PR TITLE
feat: add Windows support

### DIFF
--- a/desktop/src/components/app/keybinding_engine.rs
+++ b/desktop/src/components/app/keybinding_engine.rs
@@ -52,12 +52,13 @@ pub(super) fn setup_keybinding_engine(
         // Keyboard event processing loop
         spawn(async move {
             // Wait for JS keyboard API to be ready, then register callback.
-            // Retries up to 50 times (2.5s) before giving up.
+            // Retries up to 200 times (10s) before giving up.
+            // Windows WebView2 may take longer to parse large JS bundles.
             let mut eval = document::eval(
                 r#"
             (async () => {
                 let retries = 0;
-                while (!window.Arto?.keyboard?.onKeydown && retries++ < 50) {
+                while (!window.Arto?.keyboard?.onKeydown && retries++ < 200) {
                     await new Promise(r => setTimeout(r, 50));
                 }
                 if (!window.Arto?.keyboard?.onKeydown) {

--- a/desktop/src/components/search_bar.rs
+++ b/desktop/src/components/search_bar.rs
@@ -64,8 +64,9 @@ async fn wait_for_js_ready() {
     use std::time::Duration;
 
     // Poll until window.Arto.search.setPinned is available
-    for _ in 0..50 {
-        // 50 * 50ms = 2.5s max wait
+    // Windows WebView2 may take longer to parse large JS bundles, so use generous timeout
+    for _ in 0..200 {
+        // 200 * 50ms = 10s max wait
         let mut eval =
             document::eval("dioxus.send(typeof window.Arto?.search?.setPinned === 'function')");
         if let Ok(true) = eval.recv::<bool>().await {

--- a/desktop/src/keybindings/hint.rs
+++ b/desktop/src/keybindings/hint.rs
@@ -71,7 +71,9 @@ fn format_chord_hint(chord: &str) -> String {
 
     let key_part = parts.pop().unwrap();
     let mut out = String::new();
-    for modifier in parts {
+
+    #[cfg(target_os = "macos")]
+    for modifier in &parts {
         match modifier.to_ascii_lowercase().as_str() {
             "cmd" | "command" | "meta" => out.push('⌘'),
             "ctrl" | "control" => out.push('⌃'),
@@ -83,10 +85,46 @@ fn format_chord_hint(chord: &str) -> String {
             }
         }
     }
+
+    #[cfg(not(target_os = "macos"))]
+    for modifier in &parts {
+        match modifier.to_ascii_lowercase().as_str() {
+            "cmd" | "command" | "meta" => out.push_str("Ctrl+"),
+            "ctrl" | "control" => out.push_str("Ctrl+"),
+            "shift" => out.push_str("Shift+"),
+            "alt" | "option" => out.push_str("Alt+"),
+            other => {
+                out.push_str(other);
+                out.push('+');
+            }
+        }
+    }
+
     out.push_str(&format_key_name_hint(key_part));
     out
 }
 
+#[cfg(not(target_os = "macos"))]
+fn format_key_name_hint(key: &str) -> String {
+    match key {
+        "ArrowUp" => "Up".to_string(),
+        "ArrowDown" => "Down".to_string(),
+        "ArrowLeft" => "Left".to_string(),
+        "ArrowRight" => "Right".to_string(),
+        "Backspace" => "Backspace".to_string(),
+        "Enter" => "Enter".to_string(),
+        "Escape" => "Esc".to_string(),
+        "Tab" => "Tab".to_string(),
+        "Space" => "Space".to_string(),
+        "PageUp" => "PgUp".to_string(),
+        "PageDown" => "PgDn".to_string(),
+        "Home" => "Home".to_string(),
+        "End" => "End".to_string(),
+        _ => key.to_uppercase(),
+    }
+}
+
+#[cfg(target_os = "macos")]
 fn format_key_name_hint(key: &str) -> String {
     match key {
         "ArrowUp" => "↑".to_string(),

--- a/desktop/src/shortcut.rs
+++ b/desktop/src/shortcut.rs
@@ -254,7 +254,12 @@ fn parse_chord(token: &str) -> Result<KeyChord, ShortcutParseError> {
             "ctrl" | "control" => modifiers.insert(Modifiers::CONTROL),
             "shift" => modifiers.insert(Modifiers::SHIFT),
             "alt" | "option" => modifiers.insert(Modifiers::ALT),
+            // On non-macOS platforms, map Cmd/Command/Meta to CONTROL
+            // so that preset keybindings like "Cmd+n" work as "Ctrl+n" on Windows/Linux
+            #[cfg(target_os = "macos")]
             "meta" | "cmd" | "command" => modifiers.insert(Modifiers::META),
+            #[cfg(not(target_os = "macos"))]
+            "meta" | "cmd" | "command" => modifiers.insert(Modifiers::CONTROL),
             _ => {
                 if key_part.is_some() {
                     return Err(ShortcutParseError::UnknownModifier(part.to_string()));


### PR DESCRIPTION
## Summary

Adds initial Windows support for Arto. The application builds and runs on Windows with these changes:

- **Shortcut key mapping**: `Cmd`/`Meta` is mapped to `Ctrl` on non-macOS platforms, so preset keybindings like `Cmd+n` work as `Ctrl+n` on Windows
- **Platform-specific shortcut hints**: macOS uses symbols (⌘⇧⌥⌃), Windows/Linux uses text labels (Ctrl+, Shift+, Alt+)
- **JS initialization timeout**: Increased from 2.5s to 10s for keyboard interceptor and search API, as WebView2 on Windows takes longer to parse the 5MB JS bundle

## Test plan

- [x] `cargo check` passes on Windows (0 errors, 2 pre-existing warnings)
- [x] `dx bundle --release` produces a working Windows executable
- [x] Application launches and renders Markdown correctly
- [x] Dark theme detection works
- [x] File watching works
- [x] IPC server starts (Windows Named Pipes)
- [x] Keyboard shortcuts display as `Ctrl+` instead of `⌘`
- [x] JS keyboard interceptor initializes successfully (no timeout warning)
- [x] JS search API initializes successfully (no timeout warning)

## Notes

- Windows icon (`.ico`) is not yet created, so `dx bundle` shows a non-fatal icon error
- DPI awareness could be improved in a follow-up
- Tested on Windows 11 with Rust 1.89.0 and Dioxus CLI 0.7.3