### PR TITLE
fix: prevent flash of unstyled content on cold start

### DIFF
--- a/desktop/src/window/index.rs
+++ b/desktop/src/window/index.rs
@@ -1,91 +1,77 @@
 use crate::theme::{resolve_theme, Theme};
 
+/// Inline CSS to hide body until stylesheets are loaded (FOUC prevention).
+const FOUC_STYLE: &str = r#"<style>
+    body { opacity: 0; transition: opacity 0.1s ease-in; }
+    body.loaded { opacity: 1; }
+</style>"#;
+
+/// Inline JS to detect external stylesheet readiness and reveal the body.
+/// Only checks stylesheets with an `href` (external) to avoid matching
+/// the inline FOUC style itself. Falls back after 200ms.
+const FOUC_SCRIPT: &str = r#"<script>
+    (function() {
+        function showBody() { document.body.classList.add('loaded'); }
+        function hasLoadedExternalStylesheet() {
+            for (var i = 0; i < document.styleSheets.length; i++) {
+                try {
+                    var sheet = document.styleSheets[i];
+                    if (sheet.href && sheet.cssRules && sheet.cssRules.length > 0) return true;
+                } catch (e) {}
+            }
+            return false;
+        }
+        window.addEventListener('DOMContentLoaded', function() {
+            if (hasLoadedExternalStylesheet()) { showBody(); return; }
+            var elapsed = 0;
+            var interval = setInterval(function() {
+                elapsed += 10;
+                if (hasLoadedExternalStylesheet() || elapsed >= 200) { clearInterval(interval); showBody(); }
+            }, 10);
+        });
+    })();
+</script>"#;
+
 pub fn build_custom_index(theme: Theme) -> String {
     let resolved = resolve_theme(theme);
-    indoc::formatdoc! {r#"
-    <!DOCTYPE html>
-    <html>
-        <head>
-            <title>Arto</title>
-            <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-            <!-- CUSTOM HEAD -->
-            <style>
-                /* Hide body until CSS is loaded to prevent FOUC on cold start.
-                   WebView2 on Windows may take longer to load stylesheets. */
-                body {{ opacity: 0; transition: opacity 0.1s ease-in; }}
-                body.loaded {{ opacity: 1; }}
-            </style>
-        </head>
-        <body data-theme="{resolved}">
-            <div id="main"></div>
-            <!-- MODULE LOADER -->
-            <script>
-                (function() {{
-                    function showBody() {{ document.body.classList.add('loaded'); }}
-                    function hasLoadedStylesheets() {{
-                        for (var i = 0; i < document.styleSheets.length; i++) {{
-                            try {{
-                                if (document.styleSheets[i].cssRules && document.styleSheets[i].cssRules.length > 0) return true;
-                            }} catch (e) {{}}
-                        }}
-                        return false;
-                    }}
-                    window.addEventListener('DOMContentLoaded', function() {{
-                        if (hasLoadedStylesheets()) {{ showBody(); return; }}
-                        var elapsed = 0;
-                        var interval = setInterval(function() {{
-                            elapsed += 10;
-                            if (hasLoadedStylesheets() || elapsed >= 200) {{ clearInterval(interval); showBody(); }}
-                        }}, 10);
-                    }});
-                }})();
-            </script>
-        </body>
-    </html>
-    "#}
+    format!(
+        r#"<!DOCTYPE html>
+<html>
+    <head>
+        <title>Arto</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+        <!-- CUSTOM HEAD -->
+        {FOUC_STYLE}
+    </head>
+    <body data-theme="{resolved}">
+        <div id="main"></div>
+        <!-- MODULE LOADER -->
+        {FOUC_SCRIPT}
+    </body>
+</html>
+"#
+    )
 }
 
 fn build_viewer_window_index(title: &str, body_class: &str, theme: Theme) -> String {
     let resolved = resolve_theme(theme);
-    indoc::formatdoc! {r#"
-    <!DOCTYPE html>
-    <html>
-        <head>
-            <title>{title} - Arto</title>
-            <meta name="viewport" content="width=device-width, initial-scale=1.0">
-            <!-- CUSTOM HEAD -->
-            <style>
-                body {{ opacity: 0; transition: opacity 0.1s ease-in; }}
-                body.loaded {{ opacity: 1; }}
-            </style>
-        </head>
-        <body data-theme="{resolved}" class="{body_class}">
-            <div id="main"></div>
-            <!-- MODULE LOADER -->
-            <script>
-                (function() {{
-                    function showBody() {{ document.body.classList.add('loaded'); }}
-                    function hasLoadedStylesheets() {{
-                        for (var i = 0; i < document.styleSheets.length; i++) {{
-                            try {{
-                                if (document.styleSheets[i].cssRules && document.styleSheets[i].cssRules.length > 0) return true;
-                            }} catch (e) {{}}
-                        }}
-                        return false;
-                    }}
-                    window.addEventListener('DOMContentLoaded', function() {{
-                        if (hasLoadedStylesheets()) {{ showBody(); return; }}
-                        var elapsed = 0;
-                        var interval = setInterval(function() {{
-                            elapsed += 10;
-                            if (hasLoadedStylesheets() || elapsed >= 200) {{ clearInterval(interval); showBody(); }}
-                        }}, 10);
-                    }});
-                }})();
-            </script>
-        </body>
-    </html>
-    "#}
+    format!(
+        r#"<!DOCTYPE html>
+<html>
+    <head>
+        <title>{title} - Arto</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <!-- CUSTOM HEAD -->
+        {FOUC_STYLE}
+    </head>
+    <body data-theme="{resolved}" class="{body_class}">
+        <div id="main"></div>
+        <!-- MODULE LOADER -->
+        {FOUC_SCRIPT}
+    </body>
+</html>
+"#
+    )
 }
 
 pub(crate) fn build_mermaid_window_index(theme: Theme) -> String {

--- a/desktop/src/window/index.rs
+++ b/desktop/src/window/index.rs
@@ -9,10 +9,37 @@ pub fn build_custom_index(theme: Theme) -> String {
             <title>Arto</title>
             <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
             <!-- CUSTOM HEAD -->
+            <style>
+                /* Hide body until CSS is loaded to prevent FOUC on cold start.
+                   WebView2 on Windows may take longer to load stylesheets. */
+                body {{ opacity: 0; transition: opacity 0.1s ease-in; }}
+                body.loaded {{ opacity: 1; }}
+            </style>
         </head>
         <body data-theme="{resolved}">
             <div id="main"></div>
             <!-- MODULE LOADER -->
+            <script>
+                (function() {{
+                    function showBody() {{ document.body.classList.add('loaded'); }}
+                    function hasLoadedStylesheets() {{
+                        for (var i = 0; i < document.styleSheets.length; i++) {{
+                            try {{
+                                if (document.styleSheets[i].cssRules && document.styleSheets[i].cssRules.length > 0) return true;
+                            }} catch (e) {{}}
+                        }}
+                        return false;
+                    }}
+                    window.addEventListener('DOMContentLoaded', function() {{
+                        if (hasLoadedStylesheets()) {{ showBody(); return; }}
+                        var elapsed = 0;
+                        var interval = setInterval(function() {{
+                            elapsed += 10;
+                            if (hasLoadedStylesheets() || elapsed >= 200) {{ clearInterval(interval); showBody(); }}
+                        }}, 10);
+                    }});
+                }})();
+            </script>
         </body>
     </html>
     "#}
@@ -27,10 +54,35 @@ fn build_viewer_window_index(title: &str, body_class: &str, theme: Theme) -> Str
             <title>{title} - Arto</title>
             <meta name="viewport" content="width=device-width, initial-scale=1.0">
             <!-- CUSTOM HEAD -->
+            <style>
+                body {{ opacity: 0; transition: opacity 0.1s ease-in; }}
+                body.loaded {{ opacity: 1; }}
+            </style>
         </head>
         <body data-theme="{resolved}" class="{body_class}">
             <div id="main"></div>
             <!-- MODULE LOADER -->
+            <script>
+                (function() {{
+                    function showBody() {{ document.body.classList.add('loaded'); }}
+                    function hasLoadedStylesheets() {{
+                        for (var i = 0; i < document.styleSheets.length; i++) {{
+                            try {{
+                                if (document.styleSheets[i].cssRules && document.styleSheets[i].cssRules.length > 0) return true;
+                            }} catch (e) {{}}
+                        }}
+                        return false;
+                    }}
+                    window.addEventListener('DOMContentLoaded', function() {{
+                        if (hasLoadedStylesheets()) {{ showBody(); return; }}
+                        var elapsed = 0;
+                        var interval = setInterval(function() {{
+                            elapsed += 10;
+                            if (hasLoadedStylesheets() || elapsed >= 200) {{ clearInterval(interval); showBody(); }}
+                        }}, 10);
+                    }});
+                }})();
+            </script>
         </body>
     </html>
     "#}


### PR DESCRIPTION
## Summary

WebView2 on Windows takes longer to load stylesheets than WebKit on macOS, causing a flash of unstyled content (FOUC) — a brief moment where the UI appears with broken layout before styles are applied.

This PR hides the body (`opacity: 0`) until at least one stylesheet is confirmed loaded via `document.styleSheets[].cssRules`, then reveals it with a smooth 0.1s opacity transition. A 200ms safety timeout ensures the body is always shown even if detection fails.

Applied to both the main application window and all viewer windows (Mermaid, Math, Image).

## Changes

- `desktop/src/window/index.rs`: Add inline FOUC-prevention `<style>` and `<script>` to `build_custom_index()` and `build_viewer_window_index()`

## Test plan

- [ ] `cargo check` passes on Windows
- [ ] No FOUC visible on Windows cold start
- [ ] Application renders correctly after stylesheet loads
- [ ] No perceptible delay on macOS (CSS loads fast, body shows immediately)
- [ ] Viewer windows (Mermaid, Math, Image) also load without FOUC