### PR TITLE
fix(renderer): implement clamped scroll to prevent Chromium overscroll

### DIFF
--- a/desktop/justfile
+++ b/desktop/justfile
@@ -1,3 +1,5 @@
+set windows-shell := ["pwsh.exe", "-NoProfile", "-Command"]
+
 [private]
 default:
   @just --list
@@ -29,6 +31,10 @@ build:
   @rm -rf target/dx/arto/release/linux/app/assets
   dx bundle --release --linux --package-types deb
 
+[windows]
+build:
+  dx bundle --release --windows
+
 [macos]
 open:
   ./target/dx/arto/bundle/macos/bundle/macos/Arto.app/Contents/MacOS/arto
@@ -36,6 +42,10 @@ open:
 [linux]
 open:
   ./target/dx/arto/release/linux/app/arto
+
+[windows]
+open:
+  ./target/dx/arto/release/windows/app/arto.exe
 
 [confirm]
 [macos]

--- a/desktop/src/components/right_sidebar/contents_tab.rs
+++ b/desktop/src/components/right_sidebar/contents_tab.rs
@@ -50,8 +50,18 @@ fn HeadingItem(heading: HeadingInfo, is_keyboard_focused: bool) -> Element {
                             r#"
                             (() => {{
                                 const el = document.getElementById({id_json});
-                                if (el) {{
-                                    el.scrollIntoView({{ behavior: 'smooth', block: 'start' }});
+                                const container = document.querySelector('.content');
+                                if (el && container) {{
+                                    // Calculate target offset
+                                    const containerRect = container.getBoundingClientRect();
+                                    const elRect = el.getBoundingClientRect();
+                                    const targetScroll = container.scrollTop + (elRect.top - containerRect.top);
+                                    
+                                    // Clamp to max possible scroll
+                                    const maxScroll = Math.max(0, container.scrollHeight - container.clientHeight);
+                                    const clampedScrollTop = Math.min(targetScroll, maxScroll);
+                                    
+                                    container.scrollTo({{ top: clampedScrollTop, behavior: 'smooth' }});
                                 }}
                             }})();
                             "#,

--- a/desktop/src/ipc.rs
+++ b/desktop/src/ipc.rs
@@ -250,9 +250,7 @@ mod tests {
 
     // Re-import protocol types used by tests
     use protocol::IpcMessage;
-    use socket::is_address_in_use;
-    #[cfg(unix)]
-    use socket::{get_socket_path, SOCKET_NAME};
+    use socket::{get_socket_path, is_address_in_use, SOCKET_NAME};
 
     #[test]
     fn test_ipc_message_open_serialization() {

--- a/desktop/src/ipc/queue.rs
+++ b/desktop/src/ipc/queue.rs
@@ -1,9 +1,9 @@
 use super::protocol::OpenEvent;
 use parking_lot::Mutex;
 use std::collections::VecDeque;
-use std::sync::atomic::{AtomicBool, AtomicI32};
 #[cfg(unix)]
 use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicBool, AtomicI32};
 use std::sync::OnceLock;
 
 // ============================================================================

--- a/desktop/src/ipc/queue.rs
+++ b/desktop/src/ipc/queue.rs
@@ -1,9 +1,9 @@
 use super::protocol::OpenEvent;
 use parking_lot::Mutex;
 use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, AtomicI32};
 #[cfg(unix)]
 use std::sync::atomic::Ordering;
-use std::sync::atomic::{AtomicBool, AtomicI32};
 use std::sync::OnceLock;
 
 // ============================================================================

--- a/justfile
+++ b/justfile
@@ -1,3 +1,5 @@
+set windows-shell := ["pwsh.exe", "-NoProfile", "-Command"]
+
 mod desktop
 mod renderer
 

--- a/renderer/justfile
+++ b/renderer/justfile
@@ -1,3 +1,5 @@
+set windows-shell := ["pwsh.exe", "-NoProfile", "-Command"]
+
 [private]
 default:
   @just --list

--- a/renderer/src/content-cursor.ts
+++ b/renderer/src/content-cursor.ts
@@ -8,8 +8,6 @@ import { extractTableDelimited, formatTableAsMarkdown } from "./table-utils";
 /// Lazy rescan pattern: before each navigation, verify the current element is
 /// still in the DOM via document.contains(). If stale, rescan from .markdown-body.
 
-import { extractTableDelimited, formatTableAsMarkdown } from "./table-utils";
-
 const CURSOR_CLASS = "content-cursor-active";
 const HOLD_CLASS = "content-cursor-hold";
 

--- a/renderer/src/content-cursor.ts
+++ b/renderer/src/content-cursor.ts
@@ -1,4 +1,5 @@
-/// Content cursor for keyboard navigation of block elements in the markdown viewer.
+import { scrollIntoViewClamped } from "./scroll-controller";
+import { extractTableDelimited, formatTableAsMarkdown } from "./table-utils";
 ///
 /// Manages cursor state, navigation (next/prev, heading jump), highlight,
 /// and content extraction for copy actions. Cursor state lives in JS because
@@ -97,7 +98,7 @@ function applyHighlight(scroll: boolean): void {
     void el.offsetWidth;
     el.classList.add(CURSOR_CLASS);
     if (scroll) {
-      el.scrollIntoView({ block: "nearest", behavior: "smooth" });
+      scrollIntoViewClamped(el, "nearest");
     }
   }
 }

--- a/renderer/src/context-menu-handler.test.ts
+++ b/renderer/src/context-menu-handler.test.ts
@@ -182,9 +182,9 @@ describe("setup", () => {
     document.caretRangeFromPoint = () => null;
 
     window.Arto = {
-      ...(window.Arto ?? {}),
+      ...window.Arto,
       contentCursor: {
-        ...(window.Arto?.contentCursor ?? {}),
+        ...window.Arto?.contentCursor,
         clearCursor: () => {},
         setFromContextTarget: () => {},
       },

--- a/renderer/src/find-in-page.ts
+++ b/renderer/src/find-in-page.ts
@@ -1,3 +1,5 @@
+import { scrollIntoViewClamped } from "./scroll-controller";
+
 /**
  * Pinned search definition from Rust.
  */
@@ -226,7 +228,7 @@ function navigateToMatch(direction: "next" | "prev"): number {
   // Add active class to new current and scroll into view
   const next = state.highlightElements[state.currentIndex];
   next?.classList.add("search-highlight-active");
-  next?.scrollIntoView({ behavior: "smooth", block: "center" });
+  if (next) scrollIntoViewClamped(next, "center");
 
   return state.currentIndex + 1; // 1-based for display
 }
@@ -342,7 +344,7 @@ export function navigateTo(index: number): void {
   state.currentIndex = index;
   const target = state.highlightElements[index];
   target?.classList.add("search-highlight-active");
-  target?.scrollIntoView({ behavior: "smooth", block: "center" });
+  if (target) scrollIntoViewClamped(target, "center");
 
   // Notify callback with unified format
   const newCurrent = index + 1;
@@ -390,7 +392,7 @@ export function scrollToPinnedMatch(pinnedId: string, index: number): void {
   }
 
   const target = elements[index];
-  target?.scrollIntoView({ behavior: "smooth", block: "center" });
+  if (target) scrollIntoViewClamped(target, "center");
 
   // Brief highlight effect
   target?.classList.add("pinned-highlight-flash");

--- a/renderer/src/scroll-controller.ts
+++ b/renderer/src/scroll-controller.ts
@@ -57,3 +57,47 @@ export function scrollToBottom(): void {
   const el = getContentElement();
   if (el) scrollTo(el, el.scrollHeight);
 }
+
+/**
+ * Replaces native `element.scrollIntoView()` with a manual scroll position calculation.
+ * This prevents the known Chromium overscroll bug where elements inside a container with `zoom`
+ * cause `scrollTop` to exceed the `scrollHeight - clientHeight` bounds, resulting in blank space.
+ *
+ * @param el The target element to scroll to
+ * @param block Where to align the element ('start', 'center', 'nearest')
+ */
+export function scrollIntoViewClamped(
+  el: HTMLElement,
+  block: "start" | "center" | "nearest" = "start",
+): void {
+  const container = getContentElement();
+  if (!container || !el) return;
+
+  const containerRect = container.getBoundingClientRect();
+  const elRect = el.getBoundingClientRect();
+
+  let targetScroll = container.scrollTop;
+
+  if (block === "start") {
+    // Math: current scroll + visual offset from container top
+    targetScroll += elRect.top - containerRect.top;
+  } else if (block === "center") {
+    // Aligns the center of the element with the center of the container
+    const elCenter = elRect.top + elRect.height / 2;
+    const containerCenter = containerRect.top + containerRect.height / 2;
+    targetScroll += elCenter - containerCenter;
+  } else if (block === "nearest") {
+    // Only scroll if element is outside the visible viewport
+    if (elRect.top < containerRect.top) {
+      targetScroll += elRect.top - containerRect.top; // Align top
+    } else if (elRect.bottom > containerRect.bottom) {
+      targetScroll += elRect.bottom - containerRect.bottom; // Align bottom
+    }
+  }
+
+  // Clamp the calculated target to prevent overscroll
+  const maxScroll = Math.max(0, container.scrollHeight - container.clientHeight);
+  const clampedScrollTop = Math.min(Math.max(0, targetScroll), maxScroll);
+
+  scrollTo(container, clampedScrollTop);
+}

--- a/renderer/style/components/action-feedback.css
+++ b/renderer/style/components/action-feedback.css
@@ -22,4 +22,3 @@
   opacity: 1;
   transform: translateY(0);
 }
-

--- a/renderer/style/components/app.css
+++ b/renderer/style/components/app.css
@@ -245,8 +245,9 @@
 }
 
 .shortcut-help-key {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-    "Liberation Mono", "Courier New", monospace;
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
+    monospace;
   font-size: 12px;
   border: 1px solid var(--border-color);
   background: var(--bg-secondary);

--- a/renderer/style/components/content/code-copy.css
+++ b/renderer/style/components/content/code-copy.css
@@ -14,7 +14,10 @@
   color: var(--copy-button-fg);
   cursor: pointer;
   opacity: 0;
-  transition: opacity var(--transition-normal) ease, background-color var(--transition-normal) ease, color var(--transition-normal) ease;
+  transition:
+    opacity var(--transition-normal) ease,
+    background-color var(--transition-normal) ease,
+    color var(--transition-normal) ease;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/renderer/style/components/content/markdown-viewer.css
+++ b/renderer/style/components/content/markdown-viewer.css
@@ -30,6 +30,5 @@
          use the same font-size context */
       font-size: var(--font-size-base);
     }
-
   }
 }

--- a/renderer/style/components/content/no-file.css
+++ b/renderer/style/components/content/no-file.css
@@ -79,7 +79,8 @@
   border: 1px solid var(--border-color);
   border-radius: 0.25rem;
   font-size: 0.85rem;
-  font-family: ui-monospace, "SF Mono", Monaco, "Cascadia Mono", "Segoe UI Mono", "Courier New", monospace;
+  font-family:
+    ui-monospace, "SF Mono", Monaco, "Cascadia Mono", "Segoe UI Mono", "Courier New", monospace;
   color: var(--text-color);
   box-shadow: var(--shadow-xs);
 }
@@ -109,7 +110,8 @@
 .file-error .file-error-filename {
   color: var(--text-secondary);
   opacity: 0.75;
-  font-family: ui-monospace, "SF Mono", Monaco, "Cascadia Mono", "Segoe UI Mono", "Courier New", monospace;
+  font-family:
+    ui-monospace, "SF Mono", Monaco, "Cascadia Mono", "Segoe UI Mono", "Courier New", monospace;
   font-size: 0.95rem;
 }
 

--- a/renderer/style/components/context-menu/base.css
+++ b/renderer/style/components/context-menu/base.css
@@ -92,7 +92,10 @@
   margin-left: 24px;
   opacity: var(--opacity-muted);
   font-size: var(--font-size-sm);
-  font-family: system-ui, -apple-system, sans-serif;
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
 }
 
 /* Separator between menu sections */

--- a/renderer/style/components/header.css
+++ b/renderer/style/components/header.css
@@ -115,10 +115,7 @@
 }
 
 /* Show file action buttons on header hover */
-.header:hover
-  .header-left
-  .file-action-buttons
-  .nav-button:hover:not(:disabled) {
+.header:hover .header-left .file-action-buttons .nav-button:hover:not(:disabled) {
   opacity: 1;
 }
 

--- a/renderer/style/components/left-sidebar.css
+++ b/renderer/style/components/left-sidebar.css
@@ -23,7 +23,9 @@
 
 /* Panel focus indicator — only visible during keyboard navigation */
 .keyboard-navigating .left-sidebar.panel-focused {
-  box-shadow: inset 0 0 0 2px var(--bg-secondary), inset 0 0 0 3px var(--accent-bg);
+  box-shadow:
+    inset 0 0 0 2px var(--bg-secondary),
+    inset 0 0 0 3px var(--accent-bg);
 }
 
 /* Inner wrapper with zoom applied */

--- a/renderer/style/components/pinned-chips.css
+++ b/renderer/style/components/pinned-chips.css
@@ -27,11 +27,21 @@
 }
 
 /* Dim background color for disabled chips */
-.pinned-chip.disabled.highlight-green { background-color: color-mix(in srgb, var(--pinned-green) 35%, transparent); }
-.pinned-chip.disabled.highlight-blue { background-color: color-mix(in srgb, var(--pinned-blue) 35%, transparent); }
-.pinned-chip.disabled.highlight-pink { background-color: color-mix(in srgb, var(--pinned-pink) 35%, transparent); }
-.pinned-chip.disabled.highlight-orange { background-color: color-mix(in srgb, var(--pinned-orange) 35%, transparent); }
-.pinned-chip.disabled.highlight-purple { background-color: color-mix(in srgb, var(--pinned-purple) 35%, transparent); }
+.pinned-chip.disabled.highlight-green {
+  background-color: color-mix(in srgb, var(--pinned-green) 35%, transparent);
+}
+.pinned-chip.disabled.highlight-blue {
+  background-color: color-mix(in srgb, var(--pinned-blue) 35%, transparent);
+}
+.pinned-chip.disabled.highlight-pink {
+  background-color: color-mix(in srgb, var(--pinned-pink) 35%, transparent);
+}
+.pinned-chip.disabled.highlight-orange {
+  background-color: color-mix(in srgb, var(--pinned-orange) 35%, transparent);
+}
+.pinned-chip.disabled.highlight-purple {
+  background-color: color-mix(in srgb, var(--pinned-purple) 35%, transparent);
+}
 
 .pinned-chip-body {
   padding: 2px 4px 2px 8px;
@@ -62,11 +72,21 @@
 }
 
 /* Chip background colors */
-.pinned-chip.highlight-green { background-color: var(--pinned-green); }
-.pinned-chip.highlight-blue { background-color: var(--pinned-blue); }
-.pinned-chip.highlight-pink { background-color: var(--pinned-pink); }
-.pinned-chip.highlight-orange { background-color: var(--pinned-orange); }
-.pinned-chip.highlight-purple { background-color: var(--pinned-purple); }
+.pinned-chip.highlight-green {
+  background-color: var(--pinned-green);
+}
+.pinned-chip.highlight-blue {
+  background-color: var(--pinned-blue);
+}
+.pinned-chip.highlight-pink {
+  background-color: var(--pinned-pink);
+}
+.pinned-chip.highlight-orange {
+  background-color: var(--pinned-orange);
+}
+.pinned-chip.highlight-purple {
+  background-color: var(--pinned-purple);
+}
 
 /* ============================================
    Color Palette Popover
@@ -112,11 +132,21 @@
   box-shadow: 0 0 0 2px var(--text-color);
 }
 
-.color-palette-swatch.highlight-green { background-color: #4caf50; }
-.color-palette-swatch.highlight-blue { background-color: #00bcd4; }
-.color-palette-swatch.highlight-pink { background-color: #e91e63; }
-.color-palette-swatch.highlight-orange { background-color: #ff9800; }
-.color-palette-swatch.highlight-purple { background-color: #9c27b0; }
+.color-palette-swatch.highlight-green {
+  background-color: #4caf50;
+}
+.color-palette-swatch.highlight-blue {
+  background-color: #00bcd4;
+}
+.color-palette-swatch.highlight-pink {
+  background-color: #e91e63;
+}
+.color-palette-swatch.highlight-orange {
+  background-color: #ff9800;
+}
+.color-palette-swatch.highlight-purple {
+  background-color: #9c27b0;
+}
 
 .color-palette-separator {
   width: 1px;

--- a/renderer/style/components/preferences.css
+++ b/renderer/style/components/preferences.css
@@ -488,7 +488,9 @@
   border-radius: var(--radius-full);
   background: var(--accent-bg);
   cursor: pointer;
-  transition: transform var(--transition-fast) ease, box-shadow var(--transition-fast) ease;
+  transition:
+    transform var(--transition-fast) ease,
+    box-shadow var(--transition-fast) ease;
 }
 
 .slider-input input[type="range"]::-webkit-slider-thumb:hover {

--- a/renderer/style/components/right-sidebar.css
+++ b/renderer/style/components/right-sidebar.css
@@ -28,7 +28,9 @@
 
 /* Panel focus indicator — only visible during keyboard navigation */
 .keyboard-navigating .right-sidebar.panel-focused {
-  box-shadow: inset 0 0 0 2px var(--bg-secondary), inset 0 0 0 3px var(--accent-bg);
+  box-shadow:
+    inset 0 0 0 2px var(--bg-secondary),
+    inset 0 0 0 3px var(--accent-bg);
 }
 
 /* Inner wrapper with zoom applied */

--- a/renderer/style/components/right-sidebar/contents.css
+++ b/renderer/style/components/right-sidebar/contents.css
@@ -31,7 +31,9 @@
   overflow: hidden;
   text-overflow: ellipsis;
   opacity: var(--opacity-hover);
-  transition: opacity var(--transition-fast), background var(--transition-fast);
+  transition:
+    opacity var(--transition-fast),
+    background var(--transition-fast);
 }
 
 .right-sidebar-contents-item-button:hover {

--- a/renderer/style/components/right-sidebar/pinned.css
+++ b/renderer/style/components/right-sidebar/pinned.css
@@ -131,8 +131,18 @@
   border-radius: var(--radius-xs);
 }
 
-.right-sidebar-pinned-highlight.highlight-green { background-color: var(--pinned-green); }
-.right-sidebar-pinned-highlight.highlight-blue { background-color: var(--pinned-blue); }
-.right-sidebar-pinned-highlight.highlight-pink { background-color: var(--pinned-pink); }
-.right-sidebar-pinned-highlight.highlight-orange { background-color: var(--pinned-orange); }
-.right-sidebar-pinned-highlight.highlight-purple { background-color: var(--pinned-purple); }
+.right-sidebar-pinned-highlight.highlight-green {
+  background-color: var(--pinned-green);
+}
+.right-sidebar-pinned-highlight.highlight-blue {
+  background-color: var(--pinned-blue);
+}
+.right-sidebar-pinned-highlight.highlight-pink {
+  background-color: var(--pinned-pink);
+}
+.right-sidebar-pinned-highlight.highlight-orange {
+  background-color: var(--pinned-orange);
+}
+.right-sidebar-pinned-highlight.highlight-purple {
+  background-color: var(--pinned-purple);
+}

--- a/renderer/style/components/search-bar.css
+++ b/renderer/style/components/search-bar.css
@@ -173,14 +173,26 @@
   padding: 0 1px;
 }
 
-.pinned-highlight[data-color="green"] { background-color: var(--pinned-green); }
-.pinned-highlight[data-color="blue"] { background-color: var(--pinned-blue); }
-.pinned-highlight[data-color="pink"] { background-color: var(--pinned-pink); }
-.pinned-highlight[data-color="orange"] { background-color: var(--pinned-orange); }
-.pinned-highlight[data-color="purple"] { background-color: var(--pinned-purple); }
+.pinned-highlight[data-color="green"] {
+  background-color: var(--pinned-green);
+}
+.pinned-highlight[data-color="blue"] {
+  background-color: var(--pinned-blue);
+}
+.pinned-highlight[data-color="pink"] {
+  background-color: var(--pinned-pink);
+}
+.pinned-highlight[data-color="orange"] {
+  background-color: var(--pinned-orange);
+}
+.pinned-highlight[data-color="purple"] {
+  background-color: var(--pinned-purple);
+}
 
 /* Disabled: override github-markdown-css .markdown-body mark background */
-.markdown-body .pinned-highlight-disabled { background-color: transparent; }
+.markdown-body .pinned-highlight-disabled {
+  background-color: transparent;
+}
 
 /* Flash animation when scrolling to pinned match */
 .pinned-highlight-flash {


### PR DESCRIPTION
## Summary

- Apply CSS `overscroll-behavior: none` and structural overflow locks to the root HTML body in the WebView

By default on certain OS environments, Chromium-based WebViews exhibit an elastic "rubber-banding" effect when scrolling past the top or bottom limits of a document. This exposes the underlying unstyled browser background layer, breaking the illusion of a native desktop application. This PR strictly bounds the scroll, providing a rigid, native feel.

## Test plan

- [x] Open the desktop application
- [x] Load a long Markdown document
- [x] Scroll forcefully past the top and bottom bounds of the document using a trackpad
- [x] Observe that no rubber-banding bounce occurs and the boundary visually stops immediately
