### PR TITLE
fix: increase JS bridge initialization timeout for WebView2

### DIFF
--- a/desktop/src/components/app/keybinding_engine.rs
+++ b/desktop/src/components/app/keybinding_engine.rs
@@ -52,8 +52,9 @@ pub(super) fn setup_keybinding_engine(
         // Keyboard event processing loop
         spawn(async move {
             // Wait for JS keyboard API to be ready, then register callback.
-            // Retries up to 200 times (10s) before giving up.
-            // Windows WebView2 may take longer to parse large JS bundles.
+            // Retries up to 200 × 50ms = 10s before giving up.
+            // Keep in sync with JS_READY_MAX_RETRIES / JS_READY_POLL_INTERVAL_MS
+            // in search_bar.rs. WebView2 on Windows needs the generous timeout.
             let mut eval = document::eval(
                 r#"
             (async () => {

--- a/desktop/src/components/app/keybinding_engine.rs
+++ b/desktop/src/components/app/keybinding_engine.rs
@@ -52,12 +52,13 @@ pub(super) fn setup_keybinding_engine(
         // Keyboard event processing loop
         spawn(async move {
             // Wait for JS keyboard API to be ready, then register callback.
-            // Retries up to 50 times (2.5s) before giving up.
+            // Retries up to 200 times (10s) before giving up.
+            // Windows WebView2 may take longer to parse large JS bundles.
             let mut eval = document::eval(
                 r#"
             (async () => {
                 let retries = 0;
-                while (!window.Arto?.keyboard?.onKeydown && retries++ < 50) {
+                while (!window.Arto?.keyboard?.onKeydown && retries++ < 200) {
                     await new Promise(r => setTimeout(r, 50));
                 }
                 if (!window.Arto?.keyboard?.onKeydown) {

--- a/desktop/src/components/search_bar.rs
+++ b/desktop/src/components/search_bar.rs
@@ -64,8 +64,9 @@ async fn wait_for_js_ready() {
     use std::time::Duration;
 
     // Poll until window.Arto.search.setPinned is available
-    for _ in 0..50 {
-        // 50 * 50ms = 2.5s max wait
+    // Windows WebView2 may take longer to parse large JS bundles, so use generous timeout
+    for _ in 0..200 {
+        // 200 * 50ms = 10s max wait
         let mut eval =
             document::eval("dioxus.send(typeof window.Arto?.search?.setPinned === 'function')");
         if let Ok(true) = eval.recv::<bool>().await {

--- a/desktop/src/components/search_bar.rs
+++ b/desktop/src/components/search_bar.rs
@@ -59,21 +59,23 @@ fn build_pinned_json(searches: &[PinnedSearch]) -> String {
     format!("[{}]", json_entries.join(","))
 }
 
+/// Polling interval (ms) and max retries for waiting on JS API readiness.
+/// 200 retries × 50ms = 10s max wait. Generous for WebView2 on Windows,
+/// which may take longer to parse large JS bundles.
+const JS_READY_POLL_INTERVAL_MS: u64 = 50;
+const JS_READY_MAX_RETRIES: u32 = 200;
+
 /// Wait for JavaScript search API to be ready.
 async fn wait_for_js_ready() {
     use std::time::Duration;
 
-    // Poll until window.Arto.search.setPinned is available
-    // Windows WebView2 may take longer to parse large JS bundles, so use generous timeout
-    for _ in 0..200 {
-        // 200 * 50ms = 10s max wait
+    for _ in 0..JS_READY_MAX_RETRIES {
         let mut eval =
             document::eval("dioxus.send(typeof window.Arto?.search?.setPinned === 'function')");
         if let Ok(true) = eval.recv::<bool>().await {
             return;
         }
-        // Small delay before retrying
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        tokio::time::sleep(Duration::from_millis(JS_READY_POLL_INTERVAL_MS)).await;
     }
     tracing::warn!("Timeout waiting for JavaScript search API to be ready");
 }


### PR DESCRIPTION
## Summary

WebView2 on Windows takes longer to parse the ~5MB JS bundle than WebKit on macOS. The keyboard interceptor and search API poll for JS readiness with a 2.5s timeout (50 retries × 50ms), which is insufficient for WebView2 cold starts, resulting in:

```
Keyboard interceptor API not available after timeout
Timeout waiting for JavaScript search API to be ready
```

This PR increases the timeout to 10s (200 retries × 50ms), which is generous enough for WebView2 while having no impact on macOS (where initialization typically completes in <1s).

## Changes

- `desktop/src/components/app/keybinding_engine.rs`: Increase retry count from 50 to 200
- `desktop/src/components/search_bar.rs`: Increase retry count from 50 to 200

## Test plan

- [x] `cargo check` passes on Windows (0 errors)
- [x] No "timeout" warnings in console on Windows cold start
- [x] Keyboard shortcuts and search work after initialization
- [x] No perceptible delay on macOS (fast init completes well before new timeout)