### PR TITLE
fix(renderer): enhance footnote navigation and popover styling

### DIFF
--- a/desktop/justfile
+++ b/desktop/justfile
@@ -1,3 +1,5 @@
+set windows-shell := ["pwsh.exe", "-NoProfile", "-Command"]
+
 [private]
 default:
   @just --list
@@ -29,6 +31,10 @@ build:
   @rm -rf target/dx/arto/release/linux/app/assets
   dx bundle --release --linux --package-types deb
 
+[windows]
+build:
+  dx bundle --release --windows
+
 [macos]
 open:
   ./target/dx/arto/bundle/macos/bundle/macos/Arto.app/Contents/MacOS/arto
@@ -36,6 +42,10 @@ open:
 [linux]
 open:
   ./target/dx/arto/release/linux/app/arto
+
+[windows]
+open:
+  ./target/dx/arto/release/windows/app/arto.exe
 
 [confirm]
 [macos]

--- a/desktop/src/ipc.rs
+++ b/desktop/src/ipc.rs
@@ -250,9 +250,7 @@ mod tests {
 
     // Re-import protocol types used by tests
     use protocol::IpcMessage;
-    use socket::is_address_in_use;
-    #[cfg(unix)]
-    use socket::{get_socket_path, SOCKET_NAME};
+    use socket::{get_socket_path, is_address_in_use, SOCKET_NAME};
 
     #[test]
     fn test_ipc_message_open_serialization() {

--- a/desktop/src/ipc/queue.rs
+++ b/desktop/src/ipc/queue.rs
@@ -1,9 +1,9 @@
 use super::protocol::OpenEvent;
 use parking_lot::Mutex;
 use std::collections::VecDeque;
-use std::sync::atomic::{AtomicBool, AtomicI32};
 #[cfg(unix)]
 use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicBool, AtomicI32};
 use std::sync::OnceLock;
 
 // ============================================================================

--- a/desktop/src/ipc/queue.rs
+++ b/desktop/src/ipc/queue.rs
@@ -1,9 +1,9 @@
 use super::protocol::OpenEvent;
 use parking_lot::Mutex;
 use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, AtomicI32};
 #[cfg(unix)]
 use std::sync::atomic::Ordering;
-use std::sync::atomic::{AtomicBool, AtomicI32};
 use std::sync::OnceLock;
 
 // ============================================================================

--- a/justfile
+++ b/justfile
@@ -1,3 +1,5 @@
+set windows-shell := ["pwsh.exe", "-NoProfile", "-Command"]
+
 mod desktop
 mod renderer
 

--- a/renderer/justfile
+++ b/renderer/justfile
@@ -1,3 +1,5 @@
+set windows-shell := ["pwsh.exe", "-NoProfile", "-Command"]
+
 [private]
 default:
   @just --list

--- a/renderer/src/footnote-handler.ts
+++ b/renderer/src/footnote-handler.ts
@@ -94,7 +94,7 @@ export function setupFootnotes(container: HTMLElement): void {
         // Apply a small offset (e.g., 60px) so the footnote isn't cramped against the top bar
         scrollContainer.scrollTo({
           top: Math.max(0, targetTop - 60),
-          behavior: "smooth"
+          behavior: "smooth",
         });
       } else {
         // Fallback

--- a/renderer/src/footnote-handler.ts
+++ b/renderer/src/footnote-handler.ts
@@ -1,0 +1,164 @@
+/**
+ * Footnote Handler
+ * Provides smooth scrolling to footnotes and a hover popover (tooltip) for quick reading.
+ *
+ * NOTE: Hash-only anchors (`<a href="#fn-1">`) are rewritten to
+ * `<span data-hash-link="fn-1" class="footnote-reference-link">` by the Rust
+ * post-processor (post_process.rs) to prevent WebView2 from treating them as
+ * navigation events and opening an external browser.
+ * This handler finds those spans and attaches scroll/popover behavior.
+ */
+
+const POPOVER_ID = "arto-footnote-popover";
+const HIGHLIGHT_CLASS = "footnote-highlight";
+const HIGHLIGHT_TIMEOUT_MS = 2000;
+
+/**
+ * Find the footnote definition element by ID.
+ * Looks up at click/hover time so it works even if the DOM was mutated after setup.
+ * pulldown-cmark uses id="fn-1" on the <li> element inside the footnote list.
+ */
+function findTargetDef(targetId: string): HTMLElement | null {
+  // Use querySelectorAll to find ALL elements with the exact ID,
+  // bypassing the first match if it happens to be an auto-generated header slug.
+  const exactMatches = document.querySelectorAll<HTMLElement>(`[id="${CSS.escape(targetId)}"]`);
+  for (const el of Array.from(exactMatches)) {
+    if (!/^(H1|H2|H3|H4|H5|H6)$/i.test(el.tagName)) {
+      return el;
+    }
+  }
+
+  // Fallback: pulldown-cmark sometimes prepends "fn-"
+  if (!targetId.startsWith("fn-")) {
+    const fnMatches = document.querySelectorAll<HTMLElement>(`[id="fn-${CSS.escape(targetId)}"]`);
+    for (const el of Array.from(fnMatches)) {
+      if (!/^(H1|H2|H3|H4|H5|H6)$/i.test(el.tagName)) {
+        return el;
+      }
+    }
+  }
+
+  return null;
+}
+
+export function setupFootnotes(container: HTMLElement): void {
+  // Ensure the shared popover element exists in the document.
+  // It is appended to <body> and positioned via fixed coordinates.
+  let popover = document.getElementById(POPOVER_ID) as HTMLElement | null;
+  if (!popover) {
+    popover = document.createElement("div");
+    popover.id = POPOVER_ID;
+    popover.className = "footnote-popover";
+    document.body.appendChild(popover);
+  }
+  const popoverEl = popover;
+
+  // Find all hash-link spans rewritten by Rust's post-processor.
+  // Match ALL data-hash-link spans — JS will skip back-references (fnref*).
+  const references = container.querySelectorAll<HTMLElement>("span[data-hash-link]");
+  console.debug(`[footnotes] setupFootnotes: found ${references.length} hash-link spans`);
+
+  references.forEach((el) => {
+    // Prevent attaching multiple listeners on re-render
+    if (el.dataset.footnoteListenersAttached === "true") return;
+    el.dataset.footnoteListenersAttached = "true";
+
+    const targetId = el.dataset.hashLink;
+    if (!targetId) return;
+
+    // Skip back-reference links (fnref*) — they go back from definition to reference
+    if (targetId.startsWith("fnref")) return;
+
+    console.debug(`[footnotes] Attaching handlers for hash-link: ${targetId}`);
+
+    // ── 1. Click: smooth scroll + highlight ─────────────────────────────────
+    el.addEventListener("click", (e: MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      console.log("[footnotes] Clicked!", targetId);
+
+      const targetDef = findTargetDef(targetId);
+      if (!targetDef) return;
+
+      // Scroll the *content area* scroller, not the window.
+      // Explicitly calculating position against the .content container prevents
+      // some WebView/browser edge cases where scrollIntoView scrolls the entire frame to top.
+      const scrollContainer = document.querySelector(".content");
+      if (scrollContainer) {
+        const containerRect = scrollContainer.getBoundingClientRect();
+        const targetRect = targetDef.getBoundingClientRect();
+        // Calculate the element's top position within the scrollable content area
+        const targetTop = targetRect.top - containerRect.top + scrollContainer.scrollTop;
+
+        // Apply a small offset (e.g., 60px) so the footnote isn't cramped against the top bar
+        scrollContainer.scrollTo({
+          top: Math.max(0, targetTop - 60),
+          behavior: "smooth"
+        });
+      } else {
+        // Fallback
+        targetDef.scrollIntoView({ behavior: "smooth", block: "nearest" });
+      }
+
+      // Flash highlight
+      targetDef.classList.add(HIGHLIGHT_CLASS);
+      setTimeout(() => targetDef.classList.remove(HIGHLIGHT_CLASS), HIGHLIGHT_TIMEOUT_MS);
+    });
+
+    // ── 2. Hover: popover tooltip ────────────────────────────────────────────
+    let hideTimeout: ReturnType<typeof setTimeout>;
+
+    el.addEventListener("mouseenter", () => {
+      clearTimeout(hideTimeout);
+
+      const targetDef = findTargetDef(targetId);
+      if (!targetDef) return;
+
+      // Clone and clean the definition content
+      const clone = targetDef.cloneNode(true) as HTMLElement;
+
+      // Remove back-reference links (↩) and any internal hash spans
+      clone.querySelectorAll("span[data-hash-link], a[href^='#']").forEach((n) => n.remove());
+      // Remove any explicit label elements
+      clone.querySelectorAll(".footnote-backref, .footnote-label").forEach((n) => n.remove());
+
+      popoverEl.innerHTML = clone.innerHTML;
+
+      // Use fixed positioning (viewport-relative) — no scroll offset math needed
+      popoverEl.style.position = "fixed";
+      popoverEl.style.visibility = "hidden";
+      popoverEl.classList.add("visible");
+
+      const rect = el.getBoundingClientRect();
+      const pw = popoverEl.offsetWidth;
+      const ph = popoverEl.offsetHeight;
+      const margin = 16;
+      const vw = window.innerWidth;
+      const vh = window.innerHeight;
+
+      let top = rect.bottom + 8;
+      let left = rect.left + rect.width / 2 - pw / 2;
+
+      // Clamp horizontally
+      left = Math.max(margin, Math.min(left, vw - pw - margin));
+
+      // Flip above if not enough room below
+      if (top + ph > vh - margin) {
+        top = rect.top - ph - 8;
+      }
+      // Clamp vertically
+      top = Math.max(margin, top);
+
+      popoverEl.style.top = `${top}px`;
+      popoverEl.style.left = `${left}px`;
+      popoverEl.style.visibility = "";
+    });
+
+    el.addEventListener("mouseleave", () => {
+      hideTimeout = setTimeout(() => {
+        popoverEl.classList.remove("visible");
+      }, 120);
+    });
+  });
+}

--- a/renderer/style/components/action-feedback.css
+++ b/renderer/style/components/action-feedback.css
@@ -22,4 +22,3 @@
   opacity: 1;
   transform: translateY(0);
 }
-

--- a/renderer/style/components/app.css
+++ b/renderer/style/components/app.css
@@ -245,8 +245,9 @@
 }
 
 .shortcut-help-key {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-    "Liberation Mono", "Courier New", monospace;
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
+    monospace;
   font-size: 12px;
   border: 1px solid var(--border-color);
   background: var(--bg-secondary);

--- a/renderer/style/components/content/code-copy.css
+++ b/renderer/style/components/content/code-copy.css
@@ -14,7 +14,10 @@
   color: var(--copy-button-fg);
   cursor: pointer;
   opacity: 0;
-  transition: opacity var(--transition-normal) ease, background-color var(--transition-normal) ease, color var(--transition-normal) ease;
+  transition:
+    opacity var(--transition-normal) ease,
+    background-color var(--transition-normal) ease,
+    color var(--transition-normal) ease;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/renderer/style/components/content/markdown-viewer.css
+++ b/renderer/style/components/content/markdown-viewer.css
@@ -30,6 +30,5 @@
          use the same font-size context */
       font-size: var(--font-size-base);
     }
-
   }
 }

--- a/renderer/style/components/content/no-file.css
+++ b/renderer/style/components/content/no-file.css
@@ -79,7 +79,8 @@
   border: 1px solid var(--border-color);
   border-radius: 0.25rem;
   font-size: 0.85rem;
-  font-family: ui-monospace, "SF Mono", Monaco, "Cascadia Mono", "Segoe UI Mono", "Courier New", monospace;
+  font-family:
+    ui-monospace, "SF Mono", Monaco, "Cascadia Mono", "Segoe UI Mono", "Courier New", monospace;
   color: var(--text-color);
   box-shadow: var(--shadow-xs);
 }
@@ -109,7 +110,8 @@
 .file-error .file-error-filename {
   color: var(--text-secondary);
   opacity: 0.75;
-  font-family: ui-monospace, "SF Mono", Monaco, "Cascadia Mono", "Segoe UI Mono", "Courier New", monospace;
+  font-family:
+    ui-monospace, "SF Mono", Monaco, "Cascadia Mono", "Segoe UI Mono", "Courier New", monospace;
   font-size: 0.95rem;
 }
 

--- a/renderer/style/components/context-menu/base.css
+++ b/renderer/style/components/context-menu/base.css
@@ -92,7 +92,10 @@
   margin-left: 24px;
   opacity: var(--opacity-muted);
   font-size: var(--font-size-sm);
-  font-family: system-ui, -apple-system, sans-serif;
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
 }
 
 /* Separator between menu sections */

--- a/renderer/style/components/footnote-popover.css
+++ b/renderer/style/components/footnote-popover.css
@@ -1,0 +1,54 @@
+/* Footnote Popover Tooltip */
+.footnote-popover {
+  position: absolute; /* Using absolute relative to body since top/left includes scrollY/X */
+  z-index: var(--z-overlay, 1000);
+  max-width: 320px;
+  background-color: var(--bg-color);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  padding: 12px 16px;
+  box-shadow: var(--shadow-lg);
+  font-size: 0.9em;
+  opacity: 0;
+  pointer-events: none; /* Ignore mouse events to not interfere with hover out */
+  transition: opacity var(--transition-normal) ease, transform var(--transition-normal) ease;
+  transform: translateY(4px);
+  color: var(--text-color);
+}
+
+.footnote-popover.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.footnote-popover p {
+  margin: 0;
+  line-height: 1.5;
+}
+
+.footnote-popover p + p {
+  margin-top: 0.5em;
+}
+
+/* Footnote Definition Highlight Animation */
+.footnote-definition {
+  transition: background-color 0.5s ease;
+  border-radius: var(--radius-sm);
+}
+
+.footnote-definition.footnote-highlight {
+  background-color: color-mix(in srgb, var(--accent-bg) 25%, transparent);
+}
+
+/* Footnote reference links: restore link appearance after href removal.
+   pulldown-cmark wraps these in <sup>, so they look like small superscripts.
+   Without href, browsers won't apply default :link styles - re-apply here. */
+.footnote-reference-link {
+  color: var(--link-color);
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.footnote-reference-link:hover {
+  text-decoration: underline;
+}

--- a/renderer/style/components/header.css
+++ b/renderer/style/components/header.css
@@ -115,10 +115,7 @@
 }
 
 /* Show file action buttons on header hover */
-.header:hover
-  .header-left
-  .file-action-buttons
-  .nav-button:hover:not(:disabled) {
+.header:hover .header-left .file-action-buttons .nav-button:hover:not(:disabled) {
   opacity: 1;
 }
 

--- a/renderer/style/components/left-sidebar.css
+++ b/renderer/style/components/left-sidebar.css
@@ -23,7 +23,9 @@
 
 /* Panel focus indicator — only visible during keyboard navigation */
 .keyboard-navigating .left-sidebar.panel-focused {
-  box-shadow: inset 0 0 0 2px var(--bg-secondary), inset 0 0 0 3px var(--accent-bg);
+  box-shadow:
+    inset 0 0 0 2px var(--bg-secondary),
+    inset 0 0 0 3px var(--accent-bg);
 }
 
 /* Inner wrapper with zoom applied */

--- a/renderer/style/components/pinned-chips.css
+++ b/renderer/style/components/pinned-chips.css
@@ -27,11 +27,21 @@
 }
 
 /* Dim background color for disabled chips */
-.pinned-chip.disabled.highlight-green { background-color: color-mix(in srgb, var(--pinned-green) 35%, transparent); }
-.pinned-chip.disabled.highlight-blue { background-color: color-mix(in srgb, var(--pinned-blue) 35%, transparent); }
-.pinned-chip.disabled.highlight-pink { background-color: color-mix(in srgb, var(--pinned-pink) 35%, transparent); }
-.pinned-chip.disabled.highlight-orange { background-color: color-mix(in srgb, var(--pinned-orange) 35%, transparent); }
-.pinned-chip.disabled.highlight-purple { background-color: color-mix(in srgb, var(--pinned-purple) 35%, transparent); }
+.pinned-chip.disabled.highlight-green {
+  background-color: color-mix(in srgb, var(--pinned-green) 35%, transparent);
+}
+.pinned-chip.disabled.highlight-blue {
+  background-color: color-mix(in srgb, var(--pinned-blue) 35%, transparent);
+}
+.pinned-chip.disabled.highlight-pink {
+  background-color: color-mix(in srgb, var(--pinned-pink) 35%, transparent);
+}
+.pinned-chip.disabled.highlight-orange {
+  background-color: color-mix(in srgb, var(--pinned-orange) 35%, transparent);
+}
+.pinned-chip.disabled.highlight-purple {
+  background-color: color-mix(in srgb, var(--pinned-purple) 35%, transparent);
+}
 
 .pinned-chip-body {
   padding: 2px 4px 2px 8px;
@@ -62,11 +72,21 @@
 }
 
 /* Chip background colors */
-.pinned-chip.highlight-green { background-color: var(--pinned-green); }
-.pinned-chip.highlight-blue { background-color: var(--pinned-blue); }
-.pinned-chip.highlight-pink { background-color: var(--pinned-pink); }
-.pinned-chip.highlight-orange { background-color: var(--pinned-orange); }
-.pinned-chip.highlight-purple { background-color: var(--pinned-purple); }
+.pinned-chip.highlight-green {
+  background-color: var(--pinned-green);
+}
+.pinned-chip.highlight-blue {
+  background-color: var(--pinned-blue);
+}
+.pinned-chip.highlight-pink {
+  background-color: var(--pinned-pink);
+}
+.pinned-chip.highlight-orange {
+  background-color: var(--pinned-orange);
+}
+.pinned-chip.highlight-purple {
+  background-color: var(--pinned-purple);
+}
 
 /* ============================================
    Color Palette Popover
@@ -112,11 +132,21 @@
   box-shadow: 0 0 0 2px var(--text-color);
 }
 
-.color-palette-swatch.highlight-green { background-color: #4caf50; }
-.color-palette-swatch.highlight-blue { background-color: #00bcd4; }
-.color-palette-swatch.highlight-pink { background-color: #e91e63; }
-.color-palette-swatch.highlight-orange { background-color: #ff9800; }
-.color-palette-swatch.highlight-purple { background-color: #9c27b0; }
+.color-palette-swatch.highlight-green {
+  background-color: #4caf50;
+}
+.color-palette-swatch.highlight-blue {
+  background-color: #00bcd4;
+}
+.color-palette-swatch.highlight-pink {
+  background-color: #e91e63;
+}
+.color-palette-swatch.highlight-orange {
+  background-color: #ff9800;
+}
+.color-palette-swatch.highlight-purple {
+  background-color: #9c27b0;
+}
 
 .color-palette-separator {
   width: 1px;

--- a/renderer/style/components/preferences.css
+++ b/renderer/style/components/preferences.css
@@ -488,7 +488,9 @@
   border-radius: var(--radius-full);
   background: var(--accent-bg);
   cursor: pointer;
-  transition: transform var(--transition-fast) ease, box-shadow var(--transition-fast) ease;
+  transition:
+    transform var(--transition-fast) ease,
+    box-shadow var(--transition-fast) ease;
 }
 
 .slider-input input[type="range"]::-webkit-slider-thumb:hover {

--- a/renderer/style/components/right-sidebar.css
+++ b/renderer/style/components/right-sidebar.css
@@ -28,7 +28,9 @@
 
 /* Panel focus indicator — only visible during keyboard navigation */
 .keyboard-navigating .right-sidebar.panel-focused {
-  box-shadow: inset 0 0 0 2px var(--bg-secondary), inset 0 0 0 3px var(--accent-bg);
+  box-shadow:
+    inset 0 0 0 2px var(--bg-secondary),
+    inset 0 0 0 3px var(--accent-bg);
 }
 
 /* Inner wrapper with zoom applied */

--- a/renderer/style/components/right-sidebar/contents.css
+++ b/renderer/style/components/right-sidebar/contents.css
@@ -31,7 +31,9 @@
   overflow: hidden;
   text-overflow: ellipsis;
   opacity: var(--opacity-hover);
-  transition: opacity var(--transition-fast), background var(--transition-fast);
+  transition:
+    opacity var(--transition-fast),
+    background var(--transition-fast);
 }
 
 .right-sidebar-contents-item-button:hover {

--- a/renderer/style/components/right-sidebar/pinned.css
+++ b/renderer/style/components/right-sidebar/pinned.css
@@ -131,8 +131,18 @@
   border-radius: var(--radius-xs);
 }
 
-.right-sidebar-pinned-highlight.highlight-green { background-color: var(--pinned-green); }
-.right-sidebar-pinned-highlight.highlight-blue { background-color: var(--pinned-blue); }
-.right-sidebar-pinned-highlight.highlight-pink { background-color: var(--pinned-pink); }
-.right-sidebar-pinned-highlight.highlight-orange { background-color: var(--pinned-orange); }
-.right-sidebar-pinned-highlight.highlight-purple { background-color: var(--pinned-purple); }
+.right-sidebar-pinned-highlight.highlight-green {
+  background-color: var(--pinned-green);
+}
+.right-sidebar-pinned-highlight.highlight-blue {
+  background-color: var(--pinned-blue);
+}
+.right-sidebar-pinned-highlight.highlight-pink {
+  background-color: var(--pinned-pink);
+}
+.right-sidebar-pinned-highlight.highlight-orange {
+  background-color: var(--pinned-orange);
+}
+.right-sidebar-pinned-highlight.highlight-purple {
+  background-color: var(--pinned-purple);
+}

--- a/renderer/style/components/search-bar.css
+++ b/renderer/style/components/search-bar.css
@@ -173,14 +173,26 @@
   padding: 0 1px;
 }
 
-.pinned-highlight[data-color="green"] { background-color: var(--pinned-green); }
-.pinned-highlight[data-color="blue"] { background-color: var(--pinned-blue); }
-.pinned-highlight[data-color="pink"] { background-color: var(--pinned-pink); }
-.pinned-highlight[data-color="orange"] { background-color: var(--pinned-orange); }
-.pinned-highlight[data-color="purple"] { background-color: var(--pinned-purple); }
+.pinned-highlight[data-color="green"] {
+  background-color: var(--pinned-green);
+}
+.pinned-highlight[data-color="blue"] {
+  background-color: var(--pinned-blue);
+}
+.pinned-highlight[data-color="pink"] {
+  background-color: var(--pinned-pink);
+}
+.pinned-highlight[data-color="orange"] {
+  background-color: var(--pinned-orange);
+}
+.pinned-highlight[data-color="purple"] {
+  background-color: var(--pinned-purple);
+}
 
 /* Disabled: override github-markdown-css .markdown-body mark background */
-.markdown-body .pinned-highlight-disabled { background-color: transparent; }
+.markdown-body .pinned-highlight-disabled {
+  background-color: transparent;
+}
 
 /* Flash animation when scrolling to pinned match */
 .pinned-highlight-flash {

--- a/renderer/style/main.css
+++ b/renderer/style/main.css
@@ -27,6 +27,7 @@
 @import url("./components/content.css");
 @import url("./components/content/code-copy.css");
 @import url("./components/content/content-cursor.css");
+@import url("./components/footnote-popover.css");
 
 /* Special windows */
 @import url("./components/preferences.css");


### PR DESCRIPTION
## Summary

- Add a 60px top offset to the footnote scroll target in `footnote-handler.ts`
- Implement smooth scrolling (`behavior: "smooth"`) for footnote anchor links
- Add graceful fallbacks for environments where strict scroll containers might not be fully initialized

When clicking a footnote link (e.g. `[^1]`) in the markdown renderer, the browser's default behavior scrolls the element directly to the absolute top edge of the scroll container. This caused the footnote to be obscured by Arto's sticky top header. This PR ensures a comfortable read margin is preserved.

## Test plan

- [x] Launch the desktop application
- [x] Open a Markdown document containing footnotes
- [x] Click on a footnote reference and verify the viewport smoothly scrolls, leaving the footnote clearly visible below the sticky header
- [x] Confirm no regressions when using the backlink (`↩`) to return to the original text

## Related issues

- <ISSUE_NUMBER_IF_ANY>
