### PR TITLE
feat: platform-specific shortcut hint labels

### DIFF
--- a/desktop/src/keybindings/hint.rs
+++ b/desktop/src/keybindings/hint.rs
@@ -49,9 +49,8 @@ fn bindings_for_context(
 
 /// Convert keybinding notation into a menu-style shortcut hint.
 ///
-/// Examples:
-/// - `Cmd+Shift+o` -> `⌘⇧O`
-/// - `Ctrl+w h` -> `⌃W H`
+/// On macOS, uses Unicode symbols (e.g. `Cmd+Shift+o` -> `⌘⇧O`).
+/// On Windows/Linux, uses text labels (e.g. `Cmd+Shift+o` -> `Ctrl+Shift+O`).
 pub fn format_shortcut_hint(key: &str) -> String {
     key.split_whitespace()
         .map(format_chord_hint)
@@ -71,28 +70,32 @@ fn format_chord_hint(chord: &str) -> String {
 
     let key_part = parts.pop().unwrap();
     let mut out = String::new();
-
-    #[cfg(target_os = "macos")]
     for modifier in &parts {
         match modifier.to_ascii_lowercase().as_str() {
-            "cmd" | "command" | "meta" => out.push('⌘'),
-            "ctrl" | "control" => out.push('⌃'),
-            "shift" => out.push('⇧'),
-            "alt" | "option" => out.push('⌥'),
-            other => {
-                out.push_str(other);
-                out.push('+');
+            "cmd" | "command" | "meta" => {
+                #[cfg(target_os = "macos")]
+                out.push('⌘');
+                #[cfg(not(target_os = "macos"))]
+                out.push_str("Ctrl+");
             }
-        }
-    }
-
-    #[cfg(not(target_os = "macos"))]
-    for modifier in &parts {
-        match modifier.to_ascii_lowercase().as_str() {
-            "cmd" | "command" | "meta" => out.push_str("Ctrl+"),
-            "ctrl" | "control" => out.push_str("Ctrl+"),
-            "shift" => out.push_str("Shift+"),
-            "alt" | "option" => out.push_str("Alt+"),
+            "ctrl" | "control" => {
+                #[cfg(target_os = "macos")]
+                out.push('⌃');
+                #[cfg(not(target_os = "macos"))]
+                out.push_str("Ctrl+");
+            }
+            "shift" => {
+                #[cfg(target_os = "macos")]
+                out.push('⇧');
+                #[cfg(not(target_os = "macos"))]
+                out.push_str("Shift+");
+            }
+            "alt" | "option" => {
+                #[cfg(target_os = "macos")]
+                out.push('⌥');
+                #[cfg(not(target_os = "macos"))]
+                out.push_str("Alt+");
+            }
             other => {
                 out.push_str(other);
                 out.push('+');
@@ -164,14 +167,14 @@ mod tests {
 
     #[test]
     #[cfg(target_os = "macos")]
-    fn format_shortcut_hint_formats_arrow_keys() {
+    fn format_shortcut_hint_formats_arrow_keys_macos() {
         assert_eq!(format_shortcut_hint("ArrowDown"), "↓");
         assert_eq!(format_shortcut_hint("Cmd+ArrowLeft"), "⌘←");
     }
 
     #[test]
     #[cfg(not(target_os = "macos"))]
-    fn format_shortcut_hint_formats_arrow_keys() {
+    fn format_shortcut_hint_formats_arrow_keys_non_macos() {
         assert_eq!(format_shortcut_hint("ArrowDown"), "Down");
         assert_eq!(format_shortcut_hint("Cmd+ArrowLeft"), "Ctrl+Left");
     }

--- a/desktop/src/keybindings/hint.rs
+++ b/desktop/src/keybindings/hint.rs
@@ -71,7 +71,9 @@ fn format_chord_hint(chord: &str) -> String {
 
     let key_part = parts.pop().unwrap();
     let mut out = String::new();
-    for modifier in parts {
+
+    #[cfg(target_os = "macos")]
+    for modifier in &parts {
         match modifier.to_ascii_lowercase().as_str() {
             "cmd" | "command" | "meta" => out.push('⌘'),
             "ctrl" | "control" => out.push('⌃'),
@@ -83,10 +85,46 @@ fn format_chord_hint(chord: &str) -> String {
             }
         }
     }
+
+    #[cfg(not(target_os = "macos"))]
+    for modifier in &parts {
+        match modifier.to_ascii_lowercase().as_str() {
+            "cmd" | "command" | "meta" => out.push_str("Ctrl+"),
+            "ctrl" | "control" => out.push_str("Ctrl+"),
+            "shift" => out.push_str("Shift+"),
+            "alt" | "option" => out.push_str("Alt+"),
+            other => {
+                out.push_str(other);
+                out.push('+');
+            }
+        }
+    }
+
     out.push_str(&format_key_name_hint(key_part));
     out
 }
 
+#[cfg(not(target_os = "macos"))]
+fn format_key_name_hint(key: &str) -> String {
+    match key {
+        "ArrowUp" => "Up".to_string(),
+        "ArrowDown" => "Down".to_string(),
+        "ArrowLeft" => "Left".to_string(),
+        "ArrowRight" => "Right".to_string(),
+        "Backspace" => "Backspace".to_string(),
+        "Enter" => "Enter".to_string(),
+        "Escape" => "Esc".to_string(),
+        "Tab" => "Tab".to_string(),
+        "Space" => "Space".to_string(),
+        "PageUp" => "PgUp".to_string(),
+        "PageDown" => "PgDn".to_string(),
+        "Home" => "Home".to_string(),
+        "End" => "End".to_string(),
+        _ => key.to_uppercase(),
+    }
+}
+
+#[cfg(target_os = "macos")]
 fn format_key_name_hint(key: &str) -> String {
     match key {
         "ArrowUp" => "↑".to_string(),
@@ -111,15 +149,31 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg(target_os = "macos")]
     fn format_shortcut_hint_uses_menu_style_symbols() {
         assert_eq!(format_shortcut_hint("Cmd+Shift+o"), "⌘⇧O");
         assert_eq!(format_shortcut_hint("Ctrl+w h"), "⌃W H");
     }
 
     #[test]
+    #[cfg(not(target_os = "macos"))]
+    fn format_shortcut_hint_uses_text_labels() {
+        assert_eq!(format_shortcut_hint("Cmd+Shift+o"), "Ctrl+Shift+O");
+        assert_eq!(format_shortcut_hint("Ctrl+w h"), "Ctrl+W H");
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
     fn format_shortcut_hint_formats_arrow_keys() {
         assert_eq!(format_shortcut_hint("ArrowDown"), "↓");
         assert_eq!(format_shortcut_hint("Cmd+ArrowLeft"), "⌘←");
+    }
+
+    #[test]
+    #[cfg(not(target_os = "macos"))]
+    fn format_shortcut_hint_formats_arrow_keys() {
+        assert_eq!(format_shortcut_hint("ArrowDown"), "Down");
+        assert_eq!(format_shortcut_hint("Cmd+ArrowLeft"), "Ctrl+Left");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

On macOS, shortcut hints in menus use Unicode symbols (⌘⇧⌥⌃, ↑↓←→, ⌫↩⎋, etc.) which are familiar to Mac users. On Windows/Linux, these symbols are not recognizable.

This PR renders shortcut hints with text labels on non-macOS platforms:
- `⌘` → `Ctrl+`, `⌃` → `Ctrl+`, `⇧` → `Shift+`, `⌥` → `Alt+`
- `↑↓←→` → `Up`, `Down`, `Left`, `Right`
- `⌫` → `Backspace`, `↩` → `Enter`, `⎋` → `Esc`, etc.

## Changes

- `desktop/src/keybindings/hint.rs`: Add platform-specific `format_chord_hint()` and `format_key_name_hint()` implementations via `#[cfg]` attributes
- Platform-conditional tests for both macOS symbols and Windows/Linux text labels

## Test plan

- [x] `cargo check` passes on Windows (0 errors)
- [x] `cargo test` passes on Windows (platform-specific test assertions)
- [x] Menu shortcuts display as `Ctrl+N`, `Ctrl+T`, `Shift+`, etc. on Windows
- [x] No behavior change on macOS