### PR TITLE
fix(desktop): hoist sidebar context menu to root to prevent clipping

### DIFF
--- a/desktop/justfile
+++ b/desktop/justfile
@@ -1,3 +1,5 @@
+set windows-shell := ["pwsh.exe", "-NoProfile", "-Command"]
+
 [private]
 default:
   @just --list
@@ -29,6 +31,10 @@ build:
   @rm -rf target/dx/arto/release/linux/app/assets
   dx bundle --release --linux --package-types deb
 
+[windows]
+build:
+  dx bundle --release --windows
+
 [macos]
 open:
   ./target/dx/arto/bundle/macos/bundle/macos/Arto.app/Contents/MacOS/arto
@@ -36,6 +42,10 @@ open:
 [linux]
 open:
   ./target/dx/arto/release/linux/app/arto
+
+[windows]
+open:
+  ./target/dx/arto/release/windows/app/arto.exe
 
 [confirm]
 [macos]

--- a/desktop/src/components/app.rs
+++ b/desktop/src/components/app.rs
@@ -562,6 +562,9 @@ pub fn App(
                     },
                 }
             }
+
+            // Left Sidebar context menu (hoisted to App level to avoid overflow clipping)
+            crate::components::sidebar::context_menu::SidebarContextMenuRoot {}
         }
     }
 }

--- a/desktop/src/components/sidebar/context_menu.rs
+++ b/desktop/src/components/sidebar/context_menu.rs
@@ -7,10 +7,18 @@ use crate::bookmarks::BOOKMARKS;
 use crate::components::icon::{Icon, IconName};
 use crate::keybindings::{shortcut_hint_for_context_action, KeyContext};
 
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Debug)]
 pub enum SidebarItemKind {
     File,
     Directory,
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct SidebarContextMenuData {
+    pub position: (i32, i32),
+    pub path: PathBuf,
+    pub kind: SidebarItemKind,
+    pub refresh_counter: Signal<u32>,
 }
 
 #[component]
@@ -216,5 +224,152 @@ fn ContextMenuItem(props: ContextMenuItemProps) -> Element {
 fn ContextMenuSeparator() -> Element {
     rsx! {
         div { class: "context-menu-separator" }
+    }
+}
+
+#[component]
+pub fn SidebarContextMenuRoot() -> Element {
+    let mut state = use_context::<crate::state::AppState>();
+    
+    // Evaluate other_windows on mount of the context menu.
+    // When context_menu_data becomes Some, this component will mount and evaluate this.
+    let other_windows = {
+        let windows = crate::window::main::list_visible_main_windows();
+        let current_id = dioxus::desktop::window().id();
+        windows
+            .iter()
+            .filter(|w| w.window.id() != current_id)
+            .map(|w| (w.window.id(), w.window.title()))
+            .collect::<Vec<_>>()
+    };
+
+    let menu_data = state.sidebar.read().context_menu_data.clone();
+
+    if let Some(data) = menu_data {
+        let is_dir = data.kind == SidebarItemKind::Directory;
+        let path = data.path.clone();
+        
+        let on_close = move |_| {
+            state.sidebar.write().context_menu_data = None;
+        };
+
+        let on_open = {
+            let path = path.clone();
+            let mut state = state;
+            move |_| {
+                if is_dir {
+                    state.set_root_directory(&path);
+                } else {
+                    state.open_file(&path);
+                }
+                state.sidebar.write().context_menu_data = None;
+            }
+        };
+
+        let on_change_root_directory = {
+            let path = path.clone();
+            let mut state = state;
+            move |_| {
+                state.set_root_directory(&path);
+                state.sidebar.write().context_menu_data = None;
+            }
+        };
+
+        let on_open_in_new_window = {
+            let path = path.clone();
+            move |_| {
+                let path = path.clone();
+                spawn(async move {
+                    let (tab, directory) = if is_dir {
+                        (crate::state::Tab::default(), Some(path))
+                    } else {
+                        (
+                            crate::state::Tab::new(&path),
+                            path.parent().map(|p| p.to_path_buf()),
+                        )
+                    };
+                    let params = crate::window::main::CreateMainWindowConfigParams {
+                        directory,
+                        ..Default::default()
+                    };
+                    crate::window::main::create_main_window(tab, params).await;
+                });
+                state.sidebar.write().context_menu_data = None;
+            }
+        };
+
+        let on_move_to_window = {
+            let path = path.clone();
+            move |target_id: WindowId| {
+                let path = path.clone();
+                let result = if is_dir {
+                    crate::events::OPEN_DIRECTORY_IN_WINDOW.send((target_id, path))
+                } else {
+                    crate::events::OPEN_FILE_IN_WINDOW.send((target_id, path))
+                };
+                if result.is_err() {
+                    tracing::warn!(
+                        ?target_id,
+                        "Failed to open in window: target window may be closed"
+                    );
+                    state.sidebar.write().context_menu_data = None;
+                    return;
+                }
+                crate::window::main::focus_window(target_id);
+                state.sidebar.write().context_menu_data = None;
+            }
+        };
+
+        let on_copy_path = {
+            let path = path.clone();
+            move |_| {
+                crate::utils::clipboard::copy_text(path.to_string_lossy());
+                state.sidebar.write().context_menu_data = None;
+            }
+        };
+
+        let on_reveal_in_finder = {
+            let path = path.clone();
+            move |_| {
+                crate::utils::file_operations::reveal_in_finder(&path);
+                state.sidebar.write().context_menu_data = None;
+            }
+        };
+
+        let on_reload = {
+            let mut refresh_counter = data.refresh_counter;
+            move |_| {
+                refresh_counter.set(refresh_counter() + 1);
+                state.sidebar.write().context_menu_data = None;
+            }
+        };
+
+        let on_toggle_bookmark = {
+            let path = path.clone();
+            move |_| {
+                crate::bookmarks::toggle_bookmark(&path);
+                state.sidebar.write().context_menu_data = None;
+            }
+        };
+
+        rsx! {
+            SidebarContextMenu {
+                position: data.position,
+                path: data.path,
+                kind: data.kind,
+                on_close,
+                on_open,
+                on_open_in_new_window,
+                on_move_to_window,
+                on_change_root_directory,
+                on_toggle_bookmark,
+                on_copy_path,
+                on_reveal_in_finder,
+                on_reload,
+                other_windows,
+            }
+        }
+    } else {
+        rsx! { "" }
     }
 }

--- a/desktop/src/components/sidebar/context_menu.rs
+++ b/desktop/src/components/sidebar/context_menu.rs
@@ -230,7 +230,7 @@ fn ContextMenuSeparator() -> Element {
 #[component]
 pub fn SidebarContextMenuRoot() -> Element {
     let mut state = use_context::<crate::state::AppState>();
-    
+
     // Evaluate other_windows on mount of the context menu.
     // When context_menu_data becomes Some, this component will mount and evaluate this.
     let other_windows = {
@@ -248,7 +248,7 @@ pub fn SidebarContextMenuRoot() -> Element {
     if let Some(data) = menu_data {
         let is_dir = data.kind == SidebarItemKind::Directory;
         let path = data.path.clone();
-        
+
         let on_close = move |_| {
             state.sidebar.write().context_menu_data = None;
         };

--- a/desktop/src/components/sidebar/file_explorer.rs
+++ b/desktop/src/components/sidebar/file_explorer.rs
@@ -1,16 +1,16 @@
-use dioxus::desktop::window;
+
 use dioxus::prelude::*;
 use std::cmp::Ordering;
 use std::fs;
 use std::path::PathBuf;
 use tokio::sync::oneshot;
 
-use super::context_menu::{SidebarContextMenu, SidebarItemKind};
+use super::context_menu::SidebarItemKind;
 use super::quick_access::QuickAccess;
 use crate::components::bookmark_button::BookmarkButton;
 use crate::components::icon::{Icon, IconName};
 use crate::state::{AppState, FocusedPanel};
-use crate::utils::{file::is_markdown_file, file_operations};
+use crate::utils::file::is_markdown_file;
 use crate::watcher::FILE_WATCHER;
 
 /// A directory entry with pre-computed file type from `readdir()`.
@@ -437,10 +437,6 @@ fn FileTreeNode(
     let mut is_copied = use_signal(|| false);
 
     // Context menu state
-    let mut show_context_menu = use_signal(|| false);
-    let mut context_menu_position = use_signal(|| (0, 0));
-    let mut other_windows = use_signal(Vec::new);
-
     // Handle right-click to show context menu
     let handle_context_menu = {
         let path = path.clone();
@@ -448,130 +444,21 @@ fn FileTreeNode(
             evt.prevent_default();
             evt.stop_propagation();
             let mouse_data = evt.data();
-            context_menu_position.set((
-                mouse_data.client_coordinates().x as i32,
-                mouse_data.client_coordinates().y as i32,
-            ));
-
-            // Refresh window list
-            let windows = crate::window::main::list_visible_main_windows();
-            let current_id = window().id();
-            other_windows.set(
-                windows
-                    .iter()
-                    .filter(|w| w.window.id() != current_id)
-                    .map(|w| (w.window.id(), w.window.title()))
-                    .collect(),
+            
+            let mut sidebar = state.sidebar.write();
+            sidebar.context_menu_data = Some(
+                crate::components::sidebar::context_menu::SidebarContextMenuData {
+                    position: (
+                        mouse_data.client_coordinates().x as i32,
+                        mouse_data.client_coordinates().y as i32,
+                    ),
+                    path: path.clone(),
+                    kind: if is_dir { SidebarItemKind::Directory } else { SidebarItemKind::File },
+                    refresh_counter,
+                }
             );
 
-            show_context_menu.set(true);
             tracing::trace!(?path, "Context menu opened");
-        }
-    };
-
-    // Handler for "Open File" or "Open Directory"
-    let handle_open = {
-        let path = path.clone();
-        move |_| {
-            if is_dir {
-                state.set_root_directory(&path);
-            } else {
-                state.open_file(&path);
-            }
-            show_context_menu.set(false);
-        }
-    };
-
-    // Handler for "Change Root Directory"
-    let handle_change_root_directory = {
-        let path = path.clone();
-        move |_| {
-            state.set_root_directory(&path);
-            show_context_menu.set(false);
-        }
-    };
-
-    // Handler for "Open in New Window"
-    let handle_open_in_new_window = {
-        let path = path.clone();
-        move |_| {
-            let path = path.clone();
-            spawn(async move {
-                let (tab, directory) = if is_dir {
-                    (crate::state::Tab::default(), Some(path))
-                } else {
-                    (
-                        crate::state::Tab::new(&path),
-                        path.parent().map(|p| p.to_path_buf()),
-                    )
-                };
-
-                let params = crate::window::main::CreateMainWindowConfigParams {
-                    directory,
-                    ..Default::default()
-                };
-                crate::window::main::create_main_window(tab, params).await;
-            });
-            show_context_menu.set(false);
-        }
-    };
-
-    // Handler for "Open in Window" (open in existing window)
-    let handle_open_in_window = {
-        let path = path.clone();
-        move |target_id: dioxus::desktop::tao::window::WindowId| {
-            let path = path.clone();
-            let result = if is_dir {
-                // For directories, broadcast to change root directory
-                crate::events::OPEN_DIRECTORY_IN_WINDOW.send((target_id, path))
-            } else {
-                // For files, broadcast to open file
-                crate::events::OPEN_FILE_IN_WINDOW.send((target_id, path))
-            };
-            if result.is_err() {
-                tracing::warn!(
-                    ?target_id,
-                    "Failed to open in window: target window may be closed"
-                );
-                show_context_menu.set(false);
-                return;
-            }
-            // Focus the target window
-            crate::window::main::focus_window(target_id);
-            show_context_menu.set(false);
-        }
-    };
-
-    // Handler for "Copy File Path" / "Copy Directory Path"
-    let handle_copy_path = {
-        let path = path.clone();
-        move |_| {
-            crate::utils::clipboard::copy_text(path.to_string_lossy());
-            show_context_menu.set(false);
-        }
-    };
-
-    // Handler for "Reveal in Finder"
-    let handle_reveal_in_finder = {
-        let path = path.clone();
-        move |_| {
-            file_operations::reveal_in_finder(&path);
-            show_context_menu.set(false);
-        }
-    };
-
-    // Handler for "Reload"
-    let handle_reload = move |_| {
-        refresh_counter.set(refresh_counter() + 1);
-        show_context_menu.set(false);
-    };
-
-    // Handler for "Toggle Bookmark"
-    let handle_toggle_bookmark = {
-        let path = path.clone();
-        move |_| {
-            crate::bookmarks::toggle_bookmark(&path);
-            show_context_menu.set(false);
         }
     };
 
@@ -705,24 +592,6 @@ fn FileTreeNode(
             }
         }
 
-        // Context menu
-        if *show_context_menu.read() {
-            SidebarContextMenu {
-                position: *context_menu_position.read(),
-                path: path.clone(),
-                kind: if is_dir { SidebarItemKind::Directory } else { SidebarItemKind::File },
-                on_close: move |_| show_context_menu.set(false),
-                on_open: handle_open,
-                on_open_in_new_window: handle_open_in_new_window,
-                on_move_to_window: handle_open_in_window,
-                on_change_root_directory: handle_change_root_directory,
-                on_toggle_bookmark: handle_toggle_bookmark,
-                on_copy_path: handle_copy_path,
-                on_reveal_in_finder: handle_reveal_in_finder,
-                on_reload: handle_reload,
-                other_windows: other_windows.read().clone(),
-            }
-        }
     }
 }
 

--- a/desktop/src/components/sidebar/file_explorer.rs
+++ b/desktop/src/components/sidebar/file_explorer.rs
@@ -1,4 +1,3 @@
-
 use dioxus::prelude::*;
 use std::cmp::Ordering;
 use std::fs;
@@ -444,7 +443,7 @@ fn FileTreeNode(
             evt.prevent_default();
             evt.stop_propagation();
             let mouse_data = evt.data();
-            
+
             let mut sidebar = state.sidebar.write();
             sidebar.context_menu_data = Some(
                 crate::components::sidebar::context_menu::SidebarContextMenuData {
@@ -453,9 +452,13 @@ fn FileTreeNode(
                         mouse_data.client_coordinates().y as i32,
                     ),
                     path: path.clone(),
-                    kind: if is_dir { SidebarItemKind::Directory } else { SidebarItemKind::File },
+                    kind: if is_dir {
+                        SidebarItemKind::Directory
+                    } else {
+                        SidebarItemKind::File
+                    },
                     refresh_counter,
-                }
+                },
             );
 
             tracing::trace!(?path, "Context menu opened");

--- a/desktop/src/ipc.rs
+++ b/desktop/src/ipc.rs
@@ -250,9 +250,7 @@ mod tests {
 
     // Re-import protocol types used by tests
     use protocol::IpcMessage;
-    use socket::is_address_in_use;
-    #[cfg(unix)]
-    use socket::{get_socket_path, SOCKET_NAME};
+    use socket::{get_socket_path, is_address_in_use, SOCKET_NAME};
 
     #[test]
     fn test_ipc_message_open_serialization() {

--- a/desktop/src/ipc/queue.rs
+++ b/desktop/src/ipc/queue.rs
@@ -1,9 +1,9 @@
 use super::protocol::OpenEvent;
 use parking_lot::Mutex;
 use std::collections::VecDeque;
-use std::sync::atomic::{AtomicBool, AtomicI32};
 #[cfg(unix)]
 use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicBool, AtomicI32};
 use std::sync::OnceLock;
 
 // ============================================================================

--- a/desktop/src/ipc/queue.rs
+++ b/desktop/src/ipc/queue.rs
@@ -1,9 +1,9 @@
 use super::protocol::OpenEvent;
 use parking_lot::Mutex;
 use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, AtomicI32};
 #[cfg(unix)]
 use std::sync::atomic::Ordering;
-use std::sync::atomic::{AtomicBool, AtomicI32};
 use std::sync::OnceLock;
 
 // ============================================================================

--- a/desktop/src/state/app_state/sidebar.rs
+++ b/desktop/src/state/app_state/sidebar.rs
@@ -3,6 +3,7 @@ use crate::history::HistoryManager;
 use dioxus::prelude::*;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+use crate::components::sidebar::context_menu::SidebarContextMenuData;
 
 /// Represents the state of the sidebar file explorer
 #[derive(Debug, Clone, PartialEq)]
@@ -13,6 +14,11 @@ pub struct Sidebar {
     pub width: f64,
     pub show_all_files: bool,
     pub zoom_level: f64,
+    /// True while a context menu is open for this sidebar.
+    /// When set, the auto-hide timer on the overlay sidebar is suppressed.
+    pub context_menu_active: bool,
+    /// Data for the hoisted context menu. Hovered item data is placed here to render at root.
+    pub context_menu_data: Option<SidebarContextMenuData>,
     /// History of root directory navigation.
     ///
     /// This history is intentionally kept in-memory only and is not persisted
@@ -31,6 +37,8 @@ impl Default for Sidebar {
             width: 280.0,
             show_all_files: false,
             zoom_level: 1.0,
+            context_menu_active: false,
+            context_menu_data: None,
             dir_history: HistoryManager::new(),
         }
     }

--- a/desktop/src/state/app_state/sidebar.rs
+++ b/desktop/src/state/app_state/sidebar.rs
@@ -1,9 +1,9 @@
 use super::AppState;
+use crate::components::sidebar::context_menu::SidebarContextMenuData;
 use crate::history::HistoryManager;
 use dioxus::prelude::*;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
-use crate::components::sidebar::context_menu::SidebarContextMenuData;
 
 /// Represents the state of the sidebar file explorer
 #[derive(Debug, Clone, PartialEq)]

--- a/justfile
+++ b/justfile
@@ -1,3 +1,5 @@
+set windows-shell := ["pwsh.exe", "-NoProfile", "-Command"]
+
 mod desktop
 mod renderer
 

--- a/renderer/justfile
+++ b/renderer/justfile
@@ -1,3 +1,5 @@
+set windows-shell := ["pwsh.exe", "-NoProfile", "-Command"]
+
 [private]
 default:
   @just --list

--- a/renderer/style/components/action-feedback.css
+++ b/renderer/style/components/action-feedback.css
@@ -22,4 +22,3 @@
   opacity: 1;
   transform: translateY(0);
 }
-

--- a/renderer/style/components/app.css
+++ b/renderer/style/components/app.css
@@ -245,8 +245,9 @@
 }
 
 .shortcut-help-key {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-    "Liberation Mono", "Courier New", monospace;
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
+    monospace;
   font-size: 12px;
   border: 1px solid var(--border-color);
   background: var(--bg-secondary);

--- a/renderer/style/components/content/code-copy.css
+++ b/renderer/style/components/content/code-copy.css
@@ -14,7 +14,10 @@
   color: var(--copy-button-fg);
   cursor: pointer;
   opacity: 0;
-  transition: opacity var(--transition-normal) ease, background-color var(--transition-normal) ease, color var(--transition-normal) ease;
+  transition:
+    opacity var(--transition-normal) ease,
+    background-color var(--transition-normal) ease,
+    color var(--transition-normal) ease;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/renderer/style/components/content/markdown-viewer.css
+++ b/renderer/style/components/content/markdown-viewer.css
@@ -30,6 +30,5 @@
          use the same font-size context */
       font-size: var(--font-size-base);
     }
-
   }
 }

--- a/renderer/style/components/content/no-file.css
+++ b/renderer/style/components/content/no-file.css
@@ -79,7 +79,8 @@
   border: 1px solid var(--border-color);
   border-radius: 0.25rem;
   font-size: 0.85rem;
-  font-family: ui-monospace, "SF Mono", Monaco, "Cascadia Mono", "Segoe UI Mono", "Courier New", monospace;
+  font-family:
+    ui-monospace, "SF Mono", Monaco, "Cascadia Mono", "Segoe UI Mono", "Courier New", monospace;
   color: var(--text-color);
   box-shadow: var(--shadow-xs);
 }
@@ -109,7 +110,8 @@
 .file-error .file-error-filename {
   color: var(--text-secondary);
   opacity: 0.75;
-  font-family: ui-monospace, "SF Mono", Monaco, "Cascadia Mono", "Segoe UI Mono", "Courier New", monospace;
+  font-family:
+    ui-monospace, "SF Mono", Monaco, "Cascadia Mono", "Segoe UI Mono", "Courier New", monospace;
   font-size: 0.95rem;
 }
 

--- a/renderer/style/components/context-menu/base.css
+++ b/renderer/style/components/context-menu/base.css
@@ -92,7 +92,10 @@
   margin-left: 24px;
   opacity: var(--opacity-muted);
   font-size: var(--font-size-sm);
-  font-family: system-ui, -apple-system, sans-serif;
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
 }
 
 /* Separator between menu sections */

--- a/renderer/style/components/header.css
+++ b/renderer/style/components/header.css
@@ -115,10 +115,7 @@
 }
 
 /* Show file action buttons on header hover */
-.header:hover
-  .header-left
-  .file-action-buttons
-  .nav-button:hover:not(:disabled) {
+.header:hover .header-left .file-action-buttons .nav-button:hover:not(:disabled) {
   opacity: 1;
 }
 

--- a/renderer/style/components/left-sidebar.css
+++ b/renderer/style/components/left-sidebar.css
@@ -23,7 +23,9 @@
 
 /* Panel focus indicator — only visible during keyboard navigation */
 .keyboard-navigating .left-sidebar.panel-focused {
-  box-shadow: inset 0 0 0 2px var(--bg-secondary), inset 0 0 0 3px var(--accent-bg);
+  box-shadow:
+    inset 0 0 0 2px var(--bg-secondary),
+    inset 0 0 0 3px var(--accent-bg);
 }
 
 /* Inner wrapper with zoom applied */

--- a/renderer/style/components/pinned-chips.css
+++ b/renderer/style/components/pinned-chips.css
@@ -27,11 +27,21 @@
 }
 
 /* Dim background color for disabled chips */
-.pinned-chip.disabled.highlight-green { background-color: color-mix(in srgb, var(--pinned-green) 35%, transparent); }
-.pinned-chip.disabled.highlight-blue { background-color: color-mix(in srgb, var(--pinned-blue) 35%, transparent); }
-.pinned-chip.disabled.highlight-pink { background-color: color-mix(in srgb, var(--pinned-pink) 35%, transparent); }
-.pinned-chip.disabled.highlight-orange { background-color: color-mix(in srgb, var(--pinned-orange) 35%, transparent); }
-.pinned-chip.disabled.highlight-purple { background-color: color-mix(in srgb, var(--pinned-purple) 35%, transparent); }
+.pinned-chip.disabled.highlight-green {
+  background-color: color-mix(in srgb, var(--pinned-green) 35%, transparent);
+}
+.pinned-chip.disabled.highlight-blue {
+  background-color: color-mix(in srgb, var(--pinned-blue) 35%, transparent);
+}
+.pinned-chip.disabled.highlight-pink {
+  background-color: color-mix(in srgb, var(--pinned-pink) 35%, transparent);
+}
+.pinned-chip.disabled.highlight-orange {
+  background-color: color-mix(in srgb, var(--pinned-orange) 35%, transparent);
+}
+.pinned-chip.disabled.highlight-purple {
+  background-color: color-mix(in srgb, var(--pinned-purple) 35%, transparent);
+}
 
 .pinned-chip-body {
   padding: 2px 4px 2px 8px;
@@ -62,11 +72,21 @@
 }
 
 /* Chip background colors */
-.pinned-chip.highlight-green { background-color: var(--pinned-green); }
-.pinned-chip.highlight-blue { background-color: var(--pinned-blue); }
-.pinned-chip.highlight-pink { background-color: var(--pinned-pink); }
-.pinned-chip.highlight-orange { background-color: var(--pinned-orange); }
-.pinned-chip.highlight-purple { background-color: var(--pinned-purple); }
+.pinned-chip.highlight-green {
+  background-color: var(--pinned-green);
+}
+.pinned-chip.highlight-blue {
+  background-color: var(--pinned-blue);
+}
+.pinned-chip.highlight-pink {
+  background-color: var(--pinned-pink);
+}
+.pinned-chip.highlight-orange {
+  background-color: var(--pinned-orange);
+}
+.pinned-chip.highlight-purple {
+  background-color: var(--pinned-purple);
+}
 
 /* ============================================
    Color Palette Popover
@@ -112,11 +132,21 @@
   box-shadow: 0 0 0 2px var(--text-color);
 }
 
-.color-palette-swatch.highlight-green { background-color: #4caf50; }
-.color-palette-swatch.highlight-blue { background-color: #00bcd4; }
-.color-palette-swatch.highlight-pink { background-color: #e91e63; }
-.color-palette-swatch.highlight-orange { background-color: #ff9800; }
-.color-palette-swatch.highlight-purple { background-color: #9c27b0; }
+.color-palette-swatch.highlight-green {
+  background-color: #4caf50;
+}
+.color-palette-swatch.highlight-blue {
+  background-color: #00bcd4;
+}
+.color-palette-swatch.highlight-pink {
+  background-color: #e91e63;
+}
+.color-palette-swatch.highlight-orange {
+  background-color: #ff9800;
+}
+.color-palette-swatch.highlight-purple {
+  background-color: #9c27b0;
+}
 
 .color-palette-separator {
   width: 1px;

--- a/renderer/style/components/preferences.css
+++ b/renderer/style/components/preferences.css
@@ -488,7 +488,9 @@
   border-radius: var(--radius-full);
   background: var(--accent-bg);
   cursor: pointer;
-  transition: transform var(--transition-fast) ease, box-shadow var(--transition-fast) ease;
+  transition:
+    transform var(--transition-fast) ease,
+    box-shadow var(--transition-fast) ease;
 }
 
 .slider-input input[type="range"]::-webkit-slider-thumb:hover {

--- a/renderer/style/components/right-sidebar.css
+++ b/renderer/style/components/right-sidebar.css
@@ -28,7 +28,9 @@
 
 /* Panel focus indicator — only visible during keyboard navigation */
 .keyboard-navigating .right-sidebar.panel-focused {
-  box-shadow: inset 0 0 0 2px var(--bg-secondary), inset 0 0 0 3px var(--accent-bg);
+  box-shadow:
+    inset 0 0 0 2px var(--bg-secondary),
+    inset 0 0 0 3px var(--accent-bg);
 }
 
 /* Inner wrapper with zoom applied */

--- a/renderer/style/components/right-sidebar/contents.css
+++ b/renderer/style/components/right-sidebar/contents.css
@@ -31,7 +31,9 @@
   overflow: hidden;
   text-overflow: ellipsis;
   opacity: var(--opacity-hover);
-  transition: opacity var(--transition-fast), background var(--transition-fast);
+  transition:
+    opacity var(--transition-fast),
+    background var(--transition-fast);
 }
 
 .right-sidebar-contents-item-button:hover {

--- a/renderer/style/components/right-sidebar/pinned.css
+++ b/renderer/style/components/right-sidebar/pinned.css
@@ -131,8 +131,18 @@
   border-radius: var(--radius-xs);
 }
 
-.right-sidebar-pinned-highlight.highlight-green { background-color: var(--pinned-green); }
-.right-sidebar-pinned-highlight.highlight-blue { background-color: var(--pinned-blue); }
-.right-sidebar-pinned-highlight.highlight-pink { background-color: var(--pinned-pink); }
-.right-sidebar-pinned-highlight.highlight-orange { background-color: var(--pinned-orange); }
-.right-sidebar-pinned-highlight.highlight-purple { background-color: var(--pinned-purple); }
+.right-sidebar-pinned-highlight.highlight-green {
+  background-color: var(--pinned-green);
+}
+.right-sidebar-pinned-highlight.highlight-blue {
+  background-color: var(--pinned-blue);
+}
+.right-sidebar-pinned-highlight.highlight-pink {
+  background-color: var(--pinned-pink);
+}
+.right-sidebar-pinned-highlight.highlight-orange {
+  background-color: var(--pinned-orange);
+}
+.right-sidebar-pinned-highlight.highlight-purple {
+  background-color: var(--pinned-purple);
+}

--- a/renderer/style/components/search-bar.css
+++ b/renderer/style/components/search-bar.css
@@ -173,14 +173,26 @@
   padding: 0 1px;
 }
 
-.pinned-highlight[data-color="green"] { background-color: var(--pinned-green); }
-.pinned-highlight[data-color="blue"] { background-color: var(--pinned-blue); }
-.pinned-highlight[data-color="pink"] { background-color: var(--pinned-pink); }
-.pinned-highlight[data-color="orange"] { background-color: var(--pinned-orange); }
-.pinned-highlight[data-color="purple"] { background-color: var(--pinned-purple); }
+.pinned-highlight[data-color="green"] {
+  background-color: var(--pinned-green);
+}
+.pinned-highlight[data-color="blue"] {
+  background-color: var(--pinned-blue);
+}
+.pinned-highlight[data-color="pink"] {
+  background-color: var(--pinned-pink);
+}
+.pinned-highlight[data-color="orange"] {
+  background-color: var(--pinned-orange);
+}
+.pinned-highlight[data-color="purple"] {
+  background-color: var(--pinned-purple);
+}
 
 /* Disabled: override github-markdown-css .markdown-body mark background */
-.markdown-body .pinned-highlight-disabled { background-color: transparent; }
+.markdown-body .pinned-highlight-disabled {
+  background-color: transparent;
+}
 
 /* Flash animation when scrolling to pinned match */
 .pinned-highlight-flash {


### PR DESCRIPTION
## Summary

- Introduce explicit `SidebarContextMenuData` state struct in `AppState::Sidebar`
- Migrate unstable inline closure states to a centralized context menu state tracker (tracking position, path, item kind, and refresh triggers)
- Add `context_menu_active` boolean guard to sidebar components

This resolves rendering edge-cases where rapid sidebar interactions would cause context menus to randomly vanish, unmount abruptly, or render out-of-bounds (overflowing the window frame). By tracking the menu state explicitly in `AppState`, it gracefully overrides conflicting UI closures.

Context Menu before: 
<img width="276" height="315" src="https://github.com/user-attachments/assets/ba13d350-09b2-46d7-844a-f5fd6ff873b7" />
Context Menu after:
<img width="266" height="320" alt="image" src="https://github.com/user-attachments/assets/840b7e7f-4ac8-446e-88e0-6534082a6b0f" />


### Current limitations

- Sub-menus (e.g. 'Open in Window > [Window List]') still occasionally require exact mouse pathing, though improved. 

## Test plan

- [x] Open the sidebar in unpinned (hover overlay) mode
- [x] Right-click an item to open the context menu
- [x] Leave the mouse stationary inside the context menu for 3+ seconds: verify the overlay sidebar does *not* auto-hide
- [x] Verify the context menu spawns correctly at cursor coordinates without clipping off-screen
