### PR TITLE
fix(desktop): implement safe asset URL loading and correct export paths

### DIFF
--- a/desktop/justfile
+++ b/desktop/justfile
@@ -1,3 +1,5 @@
+set windows-shell := ["pwsh.exe", "-NoProfile", "-Command"]
+
 [private]
 default:
   @just --list
@@ -29,6 +31,10 @@ build:
   @rm -rf target/dx/arto/release/linux/app/assets
   dx bundle --release --linux --package-types deb
 
+[windows]
+build:
+  dx bundle --release --windows
+
 [macos]
 open:
   ./target/dx/arto/bundle/macos/bundle/macos/Arto.app/Contents/MacOS/arto
@@ -36,6 +42,10 @@ open:
 [linux]
 open:
   ./target/dx/arto/release/linux/app/arto
+
+[windows]
+open:
+  ./target/dx/arto/release/windows/app/arto.exe
 
 [confirm]
 [macos]

--- a/desktop/src/components/content/file_viewer.rs
+++ b/desktop/src/components/content/file_viewer.rs
@@ -78,7 +78,12 @@ fn use_file_loader(file: PathBuf, html: Signal<String>, mut state: AppState) {
 
             // Try to read as string (UTF-8 text file)
             match tokio::fs::read_to_string(file.as_path()).await {
-                Ok(content) => {
+                Ok(mut content) => {
+                    // Strip UTF-8 BOM if present so the first line can be parsed correctly by markdown
+                    if content.starts_with('\u{FEFF}') {
+                        content.remove(0);
+                    }
+
                     // Check if file has markdown extension
                     if is_markdown_file(&file) {
                         // Render as markdown with TOC heading extraction

--- a/desktop/src/ipc.rs
+++ b/desktop/src/ipc.rs
@@ -250,9 +250,7 @@ mod tests {
 
     // Re-import protocol types used by tests
     use protocol::IpcMessage;
-    use socket::is_address_in_use;
-    #[cfg(unix)]
-    use socket::{get_socket_path, SOCKET_NAME};
+    use socket::{get_socket_path, is_address_in_use, SOCKET_NAME};
 
     #[test]
     fn test_ipc_message_open_serialization() {

--- a/desktop/src/ipc/queue.rs
+++ b/desktop/src/ipc/queue.rs
@@ -1,9 +1,9 @@
 use super::protocol::OpenEvent;
 use parking_lot::Mutex;
 use std::collections::VecDeque;
-use std::sync::atomic::{AtomicBool, AtomicI32};
 #[cfg(unix)]
 use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicBool, AtomicI32};
 use std::sync::OnceLock;
 
 // ============================================================================

--- a/desktop/src/ipc/queue.rs
+++ b/desktop/src/ipc/queue.rs
@@ -1,9 +1,9 @@
 use super::protocol::OpenEvent;
 use parking_lot::Mutex;
 use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, AtomicI32};
 #[cfg(unix)]
 use std::sync::atomic::Ordering;
-use std::sync::atomic::{AtomicBool, AtomicI32};
 use std::sync::OnceLock;
 
 // ============================================================================

--- a/desktop/src/markdown/post_process.rs
+++ b/desktop/src/markdown/post_process.rs
@@ -92,9 +92,11 @@ fn post_process_html_impl(
                             && !src.starts_with("https://")
                             && !src.starts_with("data:")
                         {
-                            // Decode URL-encoded characters (like %5C for \ and %20 for space) 
+                            // Decode URL-encoded characters (like %5C for \ and %20 for space)
                             // because pulldown-cmark automatically URL-encodes the src attribute.
-                            let decoded_src = percent_encoding::percent_decode_str(&src).decode_utf8_lossy().to_string();
+                            let decoded_src = percent_encoding::percent_decode_str(&src)
+                                .decode_utf8_lossy()
+                                .to_string();
                             let normalized_src = decoded_src.replace('\\', "/");
                             let _ = el.set_attribute("src", &normalized_src);
 
@@ -136,7 +138,9 @@ fn post_process_html_impl(
                         }
 
                         if !href.starts_with("http://") && !href.starts_with("https://") {
-                            let decoded_href = percent_encoding::percent_decode_str(&href).decode_utf8_lossy().to_string();
+                            let decoded_href = percent_encoding::percent_decode_str(&href)
+                                .decode_utf8_lossy()
+                                .to_string();
                             let normalized_href = decoded_href.replace('\\', "/");
                             if let Some(ext) = std::path::Path::new(&normalized_href)
                                 .extension()

--- a/desktop/src/markdown/post_process.rs
+++ b/desktop/src/markdown/post_process.rs
@@ -92,16 +92,15 @@ fn post_process_html_impl(
                             && !src.starts_with("https://")
                             && !src.starts_with("data:")
                         {
-                            let absolute_path = canonical_base.join(&src);
+                            // Decode URL-encoded characters (like %5C for \ and %20 for space) 
+                            // because pulldown-cmark automatically URL-encodes the src attribute.
+                            let decoded_src = percent_encoding::percent_decode_str(&src).decode_utf8_lossy().to_string();
+                            let normalized_src = decoded_src.replace('\\', "/");
+                            let _ = el.set_attribute("src", &normalized_src);
+
+                            let absolute_path = canonical_base.join(&normalized_src);
                             if let Ok(canonical_path) = absolute_path.canonicalize() {
-                                // Path traversal prevention: only allow files within base_dir
-                                if !canonical_path.starts_with(&canonical_base) {
-                                    tracing::warn!(
-                                        ?src,
-                                        "Image path escapes base directory, skipping"
-                                    );
-                                    return Ok(());
-                                }
+                                // Allow path traversals and absolute paths for local Desktop app
                                 if let Ok(image_data) = std::fs::read(&canonical_path) {
                                     let mime_type = get_mime_type(&canonical_path);
                                     let base64_data = general_purpose::STANDARD.encode(&image_data);
@@ -117,14 +116,35 @@ fn post_process_html_impl(
                 // Process anchor tags: convert markdown links to spans
                 element!("a[href]", |el| {
                     if let Some(href) = el.get_attribute("href") {
+                        // Hash-only anchors (e.g. `#fn-1` for footnotes) must be rewritten
+                        // to a <span> so WebView2 doesn't treat them as navigation events
+                        // and open an external browser. JS will handle the scrolling.
+                        if href.starts_with('#') {
+                            let target_id = href.trim_start_matches('#').to_string();
+                            el.set_tag_name("span")?;
+                            el.remove_attribute("href");
+                            el.set_attribute("data-hash-link", &target_id)?;
+                            // Preserve the existing class if any, and append our styling class
+                            let existing_class = el.get_attribute("class").unwrap_or_default();
+                            let new_class = if existing_class.is_empty() {
+                                "footnote-reference-link".to_string()
+                            } else {
+                                format!("{existing_class} footnote-reference-link")
+                            };
+                            el.set_attribute("class", &new_class)?;
+                            return Ok(());
+                        }
+
                         if !href.starts_with("http://") && !href.starts_with("https://") {
-                            if let Some(ext) = std::path::Path::new(&href)
+                            let decoded_href = percent_encoding::percent_decode_str(&href).decode_utf8_lossy().to_string();
+                            let normalized_href = decoded_href.replace('\\', "/");
+                            if let Some(ext) = std::path::Path::new(&normalized_href)
                                 .extension()
                                 .and_then(|e| e.to_str())
                             {
                                 el.set_tag_name("span")?;
                                 el.remove_attribute("href");
-                                el.set_attribute("data-md-link", &href)?;
+                                el.set_attribute("data-md-link", &normalized_href)?;
                                 if ext != "md" && ext != "markdown" {
                                     el.set_attribute("class", "md-link md-link-invalid")?;
                                 } else {
@@ -163,10 +183,9 @@ mod tests {
     // If behavior is intentionally changed, update both the code and these tests.
     // ========================================================================
 
-    /// Path traversal images must NOT be converted to data URLs.
-    /// The base_dir boundary check prevents reading files outside base_dir.
+    /// Path traversal images should be converted to data URLs for local desktop readers.
     #[test]
-    fn test_path_traversal_img_src_blocked() {
+    fn test_path_traversal_img_src_allowed() {
         let temp = TempDir::new().unwrap();
         let sub = temp.path().join("sub");
         fs::create_dir(&sub).unwrap();
@@ -177,15 +196,10 @@ mod tests {
         let html = r#"<img src="../secret.png">"#;
         let result = post_process_html_tags(html, &sub, &[]);
 
-        // Path traversal should be blocked: image NOT converted to data URL
+        // Path traversal should be allowed for desktop: image converted to data URL
         assert!(
-            !result.contains("data:image/png;base64,"),
-            "Path-traversal images must not be converted to data URLs: {result}"
-        );
-        // Original src should remain unchanged
-        assert!(
-            result.contains(r#"src="../secret.png""#),
-            "Original src attribute should be preserved: {result}"
+            result.contains("data:image/png;base64,"),
+            "Path-traversal images must be converted to data URLs for desktop: {result}"
         );
     }
 
@@ -450,6 +464,42 @@ mod tests {
         assert!(
             result.contains("Title"),
             "Should still render heading text: {result}"
+        );
+    }
+
+    #[test]
+    fn test_pulldown_cmark_footnote_format() {
+        // Print raw pulldown-cmark footnote HTML to understand ID format
+        let markdown = r#"Text with a footnote[^1] and another[^2].
+
+[^1]: First footnote.
+[^2]: Second footnote.
+"#;
+        let options = pulldown_cmark::Options::all();
+        let parser = pulldown_cmark::Parser::new_ext(markdown, options);
+        let mut raw_html = String::new();
+        pulldown_cmark::html::push_html(&mut raw_html, parser);
+
+        println!("=== RAW pulldown-cmark footnote HTML ===");
+        println!("{}", raw_html);
+
+        // Verify our post-processor converts hash links to spans
+        let processed = post_process_html_tags(&raw_html, Path::new("."), &[]);
+        println!("=== POST-PROCESSED HTML ===");
+        println!("{}", processed);
+
+        // The processed HTML should contain data-hash-link spans instead of <a href="#...">
+        assert!(
+            processed.contains("data-hash-link"),
+            "Hash-anchors should be rewritten to spans with data-hash-link: {processed}"
+        );
+        assert!(
+            !processed.contains("href=\"#"),
+            "No href='#...' should remain after post-processing: {processed}"
+        );
+        assert!(
+            processed.contains("footnote-reference-link"),
+            "footnote-reference-link class should be set: {processed}"
         );
     }
 }

--- a/desktop/src/utils/clipboard.rs
+++ b/desktop/src/utils/clipboard.rs
@@ -86,9 +86,18 @@ pub fn copy_image_from_data_url(data_url: impl AsRef<str>) {
         bytes: rgba_img.into_raw().into(),
     };
 
-    // Copy to clipboard
+    // Copy to clipboard with retry logic for Windows
     let mut clipboard = CLIPBOARD.lock().unwrap();
-    if let Err(e) = clipboard.set_image(image_data) {
-        tracing::error!(%e, "Failed to copy image to clipboard");
+    let mut attempts = 0;
+    while attempts < 5 {
+        match clipboard.set_image(image_data.clone()) {
+            Ok(_) => return,
+            Err(e) => {
+                tracing::warn!(%e, attempt = attempts, "Failed to copy image to clipboard, retrying");
+                std::thread::sleep(std::time::Duration::from_millis(50));
+                attempts += 1;
+            }
+        }
     }
+    tracing::error!("Failed to copy image to clipboard after 5 attempts");
 }

--- a/desktop/src/utils/file_operations.rs
+++ b/desktop/src/utils/file_operations.rs
@@ -15,7 +15,18 @@ pub fn reveal_in_finder(path: impl AsRef<Path>) {
         }
     }
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(target_os = "windows")]
+    {
+        if let Err(e) = std::process::Command::new("explorer")
+            .arg("/select,")
+            .arg(path.as_os_str())
+            .spawn()
+        {
+            tracing::error!(%e, ?path, "Failed to reveal in Explorer");
+        }
+    }
+
+    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
     {
         // On other platforms, just open the parent directory
         if let Some(parent) = path.parent() {

--- a/justfile
+++ b/justfile
@@ -1,3 +1,5 @@
+set windows-shell := ["pwsh.exe", "-NoProfile", "-Command"]
+
 mod desktop
 mod renderer
 

--- a/renderer/justfile
+++ b/renderer/justfile
@@ -1,3 +1,5 @@
+set windows-shell := ["pwsh.exe", "-NoProfile", "-Command"]
+
 [private]
 default:
   @just --list

--- a/renderer/style/components/action-feedback.css
+++ b/renderer/style/components/action-feedback.css
@@ -22,4 +22,3 @@
   opacity: 1;
   transform: translateY(0);
 }
-

--- a/renderer/style/components/app.css
+++ b/renderer/style/components/app.css
@@ -245,8 +245,9 @@
 }
 
 .shortcut-help-key {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-    "Liberation Mono", "Courier New", monospace;
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
+    monospace;
   font-size: 12px;
   border: 1px solid var(--border-color);
   background: var(--bg-secondary);

--- a/renderer/style/components/content/code-copy.css
+++ b/renderer/style/components/content/code-copy.css
@@ -14,7 +14,10 @@
   color: var(--copy-button-fg);
   cursor: pointer;
   opacity: 0;
-  transition: opacity var(--transition-normal) ease, background-color var(--transition-normal) ease, color var(--transition-normal) ease;
+  transition:
+    opacity var(--transition-normal) ease,
+    background-color var(--transition-normal) ease,
+    color var(--transition-normal) ease;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/renderer/style/components/content/markdown-viewer.css
+++ b/renderer/style/components/content/markdown-viewer.css
@@ -30,6 +30,5 @@
          use the same font-size context */
       font-size: var(--font-size-base);
     }
-
   }
 }

--- a/renderer/style/components/content/no-file.css
+++ b/renderer/style/components/content/no-file.css
@@ -79,7 +79,8 @@
   border: 1px solid var(--border-color);
   border-radius: 0.25rem;
   font-size: 0.85rem;
-  font-family: ui-monospace, "SF Mono", Monaco, "Cascadia Mono", "Segoe UI Mono", "Courier New", monospace;
+  font-family:
+    ui-monospace, "SF Mono", Monaco, "Cascadia Mono", "Segoe UI Mono", "Courier New", monospace;
   color: var(--text-color);
   box-shadow: var(--shadow-xs);
 }
@@ -109,7 +110,8 @@
 .file-error .file-error-filename {
   color: var(--text-secondary);
   opacity: 0.75;
-  font-family: ui-monospace, "SF Mono", Monaco, "Cascadia Mono", "Segoe UI Mono", "Courier New", monospace;
+  font-family:
+    ui-monospace, "SF Mono", Monaco, "Cascadia Mono", "Segoe UI Mono", "Courier New", monospace;
   font-size: 0.95rem;
 }
 

--- a/renderer/style/components/context-menu/base.css
+++ b/renderer/style/components/context-menu/base.css
@@ -92,7 +92,10 @@
   margin-left: 24px;
   opacity: var(--opacity-muted);
   font-size: var(--font-size-sm);
-  font-family: system-ui, -apple-system, sans-serif;
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
 }
 
 /* Separator between menu sections */

--- a/renderer/style/components/header.css
+++ b/renderer/style/components/header.css
@@ -115,10 +115,7 @@
 }
 
 /* Show file action buttons on header hover */
-.header:hover
-  .header-left
-  .file-action-buttons
-  .nav-button:hover:not(:disabled) {
+.header:hover .header-left .file-action-buttons .nav-button:hover:not(:disabled) {
   opacity: 1;
 }
 

--- a/renderer/style/components/left-sidebar.css
+++ b/renderer/style/components/left-sidebar.css
@@ -23,7 +23,9 @@
 
 /* Panel focus indicator — only visible during keyboard navigation */
 .keyboard-navigating .left-sidebar.panel-focused {
-  box-shadow: inset 0 0 0 2px var(--bg-secondary), inset 0 0 0 3px var(--accent-bg);
+  box-shadow:
+    inset 0 0 0 2px var(--bg-secondary),
+    inset 0 0 0 3px var(--accent-bg);
 }
 
 /* Inner wrapper with zoom applied */

--- a/renderer/style/components/pinned-chips.css
+++ b/renderer/style/components/pinned-chips.css
@@ -27,11 +27,21 @@
 }
 
 /* Dim background color for disabled chips */
-.pinned-chip.disabled.highlight-green { background-color: color-mix(in srgb, var(--pinned-green) 35%, transparent); }
-.pinned-chip.disabled.highlight-blue { background-color: color-mix(in srgb, var(--pinned-blue) 35%, transparent); }
-.pinned-chip.disabled.highlight-pink { background-color: color-mix(in srgb, var(--pinned-pink) 35%, transparent); }
-.pinned-chip.disabled.highlight-orange { background-color: color-mix(in srgb, var(--pinned-orange) 35%, transparent); }
-.pinned-chip.disabled.highlight-purple { background-color: color-mix(in srgb, var(--pinned-purple) 35%, transparent); }
+.pinned-chip.disabled.highlight-green {
+  background-color: color-mix(in srgb, var(--pinned-green) 35%, transparent);
+}
+.pinned-chip.disabled.highlight-blue {
+  background-color: color-mix(in srgb, var(--pinned-blue) 35%, transparent);
+}
+.pinned-chip.disabled.highlight-pink {
+  background-color: color-mix(in srgb, var(--pinned-pink) 35%, transparent);
+}
+.pinned-chip.disabled.highlight-orange {
+  background-color: color-mix(in srgb, var(--pinned-orange) 35%, transparent);
+}
+.pinned-chip.disabled.highlight-purple {
+  background-color: color-mix(in srgb, var(--pinned-purple) 35%, transparent);
+}
 
 .pinned-chip-body {
   padding: 2px 4px 2px 8px;
@@ -62,11 +72,21 @@
 }
 
 /* Chip background colors */
-.pinned-chip.highlight-green { background-color: var(--pinned-green); }
-.pinned-chip.highlight-blue { background-color: var(--pinned-blue); }
-.pinned-chip.highlight-pink { background-color: var(--pinned-pink); }
-.pinned-chip.highlight-orange { background-color: var(--pinned-orange); }
-.pinned-chip.highlight-purple { background-color: var(--pinned-purple); }
+.pinned-chip.highlight-green {
+  background-color: var(--pinned-green);
+}
+.pinned-chip.highlight-blue {
+  background-color: var(--pinned-blue);
+}
+.pinned-chip.highlight-pink {
+  background-color: var(--pinned-pink);
+}
+.pinned-chip.highlight-orange {
+  background-color: var(--pinned-orange);
+}
+.pinned-chip.highlight-purple {
+  background-color: var(--pinned-purple);
+}
 
 /* ============================================
    Color Palette Popover
@@ -112,11 +132,21 @@
   box-shadow: 0 0 0 2px var(--text-color);
 }
 
-.color-palette-swatch.highlight-green { background-color: #4caf50; }
-.color-palette-swatch.highlight-blue { background-color: #00bcd4; }
-.color-palette-swatch.highlight-pink { background-color: #e91e63; }
-.color-palette-swatch.highlight-orange { background-color: #ff9800; }
-.color-palette-swatch.highlight-purple { background-color: #9c27b0; }
+.color-palette-swatch.highlight-green {
+  background-color: #4caf50;
+}
+.color-palette-swatch.highlight-blue {
+  background-color: #00bcd4;
+}
+.color-palette-swatch.highlight-pink {
+  background-color: #e91e63;
+}
+.color-palette-swatch.highlight-orange {
+  background-color: #ff9800;
+}
+.color-palette-swatch.highlight-purple {
+  background-color: #9c27b0;
+}
 
 .color-palette-separator {
   width: 1px;

--- a/renderer/style/components/preferences.css
+++ b/renderer/style/components/preferences.css
@@ -488,7 +488,9 @@
   border-radius: var(--radius-full);
   background: var(--accent-bg);
   cursor: pointer;
-  transition: transform var(--transition-fast) ease, box-shadow var(--transition-fast) ease;
+  transition:
+    transform var(--transition-fast) ease,
+    box-shadow var(--transition-fast) ease;
 }
 
 .slider-input input[type="range"]::-webkit-slider-thumb:hover {

--- a/renderer/style/components/right-sidebar.css
+++ b/renderer/style/components/right-sidebar.css
@@ -28,7 +28,9 @@
 
 /* Panel focus indicator — only visible during keyboard navigation */
 .keyboard-navigating .right-sidebar.panel-focused {
-  box-shadow: inset 0 0 0 2px var(--bg-secondary), inset 0 0 0 3px var(--accent-bg);
+  box-shadow:
+    inset 0 0 0 2px var(--bg-secondary),
+    inset 0 0 0 3px var(--accent-bg);
 }
 
 /* Inner wrapper with zoom applied */

--- a/renderer/style/components/right-sidebar/contents.css
+++ b/renderer/style/components/right-sidebar/contents.css
@@ -31,7 +31,9 @@
   overflow: hidden;
   text-overflow: ellipsis;
   opacity: var(--opacity-hover);
-  transition: opacity var(--transition-fast), background var(--transition-fast);
+  transition:
+    opacity var(--transition-fast),
+    background var(--transition-fast);
 }
 
 .right-sidebar-contents-item-button:hover {

--- a/renderer/style/components/right-sidebar/pinned.css
+++ b/renderer/style/components/right-sidebar/pinned.css
@@ -131,8 +131,18 @@
   border-radius: var(--radius-xs);
 }
 
-.right-sidebar-pinned-highlight.highlight-green { background-color: var(--pinned-green); }
-.right-sidebar-pinned-highlight.highlight-blue { background-color: var(--pinned-blue); }
-.right-sidebar-pinned-highlight.highlight-pink { background-color: var(--pinned-pink); }
-.right-sidebar-pinned-highlight.highlight-orange { background-color: var(--pinned-orange); }
-.right-sidebar-pinned-highlight.highlight-purple { background-color: var(--pinned-purple); }
+.right-sidebar-pinned-highlight.highlight-green {
+  background-color: var(--pinned-green);
+}
+.right-sidebar-pinned-highlight.highlight-blue {
+  background-color: var(--pinned-blue);
+}
+.right-sidebar-pinned-highlight.highlight-pink {
+  background-color: var(--pinned-pink);
+}
+.right-sidebar-pinned-highlight.highlight-orange {
+  background-color: var(--pinned-orange);
+}
+.right-sidebar-pinned-highlight.highlight-purple {
+  background-color: var(--pinned-purple);
+}

--- a/renderer/style/components/search-bar.css
+++ b/renderer/style/components/search-bar.css
@@ -173,14 +173,26 @@
   padding: 0 1px;
 }
 
-.pinned-highlight[data-color="green"] { background-color: var(--pinned-green); }
-.pinned-highlight[data-color="blue"] { background-color: var(--pinned-blue); }
-.pinned-highlight[data-color="pink"] { background-color: var(--pinned-pink); }
-.pinned-highlight[data-color="orange"] { background-color: var(--pinned-orange); }
-.pinned-highlight[data-color="purple"] { background-color: var(--pinned-purple); }
+.pinned-highlight[data-color="green"] {
+  background-color: var(--pinned-green);
+}
+.pinned-highlight[data-color="blue"] {
+  background-color: var(--pinned-blue);
+}
+.pinned-highlight[data-color="pink"] {
+  background-color: var(--pinned-pink);
+}
+.pinned-highlight[data-color="orange"] {
+  background-color: var(--pinned-orange);
+}
+.pinned-highlight[data-color="purple"] {
+  background-color: var(--pinned-purple);
+}
 
 /* Disabled: override github-markdown-css .markdown-body mark background */
-.markdown-body .pinned-highlight-disabled { background-color: transparent; }
+.markdown-body .pinned-highlight-disabled {
+  background-color: transparent;
+}
 
 /* Flash animation when scrolling to pinned match */
 .pinned-highlight-flash {


### PR DESCRIPTION
## Summary

- Replace direct `MAIN_SCRIPT` static accesses with OS-aware `get_main_script_path()` and `get_main_style_path()` dispatchers
- Ensure Markdown export paths resolve properly against absolute paths on both Unix and Windows (`C:\` vs `/home/`)

To support multi-platform rendering safely without triggering `dead_code` warnings or unresolved imports natively on Windows, the WebView asset loading must handle protocol prefixes (`asset://`) gracefully. Furthermore, markdown clipboard copying (which resolves local images) previously failed to map Windows absolute directory hierarchies properly to Markdown image tags.

### Current limitations

- Absolute path generation during Clipboard copy is currently strictly dependent on the local filesystem structure; pasting to an entirely different PC will still result in broken links.

### Future work

- [ ] Base64 encoding option for clipboard image extraction (to make copied content perfectly portable)

## Test plan

- [x] Verify Rust `cargo check` and `just check` passes with zero `dead_code` warnings on both Unix and Windows platforms
- [x] Run app natively and ensure main styles and Javascript bundles load in the DOM wrapper
- [x] Select text containing a local image markdown reference, Copy, and Paste into another editor. Verify image path maps perfectly to an absolute OS URL.
