### PR TITLE
fix(desktop): fix Windows UI decorations and keyboard shortcuts

### DIFF
--- a/desktop/justfile
+++ b/desktop/justfile
@@ -1,3 +1,5 @@
+set windows-shell := ["pwsh.exe", "-NoProfile", "-Command"]
+
 [private]
 default:
   @just --list
@@ -29,6 +31,10 @@ build:
   @rm -rf target/dx/arto/release/linux/app/assets
   dx bundle --release --linux --package-types deb
 
+[windows]
+build:
+  dx bundle --release --windows
+
 [macos]
 open:
   ./target/dx/arto/bundle/macos/bundle/macos/Arto.app/Contents/MacOS/arto
@@ -36,6 +42,10 @@ open:
 [linux]
 open:
   ./target/dx/arto/release/linux/app/arto
+
+[windows]
+open:
+  ./target/dx/arto/release/windows/app/arto.exe
 
 [confirm]
 [macos]

--- a/desktop/src/assets.rs
+++ b/desktop/src/assets.rs
@@ -1,8 +1,30 @@
 use dioxus::asset_resolver::asset_path;
 use dioxus::prelude::*;
-
 pub static MAIN_SCRIPT: Asset = asset!("/assets/dist/main.js");
 pub static MAIN_STYLE: Asset = asset!("/assets/dist/main.css");
+
+#[cfg(windows)]
+pub fn windows_safe_asset_url(asset: &dioxus::prelude::Asset) -> String {
+    let mut path = asset.to_string().replace('\\', "/");
+    if !path.starts_with('/') && !path.starts_with("http") {
+        path = format!("/{}", path);
+    }
+    path
+}
+
+pub fn get_main_script_path() -> String {
+    #[cfg(windows)]
+    return windows_safe_asset_url(&MAIN_SCRIPT);
+    #[cfg(not(windows))]
+    return MAIN_SCRIPT.to_string();
+}
+
+pub fn get_main_style_path() -> String {
+    #[cfg(windows)]
+    return windows_safe_asset_url(&MAIN_STYLE);
+    #[cfg(not(windows))]
+    return MAIN_STYLE.to_string();
+}
 
 static ARTO_HEADER_IMAGE: Asset = asset!("/assets/arto-header-welcome.png");
 static WELCOME_TEMPLATE: Asset = asset!("/assets/welcome.md");
@@ -15,9 +37,16 @@ pub fn get_default_markdown_content() -> String {
     let header_path = asset_path(ARTO_HEADER_IMAGE).expect("Failed to resolve ARTO_HEADER_IMAGE");
     let header_str = header_path
         .to_str()
-        .expect("Failed to convert ARTO_HEADER_IMAGE path to str");
+        .expect("Failed to convert ARTO_HEADER_IMAGE path to str")
+        .replace('\\', "/");
+
+    let final_header_str = if cfg!(windows) && !header_str.starts_with('/') {
+        format!("/{}", header_str)
+    } else {
+        header_str
+    };
 
     // Replace relative image path with data URL
     //template.replace("../assets/arto-header-welcome.png", &header_data_url)
-    template.replace("../assets/arto-header-welcome.png", header_str)
+    template.replace("../assets/arto-header-welcome.png", &final_header_str)
 }

--- a/desktop/src/assets.rs
+++ b/desktop/src/assets.rs
@@ -12,19 +12,7 @@ pub fn windows_safe_asset_url(asset: &dioxus::prelude::Asset) -> String {
     path
 }
 
-pub fn get_main_script_path() -> String {
-    #[cfg(windows)]
-    return windows_safe_asset_url(&MAIN_SCRIPT);
-    #[cfg(not(windows))]
-    return MAIN_SCRIPT.to_string();
-}
 
-pub fn get_main_style_path() -> String {
-    #[cfg(windows)]
-    return windows_safe_asset_url(&MAIN_STYLE);
-    #[cfg(not(windows))]
-    return MAIN_STYLE.to_string();
-}
 
 static ARTO_HEADER_IMAGE: Asset = asset!("/assets/arto-header-welcome.png");
 static WELCOME_TEMPLATE: Asset = asset!("/assets/welcome.md");

--- a/desktop/src/assets.rs
+++ b/desktop/src/assets.rs
@@ -1,5 +1,6 @@
 use dioxus::asset_resolver::asset_path;
 use dioxus::prelude::*;
+
 pub static MAIN_SCRIPT: Asset = asset!("/assets/dist/main.js");
 pub static MAIN_STYLE: Asset = asset!("/assets/dist/main.css");
 
@@ -12,7 +13,18 @@ pub fn windows_safe_asset_url(asset: &dioxus::prelude::Asset) -> String {
     path
 }
 
+#[cfg(not(windows))]
+pub fn windows_safe_asset_url(asset: &dioxus::prelude::Asset) -> String {
+    asset.to_string()
+}
 
+pub fn get_main_script_path() -> String {
+    windows_safe_asset_url(&MAIN_SCRIPT)
+}
+
+pub fn get_main_style_path() -> String {
+    windows_safe_asset_url(&MAIN_STYLE)
+}
 
 static ARTO_HEADER_IMAGE: Asset = asset!("/assets/arto-header-welcome.png");
 static WELCOME_TEMPLATE: Asset = asset!("/assets/welcome.md");
@@ -25,16 +37,9 @@ pub fn get_default_markdown_content() -> String {
     let header_path = asset_path(ARTO_HEADER_IMAGE).expect("Failed to resolve ARTO_HEADER_IMAGE");
     let header_str = header_path
         .to_str()
-        .expect("Failed to convert ARTO_HEADER_IMAGE path to str")
-        .replace('\\', "/");
-
-    let final_header_str = if cfg!(windows) && !header_str.starts_with('/') {
-        format!("/{}", header_str)
-    } else {
-        header_str
-    };
+        .expect("Failed to convert ARTO_HEADER_IMAGE path to str");
 
     // Replace relative image path with data URL
     //template.replace("../assets/arto-header-welcome.png", &header_data_url)
-    template.replace("../assets/arto-header-welcome.png", &final_header_str)
+    template.replace("../assets/arto-header-welcome.png", header_str)
 }

--- a/desktop/src/components/app.rs
+++ b/desktop/src/components/app.rs
@@ -22,7 +22,7 @@ use super::right_sidebar::RightSidebarTab;
 use super::search_bar::SearchBar;
 use super::sidebar::Sidebar;
 use super::tab::TabBar;
-use crate::assets::MAIN_SCRIPT;
+ // use crate::assets::MAIN_SCRIPT;
 use crate::drag;
 use crate::events::{ActiveDragUpdate, ACTIVE_DRAG_UPDATE};
 use crate::menu;
@@ -116,11 +116,12 @@ pub fn App(
     // Initialize JavaScript main module (theme listeners, etc.)
     use_hook(|| {
         spawn(async move {
+            let script_path = crate::assets::get_main_script_path();
             let _ = document::eval(&format!(
                 r#"
                 (async () => {{
                     try {{
-                        const {{ init }} = await import("{MAIN_SCRIPT}");
+                        const {{ init }} = await import("{script_path}");
                         init();
                     }} catch (error) {{
                         console.error("Failed to load main module:", error);

--- a/desktop/src/components/sidebar/context_menu.rs
+++ b/desktop/src/components/sidebar/context_menu.rs
@@ -149,7 +149,7 @@ pub fn SidebarContextMenu(
             }
 
             ContextMenuItem {
-                label: "Reveal in Finder",
+                label: if cfg!(windows) { "Reveal in File Explorer" } else { "Reveal in Finder" },
                 shortcut: shortcut("file.reveal_in_finder"),
                 icon: Some(IconName::Folder),
                 on_click: move |_| on_reveal_in_finder.call(()),
@@ -174,7 +174,8 @@ pub fn SidebarContextMenu(
 
 #[derive(Props, Clone, PartialEq)]
 struct ContextMenuItemProps {
-    label: &'static str,
+    #[props(into)]
+    label: String,
     #[props(default)]
     shortcut: Option<String>,
     #[props(default)]

--- a/desktop/src/components/tab/context_menu.rs
+++ b/desktop/src/components/tab/context_menu.rs
@@ -137,7 +137,7 @@ pub fn TabContextMenu(
             }
 
             ContextMenuItem {
-                label: "Reveal in Finder",
+                label: if cfg!(windows) { "Reveal in File Explorer" } else { "Reveal in Finder" },
                 shortcut: shortcut("file.reveal_in_finder"),
                 icon: Some(IconName::Folder),
                 disabled: !has_file,

--- a/desktop/src/ipc.rs
+++ b/desktop/src/ipc.rs
@@ -250,7 +250,9 @@ mod tests {
 
     // Re-import protocol types used by tests
     use protocol::IpcMessage;
-    use socket::{get_socket_path, is_address_in_use, SOCKET_NAME};
+    #[cfg(unix)]
+    use socket::{get_socket_path, SOCKET_NAME};
+    use socket::is_address_in_use;
 
     #[test]
     fn test_ipc_message_open_serialization() {

--- a/desktop/src/ipc/queue.rs
+++ b/desktop/src/ipc/queue.rs
@@ -1,7 +1,9 @@
 use super::protocol::OpenEvent;
 use parking_lot::Mutex;
 use std::collections::VecDeque;
-use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI32};
+#[cfg(unix)]
+use std::sync::atomic::Ordering;
 use std::sync::OnceLock;
 
 // ============================================================================

--- a/desktop/src/ipc/queue.rs
+++ b/desktop/src/ipc/queue.rs
@@ -27,6 +27,7 @@ fn get_event_queue() -> &'static Mutex<VecDeque<OpenEvent>> {
     IPC_EVENT_QUEUE.get_or_init(|| Mutex::new(VecDeque::new()))
 }
 
+#[cfg(unix)]
 pub(super) fn request_shutdown(signal: i32) {
     let was_requested = SHUTDOWN_REQUESTED.swap(true, Ordering::SeqCst);
     if was_requested {

--- a/desktop/src/ipc/socket.rs
+++ b/desktop/src/ipc/socket.rs
@@ -1,4 +1,5 @@
 use super::client::try_connect_with_timeout;
+#[cfg(unix)]
 use super::queue::request_shutdown;
 use interprocess::local_socket::{GenericFilePath, ListenerOptions, Stream, ToFsName};
 use std::path::{Path, PathBuf};

--- a/desktop/src/keybindings/hint.rs
+++ b/desktop/src/keybindings/hint.rs
@@ -71,16 +71,45 @@ fn format_chord_hint(chord: &str) -> String {
 
     let key_part = parts.pop().unwrap();
     let mut out = String::new();
+
+    let is_macos = cfg!(target_os = "macos");
+
     for modifier in parts {
-        match modifier.to_ascii_lowercase().as_str() {
-            "cmd" | "command" | "meta" => out.push('⌘'),
-            "ctrl" | "control" => out.push('⌃'),
-            "shift" => out.push('⇧'),
-            "alt" | "option" => out.push('⌥'),
-            other => {
-                out.push_str(other);
-                out.push('+');
+        let modifier_lower = modifier.to_ascii_lowercase();
+        let label = match modifier_lower.as_str() {
+            "cmd" | "command" | "meta" => {
+                if is_macos {
+                    "⌘"
+                } else {
+                    "Ctrl"
+                }
             }
+            "ctrl" | "control" => {
+                if is_macos {
+                    "⌃"
+                } else {
+                    "Win"
+                }
+            }
+            "shift" => {
+                if is_macos {
+                    "⇧"
+                } else {
+                    "Shift"
+                }
+            }
+            "alt" | "option" => {
+                if is_macos {
+                    "⌥"
+                } else {
+                    "Alt"
+                }
+            }
+            other => other,
+        };
+        out.push_str(label);
+        if !is_macos {
+            out.push('+');
         }
     }
     out.push_str(&format_key_name_hint(key_part));
@@ -112,14 +141,23 @@ mod tests {
 
     #[test]
     fn format_shortcut_hint_uses_menu_style_symbols() {
-        assert_eq!(format_shortcut_hint("Cmd+Shift+o"), "⌘⇧O");
-        assert_eq!(format_shortcut_hint("Ctrl+w h"), "⌃W H");
+        if cfg!(target_os = "macos") {
+            assert_eq!(format_shortcut_hint("Cmd+Shift+o"), "⌘⇧O");
+            assert_eq!(format_shortcut_hint("Ctrl+w h"), "⌃W H");
+        } else {
+            assert_eq!(format_shortcut_hint("Cmd+Shift+o"), "Ctrl+Shift+O");
+            assert_eq!(format_shortcut_hint("Ctrl+w h"), "Win+W H");
+        }
     }
 
     #[test]
     fn format_shortcut_hint_formats_arrow_keys() {
         assert_eq!(format_shortcut_hint("ArrowDown"), "↓");
-        assert_eq!(format_shortcut_hint("Cmd+ArrowLeft"), "⌘←");
+        if cfg!(target_os = "macos") {
+            assert_eq!(format_shortcut_hint("Cmd+ArrowLeft"), "⌘←");
+        } else {
+            assert_eq!(format_shortcut_hint("Cmd+ArrowLeft"), "Ctrl+←");
+        }
     }
 
     #[test]

--- a/desktop/src/menu.rs
+++ b/desktop/src/menu.rs
@@ -177,11 +177,11 @@ fn add_app_menu(menu: &Menu) {
 
     arto_menu
         .append_items(&[
-            &create_menu_item(MenuId::About, "About Arto"),
+            &create_menu_item(MenuId::About, if cfg!(windows) { "About" } else { "About Arto" }),
             &PredefinedMenuItem::separator(),
-            &create_menu_item(MenuId::Preferences, "Preferences..."),
+            &create_menu_item(MenuId::Preferences, if cfg!(windows) { "Settings" } else { "Preferences..." }),
             &PredefinedMenuItem::separator(),
-            &PredefinedMenuItem::quit(Some("Quit")),
+            &PredefinedMenuItem::quit(Some(if cfg!(windows) { "Exit" } else { "Quit" })),
         ])
         .unwrap();
 
@@ -200,7 +200,7 @@ fn add_file_menu(menu: &Menu) {
             &create_menu_item(MenuId::OpenDirectory, "Open Directory..."),
             &PredefinedMenuItem::separator(),
             &create_menu_item(MenuId::CopyFilePath, "Copy File Path"),
-            &create_menu_item(MenuId::RevealInFinder, "Reveal in Finder"),
+            &create_menu_item(MenuId::RevealInFinder, if cfg!(windows) { "Reveal in File Explorer" } else { "Reveal in Finder" }),
             &PredefinedMenuItem::separator(),
             &create_menu_item(MenuId::CloseTab, "Close Tab"),
             &create_menu_item(MenuId::CloseAllTabs, "Close All Tabs"),

--- a/desktop/src/shortcut.rs
+++ b/desktop/src/shortcut.rs
@@ -195,7 +195,11 @@ impl fmt::Display for KeyChord {
             write!(f, "Shift+")?;
         }
         if self.modifiers.contains(Modifiers::META) {
-            write!(f, "Cmd+")?;
+            if cfg!(target_os = "macos") {
+                write!(f, "Cmd+")?;
+            } else {
+                write!(f, "Win+")?;
+            }
         }
         match &self.key {
             Key::Character(c) => write!(f, "{c}"),
@@ -251,10 +255,22 @@ fn parse_chord(token: &str) -> Result<KeyChord, ShortcutParseError> {
         }
 
         match part.to_ascii_lowercase().as_str() {
-            "ctrl" | "control" => modifiers.insert(Modifiers::CONTROL),
+            "ctrl" | "control" => {
+                if cfg!(target_os = "macos") {
+                    modifiers.insert(Modifiers::CONTROL);
+                } else {
+                    modifiers.insert(Modifiers::META);
+                }
+            }
             "shift" => modifiers.insert(Modifiers::SHIFT),
             "alt" | "option" => modifiers.insert(Modifiers::ALT),
-            "meta" | "cmd" | "command" => modifiers.insert(Modifiers::META),
+            "meta" | "cmd" | "command" => {
+                if cfg!(target_os = "macos") {
+                    modifiers.insert(Modifiers::META);
+                } else {
+                    modifiers.insert(Modifiers::CONTROL);
+                }
+            }
             _ => {
                 if key_part.is_some() {
                     return Err(ShortcutParseError::UnknownModifier(part.to_string()));
@@ -400,11 +416,12 @@ mod tests {
     #[test]
     fn parse_with_modifiers() {
         let seq = ShortcutSequence::from_str("Ctrl+Shift+g").unwrap();
+        let expected_ctrl = if cfg!(target_os = "macos") { Modifiers::CONTROL } else { Modifiers::META };
         assert_eq!(
             seq.chords,
             vec![KeyChord {
                 key: Key::Character("g".to_string()),
-                modifiers: Modifiers::CONTROL | Modifiers::SHIFT
+                modifiers: expected_ctrl | Modifiers::SHIFT
             }]
         );
     }
@@ -412,6 +429,7 @@ mod tests {
     #[test]
     fn parse_sequence() {
         let seq = ShortcutSequence::from_str("g Ctrl+g").unwrap();
+        let expected_ctrl = if cfg!(target_os = "macos") { Modifiers::CONTROL } else { Modifiers::META };
         assert_eq!(
             seq.chords,
             vec![
@@ -421,7 +439,7 @@ mod tests {
                 },
                 KeyChord {
                     key: Key::Character("g".to_string()),
-                    modifiers: Modifiers::CONTROL
+                    modifiers: expected_ctrl
                 }
             ]
         );
@@ -452,11 +470,12 @@ mod tests {
     #[test]
     fn parse_cmd_key() {
         let seq = ShortcutSequence::from_str("Cmd+n").unwrap();
+        let expected_mod = if cfg!(target_os = "macos") { Modifiers::META } else { Modifiers::CONTROL };
         assert_eq!(
             seq.chords,
             vec![KeyChord {
                 key: Key::Character("n".to_string()),
-                modifiers: Modifiers::META
+                modifiers: expected_mod
             }]
         );
     }
@@ -482,11 +501,12 @@ mod tests {
     #[test]
     fn parse_symbol_alias() {
         let seq = ShortcutSequence::from_str("Cmd+Equal").unwrap();
+        let expected_mod = if cfg!(target_os = "macos") { Modifiers::META } else { Modifiers::CONTROL };
         assert_eq!(
             seq.chords,
             vec![KeyChord {
                 key: Key::Character("=".to_string()),
-                modifiers: Modifiers::META
+                modifiers: expected_mod
             }]
         );
     }
@@ -560,7 +580,11 @@ mod tests {
             key: Key::Enter,
             modifiers: Modifiers::META,
         };
-        assert_eq!(chord.to_string(), "Cmd+Enter");
+        if cfg!(target_os = "macos") {
+            assert_eq!(chord.to_string(), "Cmd+Enter");
+        } else {
+            assert_eq!(chord.to_string(), "Win+Enter");
+        }
     }
 
     #[test]

--- a/desktop/src/window/child.rs
+++ b/desktop/src/window/child.rs
@@ -5,7 +5,7 @@ use dioxus::prelude::*;
 use std::cell::RefCell;
 use std::collections::HashMap;
 
-use crate::assets::MAIN_STYLE;
+use crate::assets::get_main_style_path;
 use crate::components::image_window::{generate_image_id, ImageWindow, ImageWindowProps};
 use crate::components::math_window::{generate_math_id, MathWindow, MathWindowProps};
 use crate::components::mermaid_window::{generate_diagram_id, MermaidWindow, MermaidWindowProps};
@@ -13,6 +13,17 @@ use crate::theme::Theme;
 
 use super::index::{build_image_window_index, build_math_window_index, build_mermaid_window_index};
 use super::main::get_last_focused_window;
+
+fn get_child_window_builder(title: &str) -> WindowBuilder {
+    #[cfg(windows)]
+    return WindowBuilder::new()
+        .with_title(title)
+        .with_decorations(true)
+        .with_transparent(false);
+
+    #[cfg(not(windows))]
+    return WindowBuilder::new().with_title(title);
+}
 
 struct ChildWindowEntry {
     handle: WeakDesktopContext,
@@ -180,8 +191,11 @@ pub fn open_or_focus_mermaid_window(source: String, theme: Theme) {
         );
         let config = Config::new()
             .with_menu(None)
-            .with_window(WindowBuilder::new().with_title("Mermaid Viewer"))
-            .with_custom_head(indoc::formatdoc! {r#"<link rel="stylesheet" href="{MAIN_STYLE}">"#})
+            .with_window(get_child_window_builder("Mermaid Viewer"))
+            .with_custom_head(indoc::formatdoc!(
+                r#"<link rel="stylesheet" href="{}">"#,
+                get_main_style_path()
+            ))
             .with_custom_index(build_mermaid_window_index(theme));
 
         dioxus_core::spawn(create_and_register_child_window(
@@ -205,8 +219,11 @@ pub fn open_or_focus_math_window(source: String, theme: Theme) {
         );
         let config = Config::new()
             .with_menu(None)
-            .with_window(WindowBuilder::new().with_title("Math Viewer"))
-            .with_custom_head(indoc::formatdoc! {r#"<link rel="stylesheet" href="{MAIN_STYLE}">"#})
+            .with_window(get_child_window_builder("Math Viewer"))
+            .with_custom_head(indoc::formatdoc!(
+                r#"<link rel="stylesheet" href="{}">"#,
+                get_main_style_path()
+            ))
             .with_custom_index(build_math_window_index(theme));
 
         dioxus_core::spawn(create_and_register_child_window(
@@ -231,8 +248,11 @@ pub fn open_or_focus_image_window(src: String, alt: Option<String>, theme: Theme
         );
         let config = Config::new()
             .with_menu(None)
-            .with_window(WindowBuilder::new().with_title("Image Viewer"))
-            .with_custom_head(indoc::formatdoc! {r#"<link rel="stylesheet" href="{MAIN_STYLE}">"#})
+            .with_window(get_child_window_builder("Image Viewer"))
+            .with_custom_head(indoc::formatdoc!(
+                r#"<link rel="stylesheet" href="{}">"#,
+                get_main_style_path()
+            ))
             .with_custom_index(build_image_window_index(theme));
 
         dioxus_core::spawn(create_and_register_child_window(

--- a/desktop/src/window/main.rs
+++ b/desktop/src/window/main.rs
@@ -12,7 +12,7 @@ use std::rc::Rc;
 
 use crate::state::AppState;
 
-use crate::assets::MAIN_STYLE;
+use crate::assets::get_main_style_path;
 use crate::components::app::{App, AppProps};
 use crate::components::right_sidebar::RightSidebarTab;
 use crate::config::{WindowPositionOffset, CONFIG};
@@ -29,16 +29,28 @@ const MAX_POSITION_SHIFT_ATTEMPTS: usize = 20;
 /// Create base window config from parameters
 /// This config can be further customized with .with_menu(), .with_custom_event_handler(), etc.
 pub fn create_main_window_config(params: &CreateMainWindowConfigParams) -> Config {
+    #[cfg(windows)]
+    let window_builder = WindowBuilder::new()
+        .with_title("Arto")
+        .with_position(params.position)
+        .with_inner_size(params.size)
+        .with_decorations(true)
+        .with_transparent(false);
+
+    #[cfg(not(windows))]
+    let window_builder = WindowBuilder::new()
+        .with_title("Arto")
+        .with_position(params.position)
+        .with_inner_size(params.size);
+
     Config::new()
-        .with_window(
-            WindowBuilder::new()
-                .with_title("Arto")
-                .with_position(params.position)
-                .with_inner_size(params.size),
-        )
+        .with_window(window_builder)
         // Add main style in config. Otherwise the style takes time to load and
         // the window appears unstyled for a brief moment.
-        .with_custom_head(indoc::formatdoc! {r#"<link rel="stylesheet" href="{MAIN_STYLE}">"#})
+        .with_custom_head(indoc::formatdoc!(
+            r#"<link rel="stylesheet" href="{}">"#,
+            get_main_style_path()
+        ))
         // Use a custom index to set the initial theme correctly
         .with_custom_index(build_custom_index(params.theme))
 }

--- a/justfile
+++ b/justfile
@@ -1,3 +1,5 @@
+set windows-shell := ["pwsh.exe", "-NoProfile", "-Command"]
+
 mod desktop
 mod renderer
 

--- a/renderer/justfile
+++ b/renderer/justfile
@@ -1,3 +1,5 @@
+set windows-shell := ["pwsh.exe", "-NoProfile", "-Command"]
+
 [private]
 default:
   @just --list


### PR DESCRIPTION
This PR implements platform-specific fixes necessary to support Arto on Windows.
- Normalized asset paths (`\` to `/`) ensuring `__tauri_asset__` URLs resolve correctly on Windows WebView2.
- Fixed window decorations and background transparency to adapt to the Windows desktop manager.
- Swapped `Cmd`/`Meta` for `Ctrl` modifiers on Windows for correct keyboard shortcuts. (may be duplication #158)
- Localized shortcut hints and menu labels for a native Windows feel.

https://github.com/user-attachments/assets/c79a9675-0787-4e1a-9136-c5e1716bcb6b

