### PR TITLE
feat: add Windows development support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,27 +44,32 @@ just setup
 ## Development Commands
 
 ```bash
-# Run in development mode
-cargo run --release
+# Run in development mode (with hot-reload via Vite + Dioxus)
+just dev
 
-# Run with hot-reload (requires dioxus-cli)
-dx serve --platform desktop
+# Or run the Dioxus dev server directly
+cd desktop && dx serve
 
 # Format, lint, and test
 just fmt check test
 ```
 
+> **Windows note:** On Windows, you must use `dx serve` (or `just dev`) instead of `cargo run`.
+> WebView2 blocks the `file://` protocol that `cargo run` uses for asset serving.
+> `dx serve` works around this by serving assets over HTTP.
+> This limitation does not affect production builds (`dx bundle --release`).
+
 ## Production Build
 
 ```bash
-# Build for macOS
+# Build for the current platform
 just build
 
-# Install to /Applications (macOS)
+# Install to /Applications (macOS only)
 just install
 ```
 
-The binary will be available at `target/release/arto` or `target/dx/arto/bundle/macos/bundle/`.
+The bundled application will be available under `target/dx/arto/bundle/`.
 
 ## Project Structure
 

--- a/desktop/justfile
+++ b/desktop/justfile
@@ -37,6 +37,14 @@ open:
 open:
   ./target/dx/arto/release/linux/app/arto
 
+[windows]
+build:
+  dx bundle --release
+
+[windows]
+open:
+  ./target/dx/arto/bundle/windows/arto.exe
+
 [confirm]
 [macos]
 install:


### PR DESCRIPTION
## Summary

Enable Windows development by documenting the correct workflow and adding Windows-specific build recipes.

## Problem

When running `cargo run` on Windows, the application launches but **CSS, JS, and SVG icons fail to load entirely**, resulting in a broken UI with no styling.

This happens because Dioxus's `asset!()` macro resolves assets to `file://` URLs in dev mode:

```
Not allowed to load local resource: file:///C:/Users/.../assets/dist/main.css
Not allowed to load local resource: file:///C:/Users/.../assets/dist/icons/tabler-sprite.svg
```

WebView2 (the Chromium-based rendering engine on Windows) blocks `file://` protocol access for security reasons. On macOS, WKWebView handles the `dioxus://` custom protocol without this restriction, so `cargo run` works fine there.

This is not a bug in Arto — it's a platform limitation of WebView2. The Dioxus framework's recommended development workflow is `dx serve`, which serves assets over HTTP and avoids this issue entirely.

## Solution

- Use `dx serve` (or `just dev`) for Windows development instead of `cargo run`
- `dx serve` starts a local HTTP server for asset delivery, bypassing WebView2's `file://` restriction
- Production builds (`dx bundle --release`) are **unaffected** — assets are embedded in the binary

## Changes

- **`desktop/justfile`**: Add `[windows]` recipes for `build` (`dx bundle --release`) and `open`
- **`CONTRIBUTING.md`**:
  - Update development commands to recommend `dx serve` / `just dev`
  - Add Windows note explaining the WebView2 limitation
  - Make production build docs platform-neutral

## Test plan

- [x] `cargo check` passes on Windows
- [x] `dx serve` launches correctly on Windows 11
- [x] CSS, JS, and SVG icons load properly via `dx serve`
- [x] Application renders correctly (dark theme, sidebar, markdown content)
- [x] No changes to Rust source code — documentation and build config only