### PR TITLE
Fix window restore on restart and make sidebar panels swappable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ package-lock.json
 
 # Build-generated version file (CI only)
 desktop/VERSION
+# CocoIndex Code (ccc)
+/.cocoindex_code/

--- a/desktop/justfile
+++ b/desktop/justfile
@@ -23,6 +23,8 @@ build:
   @rm -rf target/dx/arto/release/macos/Arto.app/Contents/Resources/assets
   @rm -rf target/dx/arto/bundle/macos/macos/Arto.app/Contents/Resources/assets
   dx bundle --release --macos --package-types dmg
+  @mkdir -p target/dx/arto/release/macos/Arto.app/Contents/Resources
+  @cp -af ../extras/mac/arto-app.icns target/dx/arto/release/macos/Arto.app/Contents/Resources/icon.icns
 
 [linux]
 build:
@@ -41,7 +43,7 @@ open:
 [macos]
 install:
   @rm -rf /Applications/Arto.app
-  @cp -af target/dx/arto/bundle/macos/macos/Arto.app /Applications/.
+  @cp -af target/dx/arto/release/macos/Arto.app /Applications/.
 
 [windows]
 build:

--- a/desktop/src/components/app.rs
+++ b/desktop/src/components/app.rs
@@ -20,7 +20,6 @@ use super::content::{
 };
 use super::header::Header;
 use super::right_sidebar::RightSidebar;
-use super::right_sidebar::RightSidebarTab;
 use super::search_bar::SearchBar;
 use super::sidebar::Sidebar;
 use super::tab::TabBar;
@@ -29,7 +28,7 @@ use crate::drag;
 use crate::events::{ActiveDragUpdate, ACTIVE_DRAG_UPDATE};
 #[cfg(not(target_os = "windows"))]
 use crate::menu;
-use crate::state::{AppState, PersistedState, Tab};
+use crate::state::{AppState, PersistedState, SidebarPanel, Tab};
 use crate::theme::Theme;
 
 use drag_drop_overlay::DragDropOverlay;
@@ -50,16 +49,20 @@ pub fn App(
     tabs: Vec<Tab>,     // Initial tabs (at least one tab must be present)
     directory: PathBuf, // Directory (resolved in create_main_window or MainApp)
     theme: Theme,       // The enum: Auto/Light/Dark
+    initial_window_position: LogicalPosition<i32>,
     sidebar_pinned: bool,
+    sidebar_panel: SidebarPanel,
     sidebar_width: f64,
     sidebar_show_all_files: bool,
     sidebar_zoom_level: f64,
     right_sidebar_pinned: bool,
     right_sidebar_width: f64,
-    right_sidebar_tab: RightSidebarTab,
+    right_sidebar_panel: SidebarPanel,
     right_sidebar_zoom_level: f64,
     zoom_level: f64,
 ) -> Element {
+    let desktop = window();
+
     // Initialize application state with the provided tab
     let mut state = use_context_provider(|| {
         let mut app_state = AppState::new(theme);
@@ -82,12 +85,13 @@ pub fn App(
             sidebar.width = sidebar_width;
             sidebar.show_all_files = sidebar_show_all_files;
         }
+        app_state.left_sidebar_panel.set(sidebar_panel);
 
         // Apply initial right sidebar settings from params
         {
             app_state.right_sidebar_pinned.set(right_sidebar_pinned);
             app_state.right_sidebar_width.set(right_sidebar_width);
-            app_state.right_sidebar_tab.set(right_sidebar_tab);
+            app_state.right_sidebar_panel.set(right_sidebar_panel);
         }
 
         // Apply initial zoom levels from params (already normalized in window::settings)
@@ -99,18 +103,22 @@ pub fn App(
             app_state.zoom_level.set(zoom_level);
         }
 
-        let metrics = crate::window::metrics::capture_window_metrics(&window().window);
+        let metrics = crate::window::metrics::capture_window_metrics(&desktop.window);
         *app_state.position.write() = LogicalPosition::new(metrics.position.x, metrics.position.y);
         *app_state.size.write() = LogicalSize::new(metrics.size.width, metrics.size.height);
 
         // Register this window in MAIN_WINDOWS list for cross-window access.
         // This enables fire-and-forget window creation (no need to await new_window()).
-        crate::window::register_main_window(std::rc::Rc::downgrade(&window()));
+        crate::window::register_main_window(std::rc::Rc::downgrade(&desktop));
 
         // Register this window's state for cross-window access
-        crate::window::register_window_state(window().id(), app_state);
+        crate::window::register_window_state(desktop.id(), app_state);
 
         app_state
+    });
+
+    use_hook(move || {
+        desktop.window.set_outer_position(initial_window_position);
     });
 
     // Track drag-and-drop hover state
@@ -153,6 +161,16 @@ pub fn App(
 
     // Handle window events
     use_wry_event_handler(move |event, _| match event {
+        TaoEvent::WindowEvent {
+            event: WindowEvent::CloseRequested | WindowEvent::Destroyed,
+            window_id,
+            ..
+        } => {
+            let window = window();
+            if window_id == &window.id() {
+                persist_window_state(state, &window.window);
+            }
+        }
         TaoEvent::WindowEvent {
             event: WindowEvent::Resized(size),
             window_id,
@@ -298,11 +316,7 @@ pub fn App(
         crate::window::unregister_window_state(window_id);
 
         // Save last used state from this window to disk for next app launch
-        let mut persisted = PersistedState::from(&state);
-        let window_metrics = crate::window::metrics::capture_window_metrics(&window().window);
-        persisted.window_position = window_metrics.position;
-        persisted.window_size = window_metrics.size;
-        persisted.save();
+        persist_window_state(state, &window().window);
 
         // Close child windows
         crate::window::close_child_windows_for_parent(window_id);
@@ -577,4 +591,15 @@ fn sync_window_metrics(
     if let Some(size) = size {
         *state.size.write() = size;
     }
+}
+
+fn persist_window_state(state: AppState, window: &dioxus::desktop::tao::window::Window) {
+    if crate::window::should_skip_persist_on_close() {
+        return;
+    }
+    let mut persisted = PersistedState::from(&state);
+    let window_metrics = crate::window::metrics::capture_window_metrics(window);
+    persisted.window_position = window_metrics.position;
+    persisted.window_size = window_metrics.size;
+    persisted.save();
 }

--- a/desktop/src/components/app.rs
+++ b/desktop/src/components/app.rs
@@ -47,6 +47,7 @@ const MOUSE_BUTTON_LEFT: u32 = 0;
 #[component]
 pub fn App(
     tabs: Vec<Tab>,     // Initial tabs (at least one tab must be present)
+    active_tab: usize,  // Initial active tab index
     directory: PathBuf, // Directory (resolved in create_main_window or MainApp)
     theme: Theme,       // The enum: Auto/Light/Dark
     initial_window_position: LogicalPosition<i32>,
@@ -71,10 +72,21 @@ pub fn App(
         } else {
             tabs
         };
+        let initial_active_tab = active_tab.min(initial_tabs.len().saturating_sub(1));
 
         // Initialize with provided tabs (preserves ordering)
         app_state.tabs.set(initial_tabs);
-        app_state.active_tab.set(0);
+        app_state.active_tab.set(initial_active_tab);
+        app_state
+            .recent_files
+            .set(PersistedState::load().recent_files);
+        let initial_scroll = app_state
+            .tabs
+            .read()
+            .get(initial_active_tab)
+            .and_then(|tab| tab.history.current().map(|entry| entry.scroll_position))
+            .filter(|scroll| *scroll > 0.0);
+        app_state.pending_scroll_position.set(initial_scroll);
 
         // Apply initial sidebar settings from params (including directory)
         {

--- a/desktop/src/components/app.rs
+++ b/desktop/src/components/app.rs
@@ -377,6 +377,7 @@ pub fn App(
     rsx! {
         div {
             class: "app-container",
+            class: if cfg!(target_os = "macos") { "macos-native-titlebar" },
             class: if is_dragging() { "drag-over" },
             ondragover: move |evt| {
                 evt.prevent_default();
@@ -407,10 +408,17 @@ pub fn App(
 
             div {
                 class: "main-area",
-                Header {},
-                SearchBar {},
-                TabBar {},
-                Content {},
+                if cfg!(target_os = "macos") {
+                    TabBar {}
+                    Header {}
+                    SearchBar {}
+                    Content {}
+                } else {
+                    Header {}
+                    SearchBar {}
+                    TabBar {}
+                    Content {}
+                }
             }
 
             // Right sidebar: pinned → flex layout, unpinned → overlay with animation

--- a/desktop/src/components/app/listeners.rs
+++ b/desktop/src/components/app/listeners.rs
@@ -30,6 +30,7 @@ pub(super) fn setup_cross_window_open_listeners(mut state: AppState) {
             if target_window_id == current_window_id {
                 tracing::info!(?path, "Opening directory from cross-window request");
                 state.set_root_directory(path.clone());
+                state.set_left_sidebar_panel(crate::state::SidebarPanel::Directory);
                 // Pin the sidebar so users can see the directory tree
                 state.sidebar.write().pinned = true;
             }

--- a/desktop/src/components/content/file_viewer.rs
+++ b/desktop/src/components/content/file_viewer.rs
@@ -37,6 +37,7 @@ pub fn FileViewer(file: PathBuf) -> Element {
     use_file_loader(file.clone(), html, state);
     use_file_watcher(file.clone(), state);
     use_link_click_handler(file.clone(), state);
+    use_pending_heading_navigation(file.clone(), state);
     use_mermaid_window_handler();
     use_math_window_handler();
     use_image_window_handler();
@@ -135,6 +136,24 @@ fn use_file_loader(file: PathBuf, html: Signal<String>, mut state: AppState) {
             }
         });
     }));
+}
+
+fn use_pending_heading_navigation(file: PathBuf, mut state: AppState) {
+    use_effect(move || {
+        let Some(pending) = state.pending_heading_navigation.read().clone() else {
+            return;
+        };
+
+        if pending.file != file {
+            return;
+        }
+
+        state.clear_pending_heading_navigation();
+
+        spawn(async move {
+            scroll_to_heading(&pending.heading_id, false).await;
+        });
+    });
 }
 
 /// Handle scroll position when navigating to a file.
@@ -339,30 +358,100 @@ fn handle_link_click(click_data: LinkClickData, base_dir: &Path, state: &mut App
 
     tracing::info!("Markdown link clicked: {} (button: {})", path, button);
 
-    // Resolve and normalize the path
-    let target_path = base_dir.join(&path);
-    let Ok(canonical_path) = target_path.canonicalize() else {
-        tracing::error!("Failed to resolve path: {:?}", target_path);
+    let current_file = match state
+        .current_tab()
+        .and_then(|tab| tab.file().map(PathBuf::from))
+    {
+        Some(file) => file,
+        None => return,
+    };
+
+    let Some(resolved_link) =
+        crate::utils::markdown_link::resolve_markdown_link(base_dir, &current_file, &path)
+    else {
+        tracing::error!("Failed to resolve markdown link: {:?}", path);
         return;
     };
 
-    tracing::info!("Opening file: {:?}", canonical_path);
+    tracing::info!(
+        file = ?resolved_link.path,
+        heading = ?resolved_link.heading_id,
+        "Opening markdown link"
+    );
 
     match button {
         MIDDLE_CLICK => {
             // Open in new tab (always create a new tab for middle-click)
-            state.add_file_tab(canonical_path, true);
+            if let Some(heading_id) = resolved_link.heading_id {
+                state.set_pending_heading_navigation(resolved_link.path.clone(), heading_id);
+            } else {
+                state.clear_pending_heading_navigation();
+            }
+            state.add_file_tab(resolved_link.path, true);
         }
         LEFT_CLICK => {
             // Save current scroll position to history before navigating
             state.save_current_scroll_position(scroll_position);
             // Navigate in current tab (in-tab navigation, no existing tab check)
-            state.navigate_to_file(canonical_path);
+            state.navigate_to_file_at_heading(resolved_link.path, resolved_link.heading_id);
         }
         _ => {
             tracing::debug!("Ignoring click with button: {}", button);
         }
     }
+}
+
+async fn scroll_to_heading(heading_id: &str, smooth: bool) {
+    let heading_id_json = serde_json::to_string(heading_id).unwrap_or_else(|_| "null".to_string());
+    let behavior_json =
+        serde_json::to_string(if smooth { "smooth" } else { "auto" }).unwrap_or_default();
+    let js = format!(
+        r#"
+        (() => {{
+            const headingId = {heading_id_json};
+            const behavior = {behavior_json};
+            const scrollToHeading = () => {{
+                const el = document.getElementById(headingId);
+                if (!el) {{
+                    return false;
+                }}
+                el.scrollIntoView({{ behavior, block: 'start' }});
+                return true;
+            }};
+
+            if (scrollToHeading()) {{
+                return;
+            }}
+
+            const container = document.querySelector('.markdown-body');
+            let observer = null;
+            if (container) {{
+                observer = new MutationObserver(() => {{
+                    if (scrollToHeading()) {{
+                        observer.disconnect();
+                        observer = null;
+                    }}
+                }});
+                observer.observe(container, {{ childList: true, subtree: true }});
+            }}
+
+            window.Arto?.render?.onComplete?.(() => {{
+                if (scrollToHeading() && observer) {{
+                    observer.disconnect();
+                    observer = null;
+                }}
+            }});
+
+            setTimeout(() => {{
+                if (observer) {{
+                    scrollToHeading();
+                    observer.disconnect();
+                }}
+            }}, 1000);
+        }})();
+        "#,
+    );
+    let _ = document::eval(&js).await;
 }
 
 /// Hook to setup Mermaid window open handler

--- a/desktop/src/components/content/file_viewer.rs
+++ b/desktop/src/components/content/file_viewer.rs
@@ -410,13 +410,23 @@ async fn scroll_to_heading(heading_id: &str, smooth: bool) {
         (() => {{
             const headingId = {heading_id_json};
             const behavior = {behavior_json};
+            const scrollWithinContent = (el) => {{
+                const content = document.querySelector('.content');
+                if (!content || !el) {{
+                    return false;
+                }}
+                const contentRect = content.getBoundingClientRect();
+                const elRect = el.getBoundingClientRect();
+                const top = content.scrollTop + (elRect.top - contentRect.top);
+                content.scrollTo({{ top, behavior }});
+                return true;
+            }};
             const scrollToHeading = () => {{
                 const el = document.getElementById(headingId);
                 if (!el) {{
                     return false;
                 }}
-                el.scrollIntoView({{ behavior, block: 'start' }});
-                return true;
+                return scrollWithinContent(el);
             }};
 
             if (scrollToHeading()) {{

--- a/desktop/src/components/content/preferences_view/tabs/right_sidebar_tab.rs
+++ b/desktop/src/components/content/preferences_view/tabs/right_sidebar_tab.rs
@@ -1,7 +1,6 @@
 use super::super::form_controls::{OptionCardItem, OptionCards, SliderInput};
-use crate::components::right_sidebar::RightSidebarTab as RightSidebarTabKind;
 use crate::config::{normalize_zoom_level, Config, NewWindowBehavior, StartupBehavior};
-use crate::state::AppState;
+use crate::state::{AppState, SidebarPanel};
 use dioxus::prelude::*;
 
 #[component]
@@ -88,20 +87,26 @@ pub fn RightSidebarTab(
                     options: vec![
                         OptionCardItem {
                             icon: None,
-                            value: RightSidebarTabKind::Contents,
+                            value: SidebarPanel::Directory,
+                            title: "Directory".to_string(),
+                            description: Some("Show file directory tree".to_string()),
+                        },
+                        OptionCardItem {
+                            icon: None,
+                            value: SidebarPanel::Contents,
                             title: "Contents".to_string(),
                             description: Some("Show table of contents".to_string()),
                         },
                         OptionCardItem {
                             icon: None,
-                            value: RightSidebarTabKind::Search,
+                            value: SidebarPanel::Search,
                             title: "Search".to_string(),
                             description: Some("Show document search".to_string()),
                         },
                     ],
-                    selected: right_sidebar_cfg.default_tab,
+                    selected: right_sidebar_cfg.default_panel,
                     on_change: move |new_tab| {
-                        config.write().right_sidebar.default_tab = new_tab;
+                        config.write().right_sidebar.default_panel = new_tab;
                         has_changes.set(true);
                     },
                 }

--- a/desktop/src/components/content/preferences_view/tabs/sidebar_tab.rs
+++ b/desktop/src/components/content/preferences_view/tabs/sidebar_tab.rs
@@ -1,6 +1,6 @@
 use super::super::form_controls::{OptionCardItem, OptionCards, SliderInput};
 use crate::config::{normalize_zoom_level, Config, NewWindowBehavior, StartupBehavior};
-use crate::state::AppState;
+use crate::state::{AppState, SidebarPanel};
 use dioxus::prelude::*;
 
 #[component]
@@ -70,6 +70,43 @@ pub fn SidebarTab(
                     selected: sidebar_cfg.default_pinned,
                     on_change: move |new_state| {
                         config.write().sidebar.default_pinned = new_state;
+                        has_changes.set(true);
+                    },
+                }
+            }
+
+            div {
+                class: "preference-item",
+                div {
+                    class: "preference-item-header",
+                    label { "Default Panel" }
+                    p { class: "preference-description", "Which content the left sidebar shows by default." }
+                }
+                OptionCards {
+                    name: "sidebar-default-panel".to_string(),
+                    options: vec![
+                        OptionCardItem {
+                            icon: None,
+                            value: SidebarPanel::Directory,
+                            title: "Directory".to_string(),
+                            description: Some("Show the file directory tree".to_string()),
+                        },
+                        OptionCardItem {
+                            icon: None,
+                            value: SidebarPanel::Contents,
+                            title: "Contents".to_string(),
+                            description: Some("Show markdown table of contents".to_string()),
+                        },
+                        OptionCardItem {
+                            icon: None,
+                            value: SidebarPanel::Search,
+                            title: "Search".to_string(),
+                            description: Some("Show document search results".to_string()),
+                        },
+                    ],
+                    selected: sidebar_cfg.default_panel,
+                    on_change: move |new_panel| {
+                        config.write().sidebar.default_panel = new_panel;
                         has_changes.set(true);
                     },
                 }

--- a/desktop/src/components/main_app.rs
+++ b/desktop/src/components/main_app.rs
@@ -68,6 +68,7 @@ pub fn MainApp() -> Element {
     // Get initial configuration values
     let directory_pref = settings::get_directory_preference(is_first_window);
     let theme_pref = settings::get_theme_preference(is_first_window);
+    let position_pref = settings::get_window_position_preference(is_first_window);
     let sidebar_pref = settings::get_sidebar_preference(is_first_window);
     let right_sidebar_pref = settings::get_right_sidebar_preference(is_first_window);
     let zoom_pref = settings::get_zoom_preference(is_first_window);
@@ -90,13 +91,15 @@ pub fn MainApp() -> Element {
             tabs: tabs,
             directory: directory,
             theme: theme_pref.theme,
+            initial_window_position: position_pref.position,
             sidebar_pinned: sidebar_pref.pinned,
+            sidebar_panel: sidebar_pref.panel,
             sidebar_width: sidebar_pref.width,
             sidebar_show_all_files: sidebar_pref.show_all_files,
             sidebar_zoom_level: sidebar_pref.zoom_level,
             right_sidebar_pinned: right_sidebar_pref.pinned,
             right_sidebar_width: right_sidebar_pref.width,
-            right_sidebar_tab: right_sidebar_pref.tab,
+            right_sidebar_panel: right_sidebar_pref.panel,
             right_sidebar_zoom_level: right_sidebar_pref.zoom_level,
             zoom_level: zoom_pref.zoom_level,
         }

--- a/desktop/src/components/main_app.rs
+++ b/desktop/src/components/main_app.rs
@@ -42,26 +42,37 @@ pub fn MainApp() -> Element {
 
     // Pop the first event from IPC queue (CLI path pushed by main.rs before launch)
     let first_event = crate::ipc::try_pop_first_event();
+    let persisted = crate::state::PersistedState::load();
     if first_event.is_some() {
         tracing::debug!(?first_event, "Received initial open event from IPC queue");
     } else {
-        tracing::debug!("No initial event, will show welcome screen");
+        tracing::debug!("No initial event, will restore previous session if available");
     }
 
     // Resolve initial tabs and directory from event
     let is_first_window = true;
-    let (tabs, directory_override) = match &first_event {
+    let (tabs, active_tab, directory_override) = match &first_event {
         Some(OpenEvent::Open(request)) => {
             let tabs = if request.files.is_empty() {
                 vec![Tab::default()]
             } else {
                 request.files.iter().cloned().map(Tab::new).collect()
             };
-            (tabs, request.directory.clone())
+            (tabs, 0, request.directory.clone())
+        }
+        _ if !persisted.open_files.is_empty() => {
+            let tabs = persisted.restored_open_tabs();
+            let active_tab = persisted.restored_active_tab();
+            tracing::debug!(
+                tab_count = tabs.len(),
+                active_tab,
+                "Restoring previous file session"
+            );
+            (tabs, active_tab, None)
         }
         _ => {
             let welcome_content = crate::assets::get_default_markdown_content();
-            (vec![Tab::with_inline_content(welcome_content)], None)
+            (vec![Tab::with_inline_content(welcome_content)], 0, None)
         }
     };
 
@@ -89,6 +100,7 @@ pub fn MainApp() -> Element {
     rsx! {
         crate::components::app::App {
             tabs: tabs,
+            active_tab: active_tab,
             directory: directory,
             theme: theme_pref.theme,
             initial_window_position: position_pref.position,

--- a/desktop/src/components/right_sidebar.rs
+++ b/desktop/src/components/right_sidebar.rs
@@ -1,24 +1,15 @@
 use dioxus::prelude::*;
-use serde::{Deserialize, Serialize};
 
 mod contents_tab;
 mod search_tab;
 mod tab_bar;
 
-use contents_tab::ContentsTab;
-use search_tab::SearchTab;
+pub(crate) use contents_tab::ContentsTab;
+pub(crate) use search_tab::SearchTab;
 use tab_bar::TabBar;
 
 use crate::markdown::HeadingInfo;
-use crate::state::{AppState, FocusedPanel};
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum RightSidebarTab {
-    #[default]
-    Contents,
-    Search,
-}
+use crate::state::{AppState, FocusedPanel, SidebarPanel};
 
 #[derive(Props, Clone, PartialEq)]
 pub struct RightSidebarProps {
@@ -31,7 +22,7 @@ pub struct RightSidebarProps {
 pub fn RightSidebar(props: RightSidebarProps) -> Element {
     let mut state = use_context::<AppState>();
     let width = *state.right_sidebar_width.read();
-    let active_tab = *state.right_sidebar_tab.read();
+    let active_panel = *state.right_sidebar_panel.read();
     let zoom_level = *state.right_sidebar_zoom_level.read();
     let is_panel_focused = *state.focused_panel.read() == FocusedPanel::RightSidebar;
     let toc_cursor = *state.toc_cursor.read();
@@ -60,8 +51,8 @@ pub fn RightSidebar(props: RightSidebarProps) -> Element {
 
                 // Tab bar
                 TabBar {
-                    active_tab,
-                    on_change: move |tab| state.set_right_sidebar_tab(tab),
+                    active_panel,
+                    on_change: move |panel| state.set_right_sidebar_panel(panel),
                     on_pin_toggle: props.on_pin_toggle,
                 }
 
@@ -69,14 +60,19 @@ pub fn RightSidebar(props: RightSidebarProps) -> Element {
                 div {
                     class: "right-sidebar-content",
 
-                    match active_tab {
-                        RightSidebarTab::Contents => rsx! {
+                    match active_panel {
+                        SidebarPanel::Directory => rsx! {
+                            crate::components::sidebar::file_explorer::FileExplorer {
+                                on_pin_toggle: None,
+                            }
+                        },
+                        SidebarPanel::Contents => rsx! {
                             ContentsTab {
                                 headings,
                                 cursor_index: if is_panel_focused { toc_cursor } else { None },
                             }
                         },
-                        RightSidebarTab::Search => rsx! { SearchTab {} },
+                        SidebarPanel::Search => rsx! { SearchTab {} },
                     }
                 }
             }

--- a/desktop/src/components/right_sidebar/contents_tab.rs
+++ b/desktop/src/components/right_sidebar/contents_tab.rs
@@ -49,9 +49,13 @@ fn HeadingItem(heading: HeadingInfo, is_keyboard_focused: bool) -> Element {
                         let js = format!(
                             r#"
                             (() => {{
+                                const content = document.querySelector('.content');
                                 const el = document.getElementById({id_json});
-                                if (el) {{
-                                    el.scrollIntoView({{ behavior: 'smooth', block: 'start' }});
+                                if (content && el) {{
+                                    const contentRect = content.getBoundingClientRect();
+                                    const elRect = el.getBoundingClientRect();
+                                    const top = content.scrollTop + (elRect.top - contentRect.top);
+                                    content.scrollTo({{ top, behavior: 'smooth' }});
                                 }}
                             }})();
                             "#,

--- a/desktop/src/components/right_sidebar/tab_bar.rs
+++ b/desktop/src/components/right_sidebar/tab_bar.rs
@@ -1,13 +1,12 @@
 use dioxus::prelude::*;
 
-use super::RightSidebarTab;
 use crate::components::icon::{Icon, IconName};
-use crate::state::AppState;
+use crate::state::{AppState, SidebarPanel};
 
 #[component]
 pub fn TabBar(
-    active_tab: RightSidebarTab,
-    on_change: EventHandler<RightSidebarTab>,
+    active_panel: SidebarPanel,
+    on_change: EventHandler<SidebarPanel>,
     on_pin_toggle: Option<EventHandler<()>>,
 ) -> Element {
     let state = use_context::<AppState>();
@@ -18,15 +17,20 @@ pub fn TabBar(
 
             // Contents tab
             button {
-                class: if active_tab == RightSidebarTab::Contents { "right-sidebar-tab active" } else { "right-sidebar-tab" },
-                onclick: move |_| on_change.call(RightSidebarTab::Contents),
+                class: if active_panel == SidebarPanel::Directory { "right-sidebar-tab active" } else { "right-sidebar-tab" },
+                onclick: move |_| on_change.call(SidebarPanel::Directory),
+                span { "Directory" }
+            }
+
+            button {
+                class: if active_panel == SidebarPanel::Contents { "right-sidebar-tab active" } else { "right-sidebar-tab" },
+                onclick: move |_| on_change.call(SidebarPanel::Contents),
                 span { "Contents" }
             }
 
-            // Search tab
             button {
-                class: if active_tab == RightSidebarTab::Search { "right-sidebar-tab active" } else { "right-sidebar-tab" },
-                onclick: move |_| on_change.call(RightSidebarTab::Search),
+                class: if active_panel == SidebarPanel::Search { "right-sidebar-tab active" } else { "right-sidebar-tab" },
+                onclick: move |_| on_change.call(SidebarPanel::Search),
                 span { "Search" }
             }
 

--- a/desktop/src/components/right_sidebar/tab_bar.rs
+++ b/desktop/src/components/right_sidebar/tab_bar.rs
@@ -15,23 +15,26 @@ pub fn TabBar(
         div {
             class: "right-sidebar-tabs",
 
-            // Contents tab
-            button {
-                class: if active_panel == SidebarPanel::Directory { "right-sidebar-tab active" } else { "right-sidebar-tab" },
-                onclick: move |_| on_change.call(SidebarPanel::Directory),
-                span { "Directory" }
-            }
+            div {
+                class: "right-sidebar-tab-list",
 
-            button {
-                class: if active_panel == SidebarPanel::Contents { "right-sidebar-tab active" } else { "right-sidebar-tab" },
-                onclick: move |_| on_change.call(SidebarPanel::Contents),
-                span { "Contents" }
-            }
+                button {
+                    class: if active_panel == SidebarPanel::Directory { "right-sidebar-tab active" } else { "right-sidebar-tab" },
+                    onclick: move |_| on_change.call(SidebarPanel::Directory),
+                    span { "Directory" }
+                }
 
-            button {
-                class: if active_panel == SidebarPanel::Search { "right-sidebar-tab active" } else { "right-sidebar-tab" },
-                onclick: move |_| on_change.call(SidebarPanel::Search),
-                span { "Search" }
+                button {
+                    class: if active_panel == SidebarPanel::Contents { "right-sidebar-tab active" } else { "right-sidebar-tab" },
+                    onclick: move |_| on_change.call(SidebarPanel::Contents),
+                    span { "Contents" }
+                }
+
+                button {
+                    class: if active_panel == SidebarPanel::Search { "right-sidebar-tab active" } else { "right-sidebar-tab" },
+                    onclick: move |_| on_change.call(SidebarPanel::Search),
+                    span { "Search" }
+                }
             }
 
             // Pin/Unpin button

--- a/desktop/src/components/sidebar.rs
+++ b/desktop/src/components/sidebar.rs
@@ -82,22 +82,30 @@ pub fn Sidebar(
                 }
 
                 match active_panel {
-                    SidebarPanel::Directory => rsx! {
-                        file_explorer::FileExplorer {
-                            on_pin_toggle: None,
+                    panel => rsx! {
+                        div {
+                            class: "right-sidebar-content",
+
+                            match panel {
+                                SidebarPanel::Directory => rsx! {
+                                    file_explorer::FileExplorer {
+                                        on_pin_toggle: None,
+                                    }
+                                },
+                                SidebarPanel::Contents => rsx! {
+                                    ContentsTab {
+                                        headings,
+                                        cursor_index: if focused_panel == FocusedPanel::LeftSidebar {
+                                            toc_cursor
+                                        } else {
+                                            None
+                                        },
+                                    }
+                                },
+                                SidebarPanel::Search => rsx! { SearchTab {} },
+                            }
                         }
                     },
-                    SidebarPanel::Contents => rsx! {
-                        ContentsTab {
-                            headings,
-                            cursor_index: if focused_panel == FocusedPanel::LeftSidebar {
-                                toc_cursor
-                            } else {
-                                None
-                            },
-                        }
-                    },
-                    SidebarPanel::Search => rsx! { SearchTab {} },
                 }
             }
 

--- a/desktop/src/components/sidebar.rs
+++ b/desktop/src/components/sidebar.rs
@@ -5,7 +5,8 @@ pub mod quick_access;
 use dioxus::document;
 use dioxus::prelude::*;
 
-use crate::state::{AppState, FocusedPanel};
+use super::right_sidebar::{ContentsTab, SearchTab};
+use crate::state::{AppState, FocusedPanel, SidebarPanel};
 
 #[component]
 pub fn Sidebar(
@@ -17,10 +18,14 @@ pub fn Sidebar(
     let width = sidebar_state.width;
     let zoom_level = sidebar_state.zoom_level;
     drop(sidebar_state);
+    let active_panel = *state.left_sidebar_panel.read();
     let focused_panel = *state.focused_panel.read();
     let is_panel_focused =
         focused_panel == FocusedPanel::LeftSidebar || focused_panel == FocusedPanel::QuickAccess;
     let mut is_resizing = use_signal(|| false);
+    let headings = state.right_sidebar_headings.read().clone();
+    let toc_cursor = *state.toc_cursor.read();
+    let is_pinned = state.sidebar.read().pinned;
 
     let outer_style = format!("width: {}px;", width);
     let inner_style = format!("zoom: {};", zoom_level);
@@ -37,9 +42,62 @@ pub fn Sidebar(
                 class: "left-sidebar-inner",
                 style: "{inner_style}",
 
-                // File explorer content (always mounted for animation)
-                file_explorer::FileExplorer {
-                    on_pin_toggle,
+                div {
+                    class: "right-sidebar-tabs",
+
+                    button {
+                        class: if active_panel == SidebarPanel::Directory { "right-sidebar-tab active" } else { "right-sidebar-tab" },
+                        onclick: move |_| state.set_left_sidebar_panel(SidebarPanel::Directory),
+                        span { "Directory" }
+                    }
+
+                    button {
+                        class: if active_panel == SidebarPanel::Contents { "right-sidebar-tab active" } else { "right-sidebar-tab" },
+                        onclick: move |_| state.set_left_sidebar_panel(SidebarPanel::Contents),
+                        span { "Contents" }
+                    }
+
+                    button {
+                        class: if active_panel == SidebarPanel::Search { "right-sidebar-tab active" } else { "right-sidebar-tab" },
+                        onclick: move |_| state.set_left_sidebar_panel(SidebarPanel::Search),
+                        span { "Search" }
+                    }
+
+                    if let Some(handler) = on_pin_toggle {
+                        button {
+                            class: "right-sidebar-pin-button",
+                            class: if is_pinned { "pinned" },
+                            title: if is_pinned { "Unpin sidebar" } else { "Pin sidebar" },
+                            onclick: move |_| handler.call(()),
+                            crate::components::icon::Icon {
+                                name: if is_pinned {
+                                    crate::components::icon::IconName::PinFilled
+                                } else {
+                                    crate::components::icon::IconName::Pin
+                                },
+                                size: 20,
+                            }
+                        }
+                    }
+                }
+
+                match active_panel {
+                    SidebarPanel::Directory => rsx! {
+                        file_explorer::FileExplorer {
+                            on_pin_toggle: None,
+                        }
+                    },
+                    SidebarPanel::Contents => rsx! {
+                        ContentsTab {
+                            headings,
+                            cursor_index: if focused_panel == FocusedPanel::LeftSidebar {
+                                toc_cursor
+                            } else {
+                                None
+                            },
+                        }
+                    },
+                    SidebarPanel::Search => rsx! { SearchTab {} },
                 }
             }
 

--- a/desktop/src/components/tab/tab_bar.rs
+++ b/desktop/src/components/tab/tab_bar.rs
@@ -203,6 +203,7 @@ pub fn TabBar() -> Element {
     let mut state = use_context::<AppState>();
     let tabs = state.tabs.read().clone();
     let active_tab_index = *state.active_tab.read();
+    let show_traffic_light_gap = cfg!(target_os = "macos") && !state.sidebar.read().pinned;
 
     // Local drag state - only tracks pending state before threshold
     // Once active, global ACTIVE_DRAG takes over
@@ -357,9 +358,22 @@ pub fn TabBar() -> Element {
         None
     };
 
+    let start_window_drag = move |evt: Event<MouseData>| {
+        let button = evt.data().trigger_button();
+        if matches!(
+            button,
+            Some(dioxus::html::input_data::MouseButton::Primary) | None
+        ) {
+            evt.prevent_default();
+            evt.stop_propagation();
+            window().drag();
+        }
+    };
+
     rsx! {
         div {
             class: "tab-bar",
+            class: if cfg!(target_os = "macos") { "native-titlebar" },
             class: if is_dragging { "dragging" },
             tabindex: "0",
             onkeydown: handle_keydown,
@@ -370,32 +384,59 @@ pub fn TabBar() -> Element {
                 tab_bar_element.set(Some(evt.data()));
             },
 
-            // Render tabs with drag support
-            for (index, tab) in tabs.iter().enumerate() {
-                TabItem {
-                    key: "{index}",
-                    index,
-                    tab: tab.clone(),
-                    shift_class: calculate_shift_class(is_target_window, drag_target_index, index),
-                    is_active: index == active_tab_index,
-                    on_drag_start: move |pending: PendingDrag| {
-                        local_drag_state.set(LocalDragState::Pending(pending));
-                    },
-                }
-            }
-
-            // Placeholder at end (always present during drag to push [+] button)
-            if drag_target_index.is_some() {
+            if show_traffic_light_gap {
                 div {
-                    class: "tab placeholder",
+                    class: "tab-bar-traffic-light-gap",
+                    onmousedown: start_window_drag,
                 }
             }
 
-            // New tab button
-            NewTabButton {}
+            div {
+                class: "tab-strip",
 
-            // Preferences button
-            PreferencesButton {}
+                // Render tabs with drag support
+                for (index, tab) in tabs.iter().enumerate() {
+                    TabItem {
+                        key: "{index}",
+                        index,
+                        tab: tab.clone(),
+                        shift_class: calculate_shift_class(is_target_window, drag_target_index, index),
+                        is_active: index == active_tab_index,
+                        on_drag_start: move |pending: PendingDrag| {
+                            local_drag_state.set(LocalDragState::Pending(pending));
+                        },
+                    }
+                }
+
+                // Placeholder at end (always present during drag to push [+] button)
+                if drag_target_index.is_some() {
+                    div {
+                        class: "tab placeholder",
+                    }
+                }
+            }
+
+            div {
+                class: "tab-bar-drag-spacer",
+                onmousedown: start_window_drag,
+            }
+
+            div {
+                class: "tab-bar-controls",
+
+                // New tab button
+                NewTabButton {}
+
+                // Preferences button
+                PreferencesButton {}
+            }
+
+            if cfg!(target_os = "macos") {
+                div {
+                    class: "tab-bar-drag-spacer",
+                    onmousedown: start_window_drag,
+                }
+            }
         }
 
         // Drag overlay for capturing events (shown during any active drag)

--- a/desktop/src/config/app_config.rs
+++ b/desktop/src/config/app_config.rs
@@ -49,6 +49,7 @@ pub struct Config {
 mod tests {
     use super::window_position_config::WindowPositionOffset;
     use super::*;
+    use crate::state::SidebarPanel;
     use crate::theme::Theme;
     use std::path::PathBuf;
 
@@ -81,6 +82,7 @@ mod tests {
 
         // Sidebar defaults
         assert!(!config.sidebar.default_pinned); // Default is false (unpinned, overlay on hover)
+        assert_eq!(config.sidebar.default_panel, SidebarPanel::Directory);
         assert_eq!(config.sidebar.default_width, 280.0);
         assert!(!config.sidebar.default_show_all_files);
         assert_eq!(config.sidebar.default_zoom_level, 1.0);
@@ -89,6 +91,7 @@ mod tests {
 
         // Right sidebar defaults
         assert!(!config.right_sidebar.default_pinned);
+        assert_eq!(config.right_sidebar.default_panel, SidebarPanel::Contents);
         assert_eq!(config.right_sidebar.default_width, 220.0);
         assert_eq!(config.right_sidebar.default_zoom_level, 1.0);
         assert_eq!(config.right_sidebar.on_startup, StartupBehavior::Default);
@@ -162,6 +165,7 @@ mod tests {
             },
             sidebar: SidebarConfig {
                 default_pinned: false,
+                default_panel: SidebarPanel::Search,
                 default_width: 320.0,
                 default_show_all_files: true,
                 default_zoom_level: 1.2,
@@ -171,7 +175,7 @@ mod tests {
             right_sidebar: RightSidebarConfig {
                 default_pinned: true,
                 default_width: 250.0,
-                default_tab: Default::default(),
+                default_panel: SidebarPanel::Directory,
                 default_zoom_level: 0.8,
                 on_startup: StartupBehavior::LastClosed,
                 on_new_window: NewWindowBehavior::LastFocused,
@@ -232,9 +236,11 @@ mod tests {
             Some(PathBuf::from("/home/user"))
         );
         assert!(!parsed.sidebar.default_pinned);
+        assert_eq!(parsed.sidebar.default_panel, SidebarPanel::Search);
         assert_eq!(parsed.sidebar.default_width, 320.0);
         assert_eq!(parsed.sidebar.default_zoom_level, 1.2);
         assert!(parsed.right_sidebar.default_pinned);
+        assert_eq!(parsed.right_sidebar.default_panel, SidebarPanel::Directory);
         assert_eq!(parsed.right_sidebar.default_width, 250.0);
         assert_eq!(parsed.right_sidebar.default_zoom_level, 0.8);
         assert_eq!(parsed.window_position.default_position.x.value, 10.0);

--- a/desktop/src/config/app_config/right_sidebar_config.rs
+++ b/desktop/src/config/app_config/right_sidebar_config.rs
@@ -1,5 +1,5 @@
 use super::behavior::{NewWindowBehavior, StartupBehavior};
-use crate::components::right_sidebar::RightSidebarTab;
+use crate::state::SidebarPanel;
 use serde::{Deserialize, Serialize};
 
 /// Default right sidebar panel width in pixels
@@ -16,6 +16,10 @@ fn default_right_sidebar_zoom_level() -> f64 {
     DEFAULT_RIGHT_SIDEBAR_ZOOM_LEVEL
 }
 
+fn default_right_sidebar_panel() -> SidebarPanel {
+    SidebarPanel::Contents
+}
+
 /// Configuration for right sidebar panel settings
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -25,9 +29,9 @@ pub struct RightSidebarConfig {
     /// Default right sidebar panel width in pixels
     #[serde(default = "default_right_sidebar_width")]
     pub default_width: f64,
-    /// Default active tab
-    #[serde(default)]
-    pub default_tab: RightSidebarTab,
+    /// Default panel content
+    #[serde(default = "default_right_sidebar_panel", alias = "defaultTab")]
+    pub default_panel: SidebarPanel,
     /// Default zoom level for right sidebar content
     #[serde(default = "default_right_sidebar_zoom_level")]
     pub default_zoom_level: f64,
@@ -42,7 +46,7 @@ impl Default for RightSidebarConfig {
         Self {
             default_pinned: false,
             default_width: default_right_sidebar_width(),
-            default_tab: RightSidebarTab::default(),
+            default_panel: default_right_sidebar_panel(),
             default_zoom_level: default_right_sidebar_zoom_level(),
             on_startup: StartupBehavior::Default,
             on_new_window: NewWindowBehavior::Default,

--- a/desktop/src/config/app_config/sidebar_config.rs
+++ b/desktop/src/config/app_config/sidebar_config.rs
@@ -1,4 +1,5 @@
 use super::behavior::{NewWindowBehavior, StartupBehavior};
+use crate::state::SidebarPanel;
 use serde::{Deserialize, Serialize};
 
 /// Default sidebar width in pixels
@@ -41,6 +42,9 @@ pub fn normalize_zoom_level(zoom: f64) -> f64 {
 pub struct SidebarConfig {
     /// Whether sidebar is pinned to the layout by default
     pub default_pinned: bool,
+    /// Default panel content
+    #[serde(default)]
+    pub default_panel: SidebarPanel,
     /// Default sidebar width in pixels
     #[serde(default = "default_sidebar_width")]
     pub default_width: f64,
@@ -59,6 +63,7 @@ impl Default for SidebarConfig {
     fn default() -> Self {
         Self {
             default_pinned: false,
+            default_panel: SidebarPanel::Directory,
             default_width: default_sidebar_width(),
             default_show_all_files: false,
             default_zoom_level: default_sidebar_zoom_level(),

--- a/desktop/src/ipc.rs
+++ b/desktop/src/ipc.rs
@@ -202,6 +202,7 @@ fn open_request_with_behavior(
 fn apply_open_request_to_state(state: &mut crate::state::AppState, request: &OpenRequest) {
     if let Some(directory) = request.directory.as_ref() {
         state.set_root_directory(directory.clone());
+        state.set_left_sidebar_panel(crate::state::SidebarPanel::Directory);
     }
     for path in &request.files {
         state.open_file(path);

--- a/desktop/src/keybindings/dispatcher.rs
+++ b/desktop/src/keybindings/dispatcher.rs
@@ -1096,13 +1096,24 @@ fn open_link_from_cursor(state: &mut AppState, open_in_new_tab: bool) {
             return;
         }
 
-        let target_path = base_dir.join(&href);
-        if let Ok(canonical) = target_path.canonicalize() {
-            if open_in_new_tab {
-                app_state.add_file_tab(canonical, true);
+        let Some(current_file) = get_current_file(&app_state) else {
+            return;
+        };
+        let Some(resolved_link) =
+            crate::utils::markdown_link::resolve_markdown_link(&base_dir, &current_file, &href)
+        else {
+            return;
+        };
+
+        if open_in_new_tab {
+            if let Some(heading_id) = resolved_link.heading_id {
+                app_state.set_pending_heading_navigation(resolved_link.path.clone(), heading_id);
             } else {
-                app_state.navigate_to_file(canonical);
+                app_state.clear_pending_heading_navigation();
             }
+            app_state.add_file_tab(resolved_link.path, true);
+        } else {
+            app_state.navigate_to_file_at_heading(resolved_link.path, resolved_link.heading_id);
         }
     });
 }

--- a/desktop/src/keybindings/dispatcher.rs
+++ b/desktop/src/keybindings/dispatcher.rs
@@ -1,10 +1,9 @@
 use dioxus::document;
 use dioxus::prelude::*;
 
-use crate::components::right_sidebar::RightSidebarTab;
 use crate::pinned_search::add_pinned_search;
 use crate::state::sidebar_cursor;
-use crate::state::{AppState, FocusedPanel};
+use crate::state::{AppState, FocusedPanel, SidebarPanel};
 use crate::theme::Theme;
 use crate::window::settings::normalize_zoom_level;
 
@@ -160,15 +159,7 @@ pub fn dispatch_action(action: &Action, mut state: AppState) {
                 state.right_hover_active.set(false);
             }
             state.focused_panel.set(FocusedPanel::LeftSidebar);
-            // Initialize cursor to first item if not set
-            if state.sidebar_cursor.read().is_none() {
-                if let Some((root, expanded, show_all)) = extract_sidebar_data(&state) {
-                    let items = sidebar_cursor::visible_items(&root, &expanded, show_all);
-                    if let Some(first) = items.first() {
-                        state.sidebar_cursor.set(Some(first.clone()));
-                    }
-                }
-            }
+            initialize_sidebar_focus(&mut state, FocusedPanel::LeftSidebar);
         }
         Action::FocusRightSidebar => {
             // Show overlay if not pinned, then focus it
@@ -177,11 +168,7 @@ pub fn dispatch_action(action: &Action, mut state: AppState) {
                 state.left_hover_active.set(false);
             }
             state.focused_panel.set(FocusedPanel::RightSidebar);
-            // Initialize cursor to first heading if not set
-            if state.toc_cursor.read().is_none() && !state.right_sidebar_headings.read().is_empty()
-            {
-                state.toc_cursor.set(Some(0));
-            }
+            initialize_sidebar_focus(&mut state, FocusedPanel::RightSidebar);
         }
         Action::FocusQuickAccess => {
             // Show overlay if not pinned (quick access is part of sidebar)
@@ -259,7 +246,7 @@ pub fn dispatch_action(action: &Action, mut state: AppState) {
             state.open_preferences();
         }
         Action::AppQuit => {
-            dioxus::desktop::window().close();
+            crate::window::shutdown_all_windows();
         }
         Action::AppGoToHomepage => {
             let _ = open::that("https://github.com/arto-app/Arto");
@@ -278,7 +265,7 @@ pub fn dispatch_action(action: &Action, mut state: AppState) {
                 state.right_hover_active.set(true);
                 state.left_hover_active.set(false);
             }
-            state.set_right_sidebar_tab(RightSidebarTab::Contents);
+            state.set_right_sidebar_panel(SidebarPanel::Contents);
             state.focused_panel.set(FocusedPanel::RightSidebar);
         }
         Action::RightSidebarShowSearch => {
@@ -286,7 +273,7 @@ pub fn dispatch_action(action: &Action, mut state: AppState) {
                 state.right_hover_active.set(true);
                 state.left_hover_active.set(false);
             }
-            state.set_right_sidebar_tab(RightSidebarTab::Search);
+            state.set_right_sidebar_panel(SidebarPanel::Search);
             state.focused_panel.set(FocusedPanel::RightSidebar);
         }
 
@@ -342,11 +329,12 @@ fn dispatch_tab_cycle(state: &mut AppState, forward: bool) {
 
 /// Cycle the right sidebar between Contents and Search tabs.
 fn toggle_right_sidebar_tab(state: &mut AppState) {
-    let tab = match *state.right_sidebar_tab.read() {
-        RightSidebarTab::Contents => RightSidebarTab::Search,
-        RightSidebarTab::Search => RightSidebarTab::Contents,
+    let panel = match *state.right_sidebar_panel.read() {
+        SidebarPanel::Directory => SidebarPanel::Contents,
+        SidebarPanel::Contents => SidebarPanel::Search,
+        SidebarPanel::Search => SidebarPanel::Directory,
     };
-    state.set_right_sidebar_tab(tab);
+    state.set_right_sidebar_panel(panel);
 }
 
 enum CursorDirection {
@@ -357,26 +345,31 @@ enum CursorDirection {
 fn dispatch_cursor_move(state: &mut AppState, direction: CursorDirection) {
     let panel = *state.focused_panel.read();
     match panel {
-        FocusedPanel::LeftSidebar => {
-            if let Some((root, expanded, show_all)) = extract_sidebar_data(state) {
-                let items = sidebar_cursor::visible_items(&root, &expanded, show_all);
-                let current = state.sidebar_cursor.read().clone();
-                let next = match direction {
-                    CursorDirection::Down => sidebar_cursor::move_down(&current, &items),
-                    CursorDirection::Up => sidebar_cursor::move_up(&current, &items),
-                };
-                state.sidebar_cursor.set(next);
-                scroll_cursor_into_view();
-            }
-        }
-        FocusedPanel::RightSidebar => {
-            let headings_len = state.right_sidebar_headings.read().len();
-            if headings_len > 0 {
-                let current = *state.toc_cursor.read();
-                state
-                    .toc_cursor
-                    .set(move_index_cursor(current, headings_len, &direction));
-                scroll_cursor_into_view();
+        FocusedPanel::LeftSidebar | FocusedPanel::RightSidebar => {
+            match active_sidebar_panel(state, panel) {
+                SidebarPanel::Directory => {
+                    if let Some((root, expanded, show_all)) = extract_sidebar_data(state) {
+                        let items = sidebar_cursor::visible_items(&root, &expanded, show_all);
+                        let current = state.sidebar_cursor.read().clone();
+                        let next = match direction {
+                            CursorDirection::Down => sidebar_cursor::move_down(&current, &items),
+                            CursorDirection::Up => sidebar_cursor::move_up(&current, &items),
+                        };
+                        state.sidebar_cursor.set(next);
+                        scroll_cursor_into_view();
+                    }
+                }
+                SidebarPanel::Contents => {
+                    let headings_len = state.right_sidebar_headings.read().len();
+                    if headings_len > 0 {
+                        let current = *state.toc_cursor.read();
+                        state
+                            .toc_cursor
+                            .set(move_index_cursor(current, headings_len, &direction));
+                        scroll_cursor_into_view();
+                    }
+                }
+                SidebarPanel::Search => {}
             }
         }
         FocusedPanel::QuickAccess => {
@@ -420,17 +413,21 @@ fn move_index_cursor(
 fn dispatch_cursor_enter(state: &mut AppState) {
     let panel = *state.focused_panel.read();
     match panel {
-        FocusedPanel::LeftSidebar => {
-            let cursor = state.sidebar_cursor.read().clone();
-            let Some(path) = cursor else { return };
-            if path.is_dir() {
-                state.set_root_directory(&path);
-            } else {
-                state.open_file(&path);
+        FocusedPanel::LeftSidebar | FocusedPanel::RightSidebar => {
+            match active_sidebar_panel(state, panel) {
+                SidebarPanel::Directory => {
+                    let cursor = state.sidebar_cursor.read().clone();
+                    let Some(path) = cursor else { return };
+                    if path.is_dir() {
+                        state.set_root_directory(&path);
+                    } else {
+                        state.open_file(&path);
+                    }
+                }
+                SidebarPanel::Contents => open_right_sidebar(state),
+                SidebarPanel::Search => {}
             }
         }
-        // Right sidebar & quick access: same as cursor.open (scroll to heading / open bookmark)
-        FocusedPanel::RightSidebar => open_right_sidebar(state),
         FocusedPanel::QuickAccess => open_quick_access(state),
         FocusedPanel::Content => {}
     }
@@ -440,8 +437,13 @@ fn dispatch_cursor_enter(state: &mut AppState) {
 fn dispatch_cursor_open(state: &mut AppState) {
     let panel = *state.focused_panel.read();
     match panel {
-        FocusedPanel::LeftSidebar => open_sidebar(state),
-        FocusedPanel::RightSidebar => open_right_sidebar(state),
+        FocusedPanel::LeftSidebar | FocusedPanel::RightSidebar => {
+            match active_sidebar_panel(state, panel) {
+                SidebarPanel::Directory => open_sidebar(state),
+                SidebarPanel::Contents => open_right_sidebar(state),
+                SidebarPanel::Search => {}
+            }
+        }
         FocusedPanel::QuickAccess => open_quick_access(state),
         FocusedPanel::Content => {}
     }
@@ -535,16 +537,16 @@ fn open_quick_access(state: &mut AppState) {
 fn dispatch_cursor_collapse(state: &mut AppState) {
     let panel = *state.focused_panel.read();
     match panel {
-        FocusedPanel::LeftSidebar => {
+        FocusedPanel::LeftSidebar | FocusedPanel::RightSidebar
+            if active_sidebar_panel(state, panel) == SidebarPanel::Directory =>
+        {
             let cursor = state.sidebar_cursor.read().clone();
             if let Some(path) = cursor {
                 let is_expanded_dir =
                     { path.is_dir() && state.sidebar.read().expanded_dirs.contains(&path) };
                 if is_expanded_dir {
-                    // Collapse this directory
                     state.toggle_directory_expansion(&path);
                 } else {
-                    // Move cursor to parent directory in the visible list
                     let parent =
                         extract_sidebar_data(state).and_then(|(root, expanded, show_all)| {
                             let items = sidebar_cursor::visible_items(&root, &expanded, show_all);
@@ -558,7 +560,40 @@ fn dispatch_cursor_collapse(state: &mut AppState) {
             }
         }
         // No-op for other panels
-        FocusedPanel::RightSidebar | FocusedPanel::QuickAccess | FocusedPanel::Content => {}
+        FocusedPanel::LeftSidebar
+        | FocusedPanel::RightSidebar
+        | FocusedPanel::QuickAccess
+        | FocusedPanel::Content => {}
+    }
+}
+
+fn active_sidebar_panel(state: &AppState, focused_panel: FocusedPanel) -> SidebarPanel {
+    match focused_panel {
+        FocusedPanel::LeftSidebar => *state.left_sidebar_panel.read(),
+        FocusedPanel::RightSidebar => *state.right_sidebar_panel.read(),
+        FocusedPanel::QuickAccess | FocusedPanel::Content => SidebarPanel::Directory,
+    }
+}
+
+fn initialize_sidebar_focus(state: &mut AppState, focused_panel: FocusedPanel) {
+    match active_sidebar_panel(state, focused_panel) {
+        SidebarPanel::Directory => {
+            if state.sidebar_cursor.read().is_none() {
+                if let Some((root, expanded, show_all)) = extract_sidebar_data(state) {
+                    let items = sidebar_cursor::visible_items(&root, &expanded, show_all);
+                    if let Some(first) = items.first() {
+                        state.sidebar_cursor.set(Some(first.clone()));
+                    }
+                }
+            }
+        }
+        SidebarPanel::Contents => {
+            if state.toc_cursor.read().is_none() && !state.right_sidebar_headings.read().is_empty()
+            {
+                state.toc_cursor.set(Some(0));
+            }
+        }
+        SidebarPanel::Search => {}
     }
 }
 

--- a/desktop/src/keybindings/dispatcher.rs
+++ b/desktop/src/keybindings/dispatcher.rs
@@ -499,9 +499,13 @@ fn open_right_sidebar(state: &mut AppState) {
         let js = format!(
             r#"
             (() => {{
+                const content = document.querySelector('.content');
                 const el = document.getElementById({id_json});
-                if (el) {{
-                    el.scrollIntoView({{ behavior: 'smooth', block: 'start' }});
+                if (content && el) {{
+                    const contentRect = content.getBoundingClientRect();
+                    const elRect = el.getBoundingClientRect();
+                    const top = content.scrollTop + (elRect.top - contentRect.top);
+                    content.scrollTo({{ top, behavior: 'smooth' }});
                 }}
             }})();
             "#,

--- a/desktop/src/lib.rs
+++ b/desktop/src/lib.rs
@@ -97,6 +97,10 @@ pub fn run(invocation: cli::CliInvocation) -> RunResult {
                     ipc::push_event(ipc::OpenEvent::Reopen { behavior: None });
                     ipc::process_main_thread_tasks();
                 }
+                Event::LoopDestroyed => {
+                    tracing::debug!("Event::LoopDestroyed received");
+                    window::persist_preferred_main_window_state();
+                }
                 Event::WindowEvent {
                     event: WindowEvent::Focused(true),
                     window_id,

--- a/desktop/src/markdown.rs
+++ b/desktop/src/markdown.rs
@@ -3,6 +3,7 @@ mod autolinks;
 mod event_processors;
 mod frontmatter;
 mod headings;
+mod liquid;
 mod post_process;
 mod source_lines;
 
@@ -14,6 +15,7 @@ use anyhow::Result;
 use event_processors::{extend_table_ranges, process_code_blocks, process_math_expressions};
 use frontmatter::extract_and_render_frontmatter;
 use headings::extract_headings;
+use liquid::preprocess_liquid_includes;
 use post_process::{post_process_html_tags, post_process_html_with_headings};
 use pulldown_cmark::{html, Options, Parser};
 use source_lines::{extract_table_source_lines, inject_source_lines};
@@ -42,6 +44,9 @@ fn run_pipeline(markdown: &str, base_path: &Path, auto_link_urls: bool) -> Pipel
 
     // Extract frontmatter if present
     let (frontmatter_html, content, frontmatter_lines) = extract_and_render_frontmatter(markdown);
+
+    // Rewrite supported Liquid includes into plain HTML before Markdown parsing.
+    let content = preprocess_liquid_includes(&content);
 
     // Convert bare URLs to <URL> autolinks before any parsing (if enabled)
     let content = if auto_link_urls {
@@ -257,6 +262,23 @@ mod tests {
             result.contains("data-original-content"),
             "Should include data attributes"
         );
+    }
+
+    #[test]
+    fn test_render_to_html_with_figure_liquid_include() {
+        let temp_dir = TempDir::new().unwrap();
+        let assets_dir = temp_dir.path().join("assets").join("img");
+        fs::create_dir_all(&assets_dir).unwrap();
+        fs::write(assets_dir.join("example.png"), [0x89, 0x50, 0x4E, 0x47]).unwrap();
+
+        let markdown =
+            r#"{% include figure.liquid path="assets/img/example.png" class="img-fluid" %}"#;
+        let md_path = temp_dir.path().join("test.md");
+
+        let result = render_to_html(markdown, &md_path).unwrap();
+
+        assert!(result.contains("data:image/png;base64,"));
+        assert!(result.contains(r#"class="img-fluid""#));
     }
 
     #[test]

--- a/desktop/src/markdown/liquid.rs
+++ b/desktop/src/markdown/liquid.rs
@@ -1,0 +1,181 @@
+use std::collections::BTreeMap;
+
+const LIQUID_INCLUDE_PREFIX: &str = "include figure.liquid";
+
+pub(super) fn preprocess_liquid_includes(markdown: &str) -> String {
+    let mut output = String::with_capacity(markdown.len());
+
+    for segment in markdown.split_inclusive('\n') {
+        let (line, newline) = match segment.strip_suffix('\n') {
+            Some(line) => (line, "\n"),
+            None => (segment, ""),
+        };
+
+        if let Some(rewritten) = rewrite_figure_include(line) {
+            output.push_str(&rewritten);
+        } else {
+            output.push_str(line);
+        }
+        output.push_str(newline);
+    }
+
+    output
+}
+
+fn rewrite_figure_include(line: &str) -> Option<String> {
+    let trimmed = line.trim();
+    let inner = trimmed.strip_prefix("{%")?.strip_suffix("%}")?.trim();
+    let attrs = inner.strip_prefix(LIQUID_INCLUDE_PREFIX)?.trim();
+    let attrs = parse_attributes(attrs);
+
+    let path = attrs.get("path").or_else(|| attrs.get("src"))?;
+    let mut img_attrs = Vec::new();
+    img_attrs.push(format!(
+        r#"src="{}""#,
+        html_escape::encode_double_quoted_attribute(path)
+    ));
+
+    for key in ["class", "alt", "title", "width", "height", "loading"] {
+        if let Some(value) = attrs.get(key) {
+            img_attrs.push(format!(
+                r#"{key}="{}""#,
+                html_escape::encode_double_quoted_attribute(value)
+            ));
+        }
+    }
+
+    let image_tag = format!("<img {}>", img_attrs.join(" "));
+    match attrs.get("caption") {
+        Some(caption) => Some(format!(
+            "<figure>{}<figcaption>{}</figcaption></figure>",
+            image_tag,
+            html_escape::encode_text(caption)
+        )),
+        None => Some(image_tag),
+    }
+}
+
+fn parse_attributes(input: &str) -> BTreeMap<String, String> {
+    let mut attrs = BTreeMap::new();
+    let chars: Vec<char> = input.chars().collect();
+    let mut index = 0;
+
+    while index < chars.len() {
+        while index < chars.len() && chars[index].is_whitespace() {
+            index += 1;
+        }
+        if index >= chars.len() {
+            break;
+        }
+
+        let key_start = index;
+        while index < chars.len() && !chars[index].is_whitespace() && chars[index] != '=' {
+            index += 1;
+        }
+        if key_start == index {
+            index += 1;
+            continue;
+        }
+        let key: String = chars[key_start..index].iter().collect();
+
+        while index < chars.len() && chars[index].is_whitespace() {
+            index += 1;
+        }
+        if index >= chars.len() || chars[index] != '=' {
+            continue;
+        }
+        index += 1;
+
+        while index < chars.len() && chars[index].is_whitespace() {
+            index += 1;
+        }
+        if index >= chars.len() {
+            break;
+        }
+
+        let quote = chars[index];
+        let value = if let Some(closing_quote) = matching_quote(quote) {
+            index += 1;
+            let value_start = index;
+            while index < chars.len() && chars[index] != closing_quote {
+                index += 1;
+            }
+            let value: String = chars[value_start..index].iter().collect();
+            if index < chars.len() && chars[index] == closing_quote {
+                index += 1;
+            }
+            value
+        } else {
+            let value_start = index;
+            while index < chars.len() && !chars[index].is_whitespace() {
+                index += 1;
+            }
+            chars[value_start..index].iter().collect()
+        };
+
+        attrs.insert(key, value);
+    }
+
+    attrs
+}
+
+fn matching_quote(ch: char) -> Option<char> {
+    match ch {
+        '"' => Some('"'),
+        '\'' => Some('\''),
+        '“' => Some('”'),
+        '‘' => Some('’'),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rewrites_figure_include_with_ascii_quotes() {
+        let markdown =
+            r#"{% include figure.liquid path="assets/img/example.png" class="img-fluid" %}"#;
+
+        let rewritten = preprocess_liquid_includes(markdown);
+
+        assert_eq!(
+            rewritten,
+            r#"<img src="assets/img/example.png" class="img-fluid">"#
+        );
+    }
+
+    #[test]
+    fn rewrites_figure_include_with_curly_quotes() {
+        let markdown =
+            "{% include figure.liquid path=“assets/img/example.png” class=“img-fluid” %}";
+
+        let rewritten = preprocess_liquid_includes(markdown);
+
+        assert_eq!(
+            rewritten,
+            r#"<img src="assets/img/example.png" class="img-fluid">"#
+        );
+    }
+
+    #[test]
+    fn rewrites_captioned_figure_include() {
+        let markdown =
+            r#"{% include figure.liquid path="assets/img/example.png" caption="A demo image" %}"#;
+
+        let rewritten = preprocess_liquid_includes(markdown);
+
+        assert_eq!(
+            rewritten,
+            r#"<figure><img src="assets/img/example.png"><figcaption>A demo image</figcaption></figure>"#
+        );
+    }
+
+    #[test]
+    fn leaves_other_liquid_tags_untouched() {
+        let markdown = r#"{% include something-else.liquid path="assets/img/example.png" %}"#;
+
+        assert_eq!(preprocess_liquid_includes(markdown), markdown);
+    }
+}

--- a/desktop/src/markdown/post_process.rs
+++ b/desktop/src/markdown/post_process.rs
@@ -118,21 +118,16 @@ fn post_process_html_impl(
                 element!("a[href]", |el| {
                     if let Some(href) = el.get_attribute("href") {
                         if !href.starts_with("http://") && !href.starts_with("https://") {
-                            if let Some(ext) = std::path::Path::new(&href)
-                                .extension()
-                                .and_then(|e| e.to_str())
-                            {
-                                el.set_tag_name("span")?;
-                                el.remove_attribute("href");
-                                el.set_attribute("data-md-link", &href)?;
-                                if ext != "md" && ext != "markdown" {
-                                    el.set_attribute("class", "md-link md-link-invalid")?;
-                                } else {
-                                    el.set_attribute("class", "md-link")?;
-                                }
-                                el.set_attribute("onmousedown",
-                                    "if(event.button===0||event.button===1){event.preventDefault();window.handleMarkdownLinkClick(this.dataset.mdLink,event.button)}")?;
+                            el.set_tag_name("span")?;
+                            el.remove_attribute("href");
+                            el.set_attribute("data-md-link", &href)?;
+                            if crate::utils::markdown_link::is_internal_markdown_href(&href) {
+                                el.set_attribute("class", "md-link")?;
+                            } else {
+                                el.set_attribute("class", "md-link md-link-invalid")?;
                             }
+                            el.set_attribute("onmousedown",
+                                "if(event.button===0||event.button===1){event.preventDefault();window.handleMarkdownLinkClick(this.dataset.mdLink,event.button)}")?;
                         }
                     }
                     Ok(())
@@ -327,6 +322,38 @@ mod tests {
         assert!(
             result.contains("handleMarkdownLinkClick"),
             "Should add click handler: {result}"
+        );
+        assert!(!result.contains("<a "), "Should not contain anchor tag");
+    }
+
+    #[test]
+    fn test_post_process_html_tags_anchor_with_fragment() {
+        let html = r#"<a href="doc.md#section-1">Link</a>"#;
+        let result = post_process_html_tags(html, Path::new("."), &[]);
+
+        assert!(
+            result.contains(r#"data-md-link="doc.md#section-1""#),
+            "Should preserve href fragment in data attribute: {result}"
+        );
+        assert!(
+            result.contains(r#"class="md-link""#),
+            "Should be a markdown link: {result}"
+        );
+        assert!(!result.contains("<a "), "Should not contain anchor tag");
+    }
+
+    #[test]
+    fn test_post_process_html_tags_same_file_anchor() {
+        let html = r##"<a href="#section-1">Link</a>"##;
+        let result = post_process_html_tags(html, Path::new("."), &[]);
+
+        assert!(
+            result.contains(r##"data-md-link="#section-1""##),
+            "Should preserve same-file anchor in data attribute: {result}"
+        );
+        assert!(
+            result.contains(r#"class="md-link""#),
+            "Should be a markdown link: {result}"
         );
         assert!(!result.contains("<a "), "Should not contain anchor tag");
     }

--- a/desktop/src/menu.rs
+++ b/desktop/src/menu.rs
@@ -3,11 +3,11 @@ use dioxus::prelude::{spawn, ReadableExt, WritableExt};
 use dioxus_desktop::muda::accelerator::Accelerator;
 use dioxus_desktop::muda::{Menu, MenuEvent, MenuItem, PredefinedMenuItem, Submenu};
 use dioxus_desktop::window;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::components::content::set_preferences_tab_to_about;
 use crate::keybindings::shortcut_hint_for_global_action;
-use crate::state::AppState;
+use crate::state::{AppState, PersistedFileView};
 use crate::window::{self, settings::normalize_zoom_level, CreateMainWindowConfigParams};
 
 /// Menu identifier enum
@@ -38,6 +38,9 @@ enum MenuId {
     GoForward,
     GoToHomepage,
 }
+
+const RECENT_FILE_MENU_PREFIX: &str = "file.open_recent.";
+const NO_RECENT_FILES_MENU_ID: &str = "file.open_recent.none";
 
 impl MenuId {
     /// Convert menu ID string to enum variant
@@ -190,6 +193,7 @@ fn add_app_menu(menu: &Menu) {
 
 fn add_file_menu(menu: &Menu) {
     let file_menu = Submenu::new("File", true);
+    let open_recent_menu = build_open_recent_menu();
 
     file_menu
         .append_items(&[
@@ -198,6 +202,7 @@ fn add_file_menu(menu: &Menu) {
             &PredefinedMenuItem::separator(),
             &create_menu_item(MenuId::Open, "Open File..."),
             &create_menu_item(MenuId::OpenDirectory, "Open Directory..."),
+            &open_recent_menu,
             &PredefinedMenuItem::separator(),
             &create_menu_item(MenuId::CopyFilePath, "Copy File Path"),
             &create_menu_item(MenuId::RevealInFinder, "Reveal in Finder"),
@@ -209,6 +214,58 @@ fn add_file_menu(menu: &Menu) {
         .unwrap();
 
     menu.append(&file_menu).unwrap();
+}
+
+fn build_open_recent_menu() -> Submenu {
+    let submenu = Submenu::with_id("file.open_recent", "Open Recent", true);
+    let recent_files = crate::state::PersistedState::load().recent_files;
+
+    if recent_files.is_empty() {
+        submenu
+            .append(&MenuItem::with_id(
+                NO_RECENT_FILES_MENU_ID,
+                "No Recent Files",
+                false,
+                None::<Accelerator>,
+            ))
+            .unwrap();
+        return submenu;
+    }
+
+    for (index, path) in recent_files.iter().enumerate() {
+        submenu
+            .append(&MenuItem::with_id(
+                format!("{RECENT_FILE_MENU_PREFIX}{index}"),
+                recent_file_menu_label(path),
+                true,
+                None::<Accelerator>,
+            ))
+            .unwrap();
+    }
+
+    submenu
+}
+
+fn recent_file_menu_label(path: &Path) -> String {
+    let name = path
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| path.display().to_string());
+
+    match path.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => format!("{name} ({})", parent.display()),
+        _ => name,
+    }
+}
+
+fn recent_file_from_menu_id(menu_id: &str) -> Option<PersistedFileView> {
+    let index = menu_id
+        .strip_prefix(RECENT_FILE_MENU_PREFIX)?
+        .parse::<usize>()
+        .ok()?;
+    crate::state::PersistedState::load()
+        .recent_file_view(index)
+        .cloned()
 }
 
 fn add_edit_menu(menu: &Menu) {
@@ -307,6 +364,18 @@ pub fn is_close_action(event: &MenuEvent) -> bool {
 pub fn handle_menu_event_global(event: &MenuEvent) -> bool {
     let menu_id = event.id().0.as_ref();
 
+    if let Some(view) = recent_file_from_menu_id(menu_id) {
+        if !window::has_any_main_windows() {
+            window::create_main_window_sync(
+                &window(),
+                crate::state::Tab::new(view.path),
+                CreateMainWindowConfigParams::default(),
+            );
+            return true;
+        }
+        return false;
+    }
+
     let id = match MenuId::from_str(menu_id) {
         Some(id) => id,
         None => return false,
@@ -378,6 +447,14 @@ pub fn handle_menu_event_with_state(event: &MenuEvent, state: &mut AppState) -> 
 
     let menu_id = event.id().0.as_ref();
     tracing::debug!("State menu event (focused window): {}", menu_id);
+
+    if let Some(view) = recent_file_from_menu_id(menu_id) {
+        state.open_file(view.path);
+        state
+            .pending_scroll_position
+            .set(Some(view.scroll_position));
+        return true;
+    }
 
     let id = match MenuId::from_str(menu_id) {
         Some(id) => id,
@@ -601,5 +678,17 @@ mod tests {
         assert!(is_close_action(&close_tab));
         assert!(is_close_action(&close_window));
         assert!(!is_close_action(&new_tab));
+    }
+
+    #[test]
+    fn test_recent_file_menu_label_includes_parent_directory() {
+        let path = PathBuf::from("/tmp/example/test.md");
+        assert_eq!(recent_file_menu_label(&path), "test.md (/tmp/example)");
+    }
+
+    #[test]
+    fn test_recent_file_from_invalid_menu_id_returns_none() {
+        assert!(recent_file_from_menu_id("file.open_recent.invalid").is_none());
+        assert!(recent_file_from_menu_id(NO_RECENT_FILES_MENU_ID).is_none());
     }
 }

--- a/desktop/src/state.rs
+++ b/desktop/src/state.rs
@@ -5,4 +5,4 @@ pub(crate) use app_state::sidebar_cursor;
 pub use app_state::{AppState, FocusedPanel, SearchMatch, Sidebar, SidebarPanel, Tab, TabContent};
 
 mod persistence;
-pub use persistence::{PersistedState, Position, Size};
+pub use persistence::{PersistedFileView, PersistedState, Position, Size};

--- a/desktop/src/state.rs
+++ b/desktop/src/state.rs
@@ -2,7 +2,7 @@
 
 mod app_state;
 pub(crate) use app_state::sidebar_cursor;
-pub use app_state::{AppState, FocusedPanel, SearchMatch, Sidebar, Tab, TabContent};
+pub use app_state::{AppState, FocusedPanel, SearchMatch, Sidebar, SidebarPanel, Tab, TabContent};
 
 mod persistence;
 pub use persistence::{PersistedState, Position, Size};

--- a/desktop/src/state/app_state.rs
+++ b/desktop/src/state/app_state.rs
@@ -32,6 +32,12 @@ pub struct SearchMatch {
     pub context_end: usize,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingHeadingNavigation {
+    pub file: PathBuf,
+    pub heading_id: String,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SidebarPanel {
@@ -66,6 +72,8 @@ pub enum SidebarPanel {
 pub struct AppState {
     pub tabs: Signal<Vec<Tab>>,
     pub active_tab: Signal<usize>,
+    pub recent_files: Signal<Vec<PathBuf>>,
+    pub pending_heading_navigation: Signal<Option<PendingHeadingNavigation>>,
     pub current_theme: Signal<Theme>,
     pub zoom_level: Signal<f64>,
     pub sidebar: Signal<Sidebar>,
@@ -122,6 +130,8 @@ impl AppState {
         Self {
             tabs: Signal::new(vec![Tab::default()]),
             active_tab: Signal::new(0),
+            recent_files: Signal::new(Vec::new()),
+            pending_heading_navigation: Signal::new(None),
             current_theme: Signal::new(theme),
             zoom_level: Signal::new(1.0),
             sidebar: Signal::new(Sidebar::default()),
@@ -161,6 +171,22 @@ impl Default for AppState {
 }
 
 impl AppState {
+    pub fn set_pending_heading_navigation(
+        &mut self,
+        file: impl Into<PathBuf>,
+        heading_id: impl Into<String>,
+    ) {
+        self.pending_heading_navigation
+            .set(Some(PendingHeadingNavigation {
+                file: file.into(),
+                heading_id: heading_id.into(),
+            }));
+    }
+
+    pub fn clear_pending_heading_navigation(&mut self) {
+        self.pending_heading_navigation.set(None);
+    }
+
     /// Set the root directory and add to history
     /// Note: The directory is persisted to state file when window closes
     pub fn set_root_directory(&mut self, path: impl Into<PathBuf>) {

--- a/desktop/src/state/app_state.rs
+++ b/desktop/src/state/app_state.rs
@@ -3,7 +3,6 @@ use dioxus::prelude::*;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use crate::components::right_sidebar::RightSidebarTab;
 use crate::config::DEFAULT_RIGHT_SIDEBAR_WIDTH;
 use crate::markdown::HeadingInfo;
 use crate::pinned_search::PinnedSearchId;
@@ -31,6 +30,15 @@ pub struct SearchMatch {
     pub context_start: usize,
     /// End position of match within context (byte index)
     pub context_end: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SidebarPanel {
+    #[default]
+    Directory,
+    Contents,
+    Search,
 }
 
 /// Per-window application state.
@@ -61,9 +69,10 @@ pub struct AppState {
     pub current_theme: Signal<Theme>,
     pub zoom_level: Signal<f64>,
     pub sidebar: Signal<Sidebar>,
+    pub left_sidebar_panel: Signal<SidebarPanel>,
     pub right_sidebar_pinned: Signal<bool>,
     pub right_sidebar_width: Signal<f64>,
-    pub right_sidebar_tab: Signal<RightSidebarTab>,
+    pub right_sidebar_panel: Signal<SidebarPanel>,
     pub right_sidebar_zoom_level: Signal<f64>,
     pub right_sidebar_headings: Signal<Vec<HeadingInfo>>,
     pub position: Signal<LogicalPosition<i32>>,
@@ -116,9 +125,10 @@ impl AppState {
             current_theme: Signal::new(theme),
             zoom_level: Signal::new(1.0),
             sidebar: Signal::new(Sidebar::default()),
+            left_sidebar_panel: Signal::new(SidebarPanel::default()),
             right_sidebar_pinned: Signal::new(false),
             right_sidebar_width: Signal::new(DEFAULT_RIGHT_SIDEBAR_WIDTH),
-            right_sidebar_tab: Signal::new(RightSidebarTab::default()),
+            right_sidebar_panel: Signal::new(SidebarPanel::Contents),
             right_sidebar_zoom_level: Signal::new(1.0),
             right_sidebar_headings: Signal::new(Vec::new()),
             position: Signal::new(Default::default()),
@@ -212,9 +222,14 @@ impl AppState {
         self.right_sidebar_width.set(width);
     }
 
-    /// Set right sidebar active tab
-    pub fn set_right_sidebar_tab(&mut self, tab: RightSidebarTab) {
-        self.right_sidebar_tab.set(tab);
+    /// Set left sidebar active panel
+    pub fn set_left_sidebar_panel(&mut self, panel: SidebarPanel) {
+        self.left_sidebar_panel.set(panel);
+    }
+
+    /// Set right sidebar active panel
+    pub fn set_right_sidebar_panel(&mut self, panel: SidebarPanel) {
+        self.right_sidebar_panel.set(panel);
     }
 
     /// Toggle search bar visibility

--- a/desktop/src/state/app_state/tabs/file_ops.rs
+++ b/desktop/src/state/app_state/tabs/file_ops.rs
@@ -65,11 +65,9 @@ impl AppState {
     }
 
     /// Open preferences in a tab. Reuses existing preferences tab if found.
-    /// Unpins both sidebars so preferences gets the full window.
+    /// Preserves pinned sidebars, but closes any transient overlay sidebars.
     pub fn open_preferences(&mut self) {
-        // Unpin both sidebars and close overlays (preferences is a full-screen settings page)
-        self.sidebar.write().pinned = false;
-        self.right_sidebar_pinned.set(false);
+        // Close transient overlays so preferences opens into a stable layout.
         self.left_hover_active.set(false);
         self.right_hover_active.set(false);
 

--- a/desktop/src/state/app_state/tabs/file_ops.rs
+++ b/desktop/src/state/app_state/tabs/file_ops.rs
@@ -8,12 +8,25 @@ use dioxus::prelude::*;
 use std::path::{Path, PathBuf};
 
 impl AppState {
+    /// Record a file in recent history, most-recent-first.
+    pub fn record_recent_file(&mut self, file: impl Into<PathBuf>) {
+        const MAX_RECENT_FILES: usize = 10;
+
+        let file = file.into();
+        let mut recent_files = self.recent_files.write();
+        recent_files.retain(|path| path != &file);
+        recent_files.insert(0, file);
+        recent_files.truncate(MAX_RECENT_FILES);
+    }
+
     /// Open a file, reusing NoFile tab or existing tab with the same file if possible
     /// Used when opening from sidebar or external sources
     pub fn open_file(&mut self, file: impl AsRef<Path>) {
-        let file = file.as_ref();
+        let file = file.as_ref().to_path_buf();
+        self.record_recent_file(file.clone());
+
         // Check if the file is already open in another tab
-        if let Some(tab_index) = self.find_tab_with_file(file) {
+        if let Some(tab_index) = self.find_tab_with_file(&file) {
             // Switch to the existing tab instead of creating a new one
             self.switch_to_tab(tab_index);
         } else if self.is_current_tab_no_file() {
@@ -30,9 +43,25 @@ impl AppState {
     /// Navigate to a file in the current tab (for in-tab navigation like markdown links)
     /// Always opens in current tab regardless of whether file is open elsewhere
     pub fn navigate_to_file(&mut self, file: impl Into<PathBuf>) {
+        let file = file.into();
+        self.record_recent_file(file.clone());
         self.update_current_tab(|tab| {
             tab.navigate_to(file);
         });
+    }
+
+    pub fn navigate_to_file_at_heading(
+        &mut self,
+        file: impl Into<PathBuf>,
+        heading_id: Option<String>,
+    ) {
+        let file = file.into();
+        if let Some(heading_id) = heading_id {
+            self.set_pending_heading_navigation(file.clone(), heading_id);
+        } else {
+            self.clear_pending_heading_navigation();
+        }
+        self.navigate_to_file(file);
     }
 
     /// Open preferences in a tab. Reuses existing preferences tab if found.

--- a/desktop/src/state/persistence.rs
+++ b/desktop/src/state/persistence.rs
@@ -1,11 +1,12 @@
 use dioxus::desktop::tao::dpi::{LogicalPosition, LogicalSize};
 use dioxus::prelude::*;
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::fs;
 use std::path::PathBuf;
 
 use crate::config::DEFAULT_RIGHT_SIDEBAR_WIDTH;
-use crate::state::{AppState, SidebarPanel};
+use crate::state::{AppState, SidebarPanel, Tab};
 use crate::theme::Theme;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -46,8 +47,30 @@ impl From<LogicalSize<u32>> for Size {
 /// when a window closes and loaded on app startup.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
+pub struct PersistedFileView {
+    pub path: PathBuf,
+    #[serde(default)]
+    pub scroll_position: f64,
+}
+
+impl Default for PersistedFileView {
+    fn default() -> Self {
+        Self {
+            path: PathBuf::new(),
+            scroll_position: 0.0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
 pub struct PersistedState {
     pub directory: Option<PathBuf>,
+    pub recent_files: Vec<PathBuf>,
+    pub recent_file_views: Vec<PersistedFileView>,
+    pub open_files: Vec<PathBuf>,
+    pub open_file_views: Vec<PersistedFileView>,
+    pub active_open_file_index: Option<usize>,
     pub theme: Theme,
     pub sidebar_pinned: bool,
     pub sidebar_width: f64,
@@ -80,6 +103,11 @@ impl Default for PersistedState {
     fn default() -> Self {
         Self {
             directory: None,
+            recent_files: Vec::new(),
+            recent_file_views: Vec::new(),
+            open_files: Vec::new(),
+            open_file_views: Vec::new(),
+            active_open_file_index: None,
             theme: Theme::default(),
             sidebar_pinned: false,
             sidebar_width: 280.0,
@@ -99,9 +127,54 @@ impl Default for PersistedState {
 
 impl From<&AppState> for PersistedState {
     fn from(state: &AppState) -> Self {
+        let previous = PersistedState::load();
         let sidebar = state.sidebar.read();
+        let tabs = state.tabs.read();
+        let active_tab = *state.active_tab.read();
+        let open_file_views =
+            dedupe_existing_file_views(tabs.iter().enumerate().filter_map(|(index, tab)| {
+                let path = tab.file()?.to_path_buf();
+                let scroll_position = if index == active_tab {
+                    *state.current_scroll_position.read()
+                } else {
+                    tab.history
+                        .current()
+                        .map(|entry| entry.scroll_position)
+                        .unwrap_or(0.0)
+                };
+                Some(PersistedFileView {
+                    path,
+                    scroll_position,
+                })
+            }));
+        let open_files = open_file_views
+            .iter()
+            .map(|view| view.path.clone())
+            .collect();
+        let active_open_file_index =
+            tabs.get(active_tab)
+                .and_then(|tab| tab.file())
+                .and_then(|active_file| {
+                    open_file_views
+                        .iter()
+                        .position(|view| view.path.as_path() == active_file)
+                });
+        let recent_file_views = merge_recent_file_views(
+            previous.recent_file_views,
+            state.recent_files.read().iter().cloned(),
+            &open_file_views,
+        );
+        let recent_files = recent_file_views
+            .iter()
+            .map(|view| view.path.clone())
+            .collect();
         Self {
             directory: sidebar.root_directory.clone(),
+            recent_files,
+            recent_file_views,
+            open_files,
+            open_file_views,
+            active_open_file_index,
             theme: *state.current_theme.read(),
             sidebar_pinned: sidebar.pinned,
             sidebar_width: sidebar.width,
@@ -117,6 +190,70 @@ impl From<&AppState> for PersistedState {
             zoom_level: *state.zoom_level.read(),
         }
     }
+}
+
+fn dedupe_existing_files(paths: impl IntoIterator<Item = PathBuf>) -> Vec<PathBuf> {
+    let mut seen = HashSet::new();
+    let mut result = Vec::new();
+
+    for path in paths {
+        if !path.is_file() || !seen.insert(path.clone()) {
+            continue;
+        }
+        result.push(path);
+    }
+
+    result
+}
+
+fn dedupe_existing_file_views(
+    views: impl IntoIterator<Item = PersistedFileView>,
+) -> Vec<PersistedFileView> {
+    let mut seen = HashSet::new();
+    let mut result = Vec::new();
+
+    for view in views {
+        if !view.path.is_file() || !seen.insert(view.path.clone()) {
+            continue;
+        }
+        result.push(view);
+    }
+
+    result
+}
+
+fn merge_recent_file_views(
+    previous_views: Vec<PersistedFileView>,
+    recent_paths: impl IntoIterator<Item = PathBuf>,
+    open_views: &[PersistedFileView],
+) -> Vec<PersistedFileView> {
+    let previous_map = previous_views
+        .into_iter()
+        .map(|view| (view.path.clone(), view))
+        .collect::<std::collections::HashMap<_, _>>();
+    let open_map = open_views
+        .iter()
+        .cloned()
+        .map(|view| (view.path.clone(), view))
+        .collect::<std::collections::HashMap<_, _>>();
+
+    dedupe_existing_file_views(
+        recent_paths
+            .into_iter()
+            .chain(open_views.iter().map(|view| view.path.clone()))
+            .filter_map(|path| {
+                open_map
+                    .get(&path)
+                    .cloned()
+                    .or_else(|| previous_map.get(&path).cloned())
+                    .or_else(|| {
+                        path.is_file().then_some(PersistedFileView {
+                            path,
+                            scroll_position: 0.0,
+                        })
+                    })
+            }),
+    )
 }
 
 impl PersistedState {
@@ -148,30 +285,104 @@ impl PersistedState {
         }
 
         match fs::read_to_string(&path) {
-            Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
+            Ok(content) => serde_json::from_str::<Self>(&content)
+                .map(Self::normalized)
+                .unwrap_or_default(),
             Err(_) => Self::default(),
         }
+    }
+
+    fn normalized(mut self) -> Self {
+        self.open_file_views = if self.open_file_views.is_empty() {
+            self.open_files
+                .iter()
+                .cloned()
+                .map(|path| PersistedFileView {
+                    path,
+                    scroll_position: 0.0,
+                })
+                .collect()
+        } else {
+            self.open_file_views
+        };
+        self.recent_file_views = if self.recent_file_views.is_empty() {
+            self.recent_files
+                .iter()
+                .cloned()
+                .map(|path| PersistedFileView {
+                    path,
+                    scroll_position: 0.0,
+                })
+                .collect()
+        } else {
+            self.recent_file_views
+        };
+
+        self.open_file_views = dedupe_existing_file_views(self.open_file_views);
+        self.recent_file_views = dedupe_existing_file_views(
+            self.recent_file_views
+                .into_iter()
+                .chain(self.open_file_views.iter().cloned()),
+        );
+        self.open_files = dedupe_existing_files(self.open_files);
+        self.open_files = self
+            .open_file_views
+            .iter()
+            .map(|view| view.path.clone())
+            .collect();
+        self.recent_files = self
+            .recent_file_views
+            .iter()
+            .map(|view| view.path.clone())
+            .collect();
+        self.active_open_file_index = self
+            .active_open_file_index
+            .filter(|index| *index < self.open_file_views.len());
+        self
+    }
+
+    pub fn restored_open_tabs(&self) -> Vec<Tab> {
+        self.open_file_views
+            .iter()
+            .cloned()
+            .map(|view| {
+                let mut tab = Tab::new(view.path);
+                tab.history.save_scroll_position(view.scroll_position);
+                tab
+            })
+            .collect()
+    }
+
+    pub fn restored_active_tab(&self) -> usize {
+        self.active_open_file_index.unwrap_or(0)
+    }
+
+    pub fn recent_file_view(&self, index: usize) -> Option<&PersistedFileView> {
+        self.recent_file_views.get(index)
     }
 
     /// Save persisted state to file
     ///
     /// This function should be called when a window is closing to persist its state.
     pub fn save(&self) {
+        let normalized = self.clone().normalized();
         let path = Self::path();
 
         tracing::debug!(
             path = %path.display(),
-            theme = ?self.theme,
-            sidebar_pinned = self.sidebar_pinned,
-            sidebar_width = self.sidebar_width,
-            sidebar_show_all_files = self.sidebar_show_all_files,
-            sidebar_zoom_level = self.sidebar_zoom_level,
-            left_sidebar_panel = ?self.left_sidebar_panel,
-            right_sidebar_pinned = self.right_sidebar_pinned,
-            right_sidebar_width = self.right_sidebar_width,
-            right_sidebar_panel = ?self.right_sidebar_panel,
-            right_sidebar_zoom_level = self.right_sidebar_zoom_level,
-            zoom_level = self.zoom_level,
+            theme = ?normalized.theme,
+            sidebar_pinned = normalized.sidebar_pinned,
+            sidebar_width = normalized.sidebar_width,
+            sidebar_show_all_files = normalized.sidebar_show_all_files,
+            sidebar_zoom_level = normalized.sidebar_zoom_level,
+            left_sidebar_panel = ?normalized.left_sidebar_panel,
+            right_sidebar_pinned = normalized.right_sidebar_pinned,
+            right_sidebar_width = normalized.right_sidebar_width,
+            right_sidebar_panel = ?normalized.right_sidebar_panel,
+            right_sidebar_zoom_level = normalized.right_sidebar_zoom_level,
+            recent_files = normalized.recent_files.len(),
+            open_files = normalized.open_files.len(),
+            zoom_level = normalized.zoom_level,
             "Saving persisted state"
         );
 
@@ -183,7 +394,7 @@ impl PersistedState {
             }
         }
 
-        match serde_json::to_string_pretty(self) {
+        match serde_json::to_string_pretty(&normalized) {
             Ok(content) => {
                 if let Err(e) = std::fs::write(&path, content) {
                     tracing::error!(?e, "Failed to save persisted state");
@@ -213,6 +424,17 @@ mod tests {
     #[test]
     fn test_serialization_roundtrip() {
         let state = PersistedState {
+            recent_files: vec![PathBuf::from("/tmp/recent.md")],
+            recent_file_views: vec![PersistedFileView {
+                path: PathBuf::from("/tmp/recent.md"),
+                scroll_position: 120.0,
+            }],
+            open_files: vec![PathBuf::from("/tmp/open.md")],
+            open_file_views: vec![PersistedFileView {
+                path: PathBuf::from("/tmp/open.md"),
+                scroll_position: 240.0,
+            }],
+            active_open_file_index: Some(0),
             sidebar_pinned: false,
             right_sidebar_pinned: true,
             ..Default::default()
@@ -223,6 +445,11 @@ mod tests {
 
         assert!(!parsed.sidebar_pinned);
         assert!(parsed.right_sidebar_pinned);
+        assert_eq!(parsed.recent_files, vec![PathBuf::from("/tmp/recent.md")]);
+        assert_eq!(parsed.open_files, vec![PathBuf::from("/tmp/open.md")]);
+        assert_eq!(parsed.recent_file_views[0].scroll_position, 120.0);
+        assert_eq!(parsed.open_file_views[0].scroll_position, 240.0);
+        assert_eq!(parsed.active_open_file_index, Some(0));
     }
 
     #[test]
@@ -288,5 +515,47 @@ mod tests {
 
         assert!(!parsed.sidebar_pinned);
         assert!(!parsed.right_sidebar_pinned);
+    }
+
+    #[test]
+    fn test_normalized_filters_missing_and_duplicate_files() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let existing = temp_dir.path().join("existing.md");
+        std::fs::write(&existing, "# test").unwrap();
+        let missing = temp_dir.path().join("missing.md");
+
+        let normalized = PersistedState {
+            recent_files: vec![existing.clone(), missing.clone(), existing.clone()],
+            recent_file_views: vec![
+                PersistedFileView {
+                    path: existing.clone(),
+                    scroll_position: 10.0,
+                },
+                PersistedFileView {
+                    path: missing.clone(),
+                    scroll_position: 20.0,
+                },
+            ],
+            open_files: vec![missing, existing.clone(), existing.clone()],
+            open_file_views: vec![
+                PersistedFileView {
+                    path: existing.clone(),
+                    scroll_position: 30.0,
+                },
+                PersistedFileView {
+                    path: existing.clone(),
+                    scroll_position: 40.0,
+                },
+            ],
+            active_open_file_index: Some(5),
+            ..Default::default()
+        }
+        .normalized();
+
+        assert_eq!(normalized.recent_files, vec![existing.clone()]);
+        assert_eq!(normalized.open_files, vec![existing]);
+        assert_eq!(normalized.recent_file_views[0].scroll_position, 10.0);
+        assert_eq!(normalized.open_file_views[0].scroll_position, 30.0);
+        assert_eq!(normalized.active_open_file_index, None);
     }
 }

--- a/desktop/src/state/persistence.rs
+++ b/desktop/src/state/persistence.rs
@@ -4,12 +4,11 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
 
-use crate::components::right_sidebar::RightSidebarTab;
 use crate::config::DEFAULT_RIGHT_SIDEBAR_WIDTH;
-use crate::state::AppState;
+use crate::state::{AppState, SidebarPanel};
 use crate::theme::Theme;
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct Position {
     pub x: i32,
@@ -25,7 +24,7 @@ impl From<LogicalPosition<i32>> for Position {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct Size {
     pub width: u32,
@@ -55,9 +54,12 @@ pub struct PersistedState {
     pub sidebar_show_all_files: bool,
     #[serde(default = "default_zoom_level")]
     pub sidebar_zoom_level: f64,
+    #[serde(default)]
+    pub left_sidebar_panel: SidebarPanel,
     pub right_sidebar_pinned: bool,
     pub right_sidebar_width: f64,
-    pub right_sidebar_tab: RightSidebarTab,
+    #[serde(default = "default_right_sidebar_panel", alias = "rightSidebarTab")]
+    pub right_sidebar_panel: SidebarPanel,
     #[serde(default = "default_zoom_level")]
     pub right_sidebar_zoom_level: f64,
     pub window_position: Position,
@@ -70,6 +72,10 @@ fn default_zoom_level() -> f64 {
     1.0
 }
 
+fn default_right_sidebar_panel() -> SidebarPanel {
+    SidebarPanel::Contents
+}
+
 impl Default for PersistedState {
     fn default() -> Self {
         Self {
@@ -79,9 +85,10 @@ impl Default for PersistedState {
             sidebar_width: 280.0,
             sidebar_show_all_files: false,
             sidebar_zoom_level: 1.0,
+            left_sidebar_panel: SidebarPanel::Directory,
             right_sidebar_pinned: false,
             right_sidebar_width: DEFAULT_RIGHT_SIDEBAR_WIDTH,
-            right_sidebar_tab: RightSidebarTab::default(),
+            right_sidebar_panel: default_right_sidebar_panel(),
             right_sidebar_zoom_level: 1.0,
             window_position: Position::default(),
             window_size: Size::default(),
@@ -100,9 +107,10 @@ impl From<&AppState> for PersistedState {
             sidebar_width: sidebar.width,
             sidebar_show_all_files: sidebar.show_all_files,
             sidebar_zoom_level: sidebar.zoom_level,
+            left_sidebar_panel: *state.left_sidebar_panel.read(),
             right_sidebar_pinned: *state.right_sidebar_pinned.read(),
             right_sidebar_width: *state.right_sidebar_width.read(),
-            right_sidebar_tab: *state.right_sidebar_tab.read(),
+            right_sidebar_panel: *state.right_sidebar_panel.read(),
             right_sidebar_zoom_level: *state.right_sidebar_zoom_level.read(),
             window_position: (*state.position.read()).into(),
             window_size: (*state.size.read()).into(),
@@ -158,9 +166,10 @@ impl PersistedState {
             sidebar_width = self.sidebar_width,
             sidebar_show_all_files = self.sidebar_show_all_files,
             sidebar_zoom_level = self.sidebar_zoom_level,
+            left_sidebar_panel = ?self.left_sidebar_panel,
             right_sidebar_pinned = self.right_sidebar_pinned,
             right_sidebar_width = self.right_sidebar_width,
-            right_sidebar_tab = ?self.right_sidebar_tab,
+            right_sidebar_panel = ?self.right_sidebar_panel,
             right_sidebar_zoom_level = self.right_sidebar_zoom_level,
             zoom_level = self.zoom_level,
             "Saving persisted state"

--- a/desktop/src/utils.rs
+++ b/desktop/src/utils.rs
@@ -2,6 +2,7 @@ pub mod clipboard;
 pub mod file;
 pub mod file_operations;
 pub mod image;
+pub mod markdown_link;
 pub mod screen;
 pub mod source_extract;
 pub mod window_title;

--- a/desktop/src/utils/markdown_link.rs
+++ b/desktop/src/utils/markdown_link.rs
@@ -1,0 +1,99 @@
+use percent_encoding::percent_decode_str;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedMarkdownLink {
+    pub path: PathBuf,
+    pub heading_id: Option<String>,
+}
+
+fn split_href_fragment(href: &str) -> (&str, Option<&str>) {
+    match href.split_once('#') {
+        Some((path, fragment)) => (path, Some(fragment)),
+        None => (href, None),
+    }
+}
+
+fn normalize_heading_fragment(fragment: Option<&str>) -> Option<String> {
+    fragment.and_then(|fragment| {
+        let decoded = percent_decode_str(fragment).decode_utf8_lossy();
+        let trimmed = decoded.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_string())
+    })
+}
+
+pub fn is_internal_markdown_href(href: &str) -> bool {
+    if href.starts_with('#') {
+        return true;
+    }
+
+    let (path, _) = split_href_fragment(href);
+    crate::utils::file::is_markdown_file(path)
+}
+
+pub fn resolve_markdown_link(
+    base_dir: &Path,
+    current_file: &Path,
+    href: &str,
+) -> Option<ResolvedMarkdownLink> {
+    let (path, fragment) = split_href_fragment(href);
+    let heading_id = normalize_heading_fragment(fragment);
+
+    let resolved_path = if path.is_empty() {
+        current_file.to_path_buf()
+    } else {
+        base_dir.join(path).canonicalize().ok()?
+    };
+
+    Some(ResolvedMarkdownLink {
+        path: resolved_path,
+        heading_id,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_internal_markdown_href_supports_fragments() {
+        assert!(is_internal_markdown_href("#section-1"));
+        assert!(is_internal_markdown_href("guide.md#overview"));
+        assert!(is_internal_markdown_href("guide.markdown"));
+        assert!(!is_internal_markdown_href("guide.txt#overview"));
+    }
+
+    #[test]
+    fn test_resolve_markdown_link_same_file_heading() {
+        let current_file = PathBuf::from("/tmp/doc.md");
+        let resolved = resolve_markdown_link(Path::new("/tmp"), &current_file, "#section-1");
+
+        assert_eq!(
+            resolved,
+            Some(ResolvedMarkdownLink {
+                path: current_file,
+                heading_id: Some("section-1".to_string()),
+            })
+        );
+    }
+
+    #[test]
+    fn test_resolve_markdown_link_other_file_heading() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let current_file = temp_dir.path().join("current.md");
+        let linked_file = temp_dir.path().join("linked.md");
+        std::fs::write(&current_file, "# current").unwrap();
+        std::fs::write(&linked_file, "# linked").unwrap();
+        let linked_file = linked_file.canonicalize().unwrap();
+
+        let resolved = resolve_markdown_link(temp_dir.path(), &current_file, "linked.md#part%201");
+
+        assert_eq!(
+            resolved,
+            Some(ResolvedMarkdownLink {
+                path: linked_file,
+                heading_id: Some("part 1".to_string()),
+            })
+        );
+    }
+}

--- a/desktop/src/utils/screen.rs
+++ b/desktop/src/utils/screen.rs
@@ -64,13 +64,22 @@ fn flip_y<T: DisplayLike>(y: i32, display: &T) -> i32 {
 /// - `None` - If no displays are available or scale factor is invalid
 pub fn get_current_display_bounds() -> Option<(LogicalPosition<i32>, LogicalSize<u32>)> {
     let display = get_cursor_display().or_else(get_primary_display)?;
-    let scale = display.scale_factor as f64;
-    if scale <= 0.0 {
-        return None;
-    }
-    let origin = to_logical_position_from_parts(display.x, display.y, scale);
-    let size = to_logical_size_from_parts(display.width, display.height, scale);
-    Some((origin, size))
+    display_bounds(&display)
+}
+
+/// Get the display bounds containing the provided logical point.
+pub fn get_display_bounds_for_logical_point(
+    point: LogicalPosition<i32>,
+) -> Option<(LogicalPosition<i32>, LogicalSize<u32>)> {
+    let displays = DisplayInfo::all().ok()?;
+
+    displays.into_iter().find_map(|display| {
+        let (origin, size) = display_bounds(&display)?;
+        let right = origin.x + size.width as i32;
+        let bottom = origin.y + size.height as i32;
+        (point.x >= origin.x && point.x < right && point.y >= origin.y && point.y < bottom)
+            .then_some((origin, size))
+    })
 }
 
 /// Get the primary display information.
@@ -120,6 +129,7 @@ pub fn get_cursor_display() -> Option<DisplayInfo> {
         .or_else(|| displays.first().cloned())
 }
 
+#[cfg(any(not(target_os = "macos"), test))]
 fn to_logical_size_from_parts(width: u32, height: u32, scale: f64) -> LogicalSize<u32> {
     // Use safe minimum scale factor to prevent division by zero
     let safe_scale = if scale <= 0.0 { 1.0 } else { scale };
@@ -128,12 +138,34 @@ fn to_logical_size_from_parts(width: u32, height: u32, scale: f64) -> LogicalSiz
     LogicalSize::new(width, height)
 }
 
+#[cfg(any(not(target_os = "macos"), test))]
 fn to_logical_position_from_parts(x: i32, y: i32, scale: f64) -> LogicalPosition<i32> {
     // Use safe minimum scale factor to prevent division by zero
     let safe_scale = if scale <= 0.0 { 1.0 } else { scale };
     let x = (x as f64 / safe_scale).round() as i32;
     let y = (y as f64 / safe_scale).round() as i32;
     LogicalPosition::new(x, y)
+}
+
+fn display_bounds(display: &DisplayInfo) -> Option<(LogicalPosition<i32>, LogicalSize<u32>)> {
+    #[cfg(target_os = "macos")]
+    {
+        return Some((
+            LogicalPosition::new(display.x, display.y),
+            LogicalSize::new(display.width, display.height),
+        ));
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        let scale = display.scale_factor as f64;
+        if scale <= 0.0 {
+            return None;
+        }
+        let origin = to_logical_position_from_parts(display.x, display.y, scale);
+        let size = to_logical_size_from_parts(display.width, display.height, scale);
+        Some((origin, size))
+    }
 }
 
 #[cfg(test)]

--- a/desktop/src/window.rs
+++ b/desktop/src/window.rs
@@ -53,11 +53,12 @@ pub use child::{
 };
 #[cfg(not(target_os = "windows"))]
 pub use main::has_any_main_windows;
+pub(crate) use main::persist_preferred_main_window_state;
 pub use main::{
     close_all_main_windows, create_main_window_config, create_main_window_sync,
     create_main_window_sync_with_tabs, get_any_main_window, register_main_window,
-    register_window_state, shutdown_all_windows, unregister_window_state,
-    update_last_focused_window, CreateMainWindowConfigParams,
+    register_window_state, should_skip_persist_on_close, shutdown_all_windows,
+    unregister_window_state, update_last_focused_window, CreateMainWindowConfigParams,
 };
 pub use preview::{
     close_preview_window, commit_preview_window, create_preview_window, discard_preview_window,

--- a/desktop/src/window/main.rs
+++ b/desktop/src/window/main.rs
@@ -9,14 +9,14 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::rc::Rc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
-use crate::state::AppState;
+use crate::state::{AppState, PersistedState};
 
 use crate::assets::MAIN_STYLE;
 use crate::components::app::{App, AppProps};
-use crate::components::right_sidebar::RightSidebarTab;
 use crate::config::{WindowPositionOffset, CONFIG};
-use crate::state::Tab;
+use crate::state::{SidebarPanel, Tab};
 use crate::theme::Theme;
 use crate::utils::screen::get_current_display_bounds;
 
@@ -48,12 +48,13 @@ pub struct CreateMainWindowConfigParams {
     pub directory: Option<PathBuf>, // Auto-detect from tab/file if None
     pub theme: Theme,               // The enum: Auto/Light/Dark
     pub sidebar_pinned: bool,
+    pub sidebar_panel: SidebarPanel,
     pub sidebar_width: f64,
     pub sidebar_show_all_files: bool,
     pub sidebar_zoom_level: f64,
     pub right_sidebar_pinned: bool,
     pub right_sidebar_width: f64,
-    pub right_sidebar_tab: RightSidebarTab,
+    pub right_sidebar_panel: SidebarPanel,
     pub right_sidebar_zoom_level: f64,
     pub zoom_level: f64,
     pub size: LogicalSize<u32>,
@@ -79,12 +80,13 @@ impl CreateMainWindowConfigParams {
             directory: directory_pref.directory,
             theme: theme_pref.theme,
             sidebar_pinned: sidebar_pref.pinned,
+            sidebar_panel: sidebar_pref.panel,
             sidebar_width: sidebar_pref.width,
             sidebar_show_all_files: sidebar_pref.show_all_files,
             sidebar_zoom_level: sidebar_pref.zoom_level,
             right_sidebar_pinned: right_sidebar_pref.pinned,
             right_sidebar_width: right_sidebar_pref.width,
-            right_sidebar_tab: right_sidebar_pref.tab,
+            right_sidebar_panel: right_sidebar_pref.panel,
             right_sidebar_zoom_level: right_sidebar_pref.zoom_level,
             zoom_level: zoom_pref.zoom_level,
             size: size_pref.size,
@@ -106,6 +108,8 @@ thread_local! {
     static LAST_FOCUSED_WINDOW: RefCell<Option<WindowId>> = const { RefCell::new(None) };
     static WINDOW_STATES: RefCell<HashMap<WindowId, AppState>> = RefCell::new(HashMap::new());
 }
+
+static SKIP_CLOSE_PERSIST: AtomicBool = AtomicBool::new(false);
 
 /// List all active (upgraded) main window contexts
 pub fn list_main_windows() -> Vec<Rc<DesktopService>> {
@@ -206,6 +210,8 @@ pub fn close_all_main_windows() {
 /// `WindowCloseBehaviour::WindowCloses` so the hidden MainApp window is actually
 /// destroyed and the process can exit on last window close.
 pub fn shutdown_all_windows() -> usize {
+    persist_preferred_main_window_state();
+    SKIP_CLOSE_PERSIST.store(true, Ordering::SeqCst);
     super::child::close_all_child_windows();
 
     let windows = list_main_windows();
@@ -214,6 +220,10 @@ pub fn shutdown_all_windows() -> usize {
         w.close();
     });
     windows.len()
+}
+
+pub fn should_skip_persist_on_close() -> bool {
+    SKIP_CLOSE_PERSIST.load(Ordering::SeqCst)
 }
 
 // ============================================================================
@@ -279,13 +289,15 @@ fn build_window_dom_and_config(
             tabs,
             directory,
             theme: params.theme,
+            initial_window_position: params.position,
             sidebar_pinned: params.sidebar_pinned,
+            sidebar_panel: params.sidebar_panel,
             sidebar_width: params.sidebar_width,
             sidebar_show_all_files: params.sidebar_show_all_files,
             sidebar_zoom_level: params.sidebar_zoom_level,
             right_sidebar_pinned: params.right_sidebar_pinned,
             right_sidebar_width: params.right_sidebar_width,
-            right_sidebar_tab: params.right_sidebar_tab,
+            right_sidebar_panel: params.right_sidebar_panel,
             right_sidebar_zoom_level: params.right_sidebar_zoom_level,
             zoom_level: params.zoom_level,
         },
@@ -412,6 +424,31 @@ pub fn get_last_focused_window_state() -> Option<AppState> {
 
 pub(crate) fn get_last_focused_window() -> Option<WindowId> {
     LAST_FOCUSED_WINDOW.with(|last| *last.borrow())
+}
+
+pub(crate) fn persist_preferred_main_window_state() {
+    let preferred = get_last_focused_window()
+        .and_then(|id| {
+            list_main_windows()
+                .into_iter()
+                .find(|ctx| ctx.window.id() == id)
+        })
+        .or_else(|| list_visible_main_windows().into_iter().next())
+        .or_else(|| list_main_windows().into_iter().next());
+
+    let Some(window_ctx) = preferred else {
+        return;
+    };
+
+    let Some(state) = get_window_state(window_ctx.window.id()) else {
+        return;
+    };
+
+    let mut persisted = PersistedState::from(&state);
+    let metrics = capture_window_metrics(&window_ctx.window);
+    persisted.window_position = metrics.position;
+    persisted.window_size = metrics.size;
+    persisted.save();
 }
 
 fn list_main_window_positions() -> Vec<LogicalPosition<i32>> {

--- a/desktop/src/window/main.rs
+++ b/desktop/src/window/main.rs
@@ -287,6 +287,7 @@ fn build_window_dom_and_config(
         App,
         AppProps {
             tabs,
+            active_tab: 0,
             directory,
             theme: params.theme,
             initial_window_position: params.position,

--- a/desktop/src/window/main.rs
+++ b/desktop/src/window/main.rs
@@ -1,5 +1,9 @@
 use dioxus::desktop::tao::dpi::{LogicalPosition, LogicalSize};
 use dioxus::desktop::tao::window::WindowId;
+#[cfg(target_os = "macos")]
+use dioxus::desktop::tao::{
+    dpi::LogicalPosition as TaoLogicalPosition, platform::macos::WindowBuilderExtMacOS,
+};
 use dioxus::desktop::{
     window, Config, DesktopService, WeakDesktopContext, WindowBuilder, WindowCloseBehaviour,
 };
@@ -29,18 +33,171 @@ const MAX_POSITION_SHIFT_ATTEMPTS: usize = 20;
 /// Create base window config from parameters
 /// This config can be further customized with .with_menu(), .with_custom_event_handler(), etc.
 pub fn create_main_window_config(params: &CreateMainWindowConfigParams) -> Config {
+    let builder = WindowBuilder::new()
+        .with_title("Arto")
+        .with_position(params.position)
+        .with_inner_size(params.size);
+
+    #[cfg(target_os = "macos")]
+    let builder = builder
+        .with_title_hidden(true)
+        .with_titlebar_transparent(true)
+        .with_fullsize_content_view(true)
+        .with_traffic_light_inset(TaoLogicalPosition::new(14.0, 16.0));
+
     Config::new()
-        .with_window(
-            WindowBuilder::new()
-                .with_title("Arto")
-                .with_position(params.position)
-                .with_inner_size(params.size),
-        )
+        .with_window(builder)
         // Add main style in config. Otherwise the style takes time to load and
         // the window appears unstyled for a brief moment.
-        .with_custom_head(indoc::formatdoc! {r#"<link rel="stylesheet" href="{MAIN_STYLE}">"#})
+        .with_custom_head(build_main_window_head())
         // Use a custom index to set the initial theme correctly
         .with_custom_index(build_custom_index(params.theme))
+}
+
+fn build_main_window_head() -> String {
+    let mut head = indoc::formatdoc! {r#"<link rel="stylesheet" href="{MAIN_STYLE}">"#};
+
+    #[cfg(target_os = "macos")]
+    head.push_str(indoc::indoc! {r#"
+        <style>
+          .tab-bar.native-titlebar {
+            align-items: center;
+            background: color-mix(in srgb, var(--header-bg) 94%, var(--bg-color));
+            border-bottom: 1px solid color-mix(in srgb, var(--border-color) 92%, transparent);
+            box-sizing: border-box;
+            gap: 5px;
+            margin-top: 0;
+            min-height: 60px;
+            opacity: 1;
+            overflow: hidden;
+            padding: 20px 14px 8px;
+            position: relative;
+            width: 100%;
+            z-index: calc(var(--z-header) + 1);
+          }
+
+          .tab-bar.native-titlebar:hover {
+            opacity: 1;
+          }
+
+          .tab-bar.native-titlebar .tab-bar-traffic-light-gap {
+            cursor: grab;
+            flex: 0 0 92px;
+            min-height: 32px;
+            min-width: 92px;
+          }
+
+          .tab-bar.native-titlebar .tab-strip {
+            align-items: center;
+            display: flex;
+            flex: 1 1 auto;
+            gap: 4px;
+            min-width: 0;
+            overflow-x: auto;
+            overflow-y: hidden;
+            padding-bottom: 2px;
+          }
+
+          .tab-bar.native-titlebar .tab-strip::-webkit-scrollbar {
+            height: 2px;
+          }
+
+          .tab-bar.native-titlebar .tab {
+            background: transparent;
+            border: 1px solid transparent;
+            border-radius: 10px;
+            color: var(--text-secondary);
+            min-height: 34px;
+            opacity: 0.88;
+          }
+
+          .tab-bar.native-titlebar .tab:hover {
+            background: color-mix(in srgb, var(--bg-secondary) 88%, transparent);
+            opacity: 1;
+          }
+
+          .tab-bar.native-titlebar .tab.active {
+            background: var(--bg-color);
+            border-color: color-mix(in srgb, var(--border-color) 92%, transparent);
+            box-shadow: var(--shadow-xs);
+            color: var(--text-color);
+          }
+
+          .tab-bar.native-titlebar .tab-close {
+            color: inherit;
+          }
+
+          .tab-bar.native-titlebar .tab-bar-drag-spacer {
+            cursor: grab;
+            flex: 1 1 72px;
+            min-height: 32px;
+            min-width: 48px;
+          }
+
+          .tab-bar.native-titlebar .tab-bar-controls {
+            align-items: center;
+            display: flex;
+            flex: 0 0 auto;
+            gap: 6px;
+          }
+
+          .tab-bar.native-titlebar .tab-new,
+          .tab-bar.native-titlebar .tab-preferences {
+            align-items: center;
+            background: transparent;
+            border: 1px solid transparent;
+            border-radius: 8px;
+            color: var(--text-secondary);
+            display: flex;
+            height: 28px;
+            justify-content: center;
+            margin-left: 0;
+            opacity: 0.9;
+            padding: 0;
+            width: 28px;
+          }
+
+          .tab-bar.native-titlebar .tab-new:hover,
+          .tab-bar.native-titlebar .tab-preferences:hover {
+            background: color-mix(in srgb, var(--bg-secondary) 88%, transparent);
+            border-color: color-mix(in srgb, var(--border-color) 92%, transparent);
+            color: var(--text-color);
+            opacity: 1;
+          }
+
+          .tab-bar.native-titlebar .tab-bar-drag-spacer,
+          .tab-bar.native-titlebar .tab-bar-traffic-light-gap {
+            border-radius: 6px;
+            user-select: none;
+            -webkit-user-select: none;
+          }
+
+          .tab-bar.native-titlebar .tab-bar-drag-spacer:active,
+          .tab-bar.native-titlebar .tab-bar-traffic-light-gap:active {
+            background: color-mix(in srgb, var(--text-color) 6%, transparent);
+            cursor: grabbing;
+          }
+
+          .app-container.macos-native-titlebar {
+            --macos-titlebar-height: 56px;
+          }
+
+          .app-container.macos-native-titlebar > .left-sidebar .right-sidebar-tabs {
+            padding-bottom: 2px;
+            padding-top: 22px;
+          }
+
+          .app-container.macos-native-titlebar > .right-sidebar .right-sidebar-tabs {
+            padding-bottom: 2px;
+          }
+
+          .header {
+            background: var(--header-bg);
+          }
+        </style>
+    "#});
+
+    head
 }
 
 /// Parameters for creating a new main window

--- a/desktop/src/window/settings.rs
+++ b/desktop/src/window/settings.rs
@@ -3,14 +3,16 @@ use dioxus::prelude::*;
 use mouse_position::mouse_position::Mouse;
 use std::path::PathBuf;
 
-use crate::components::right_sidebar::RightSidebarTab;
 use crate::config::{
     normalize_zoom_level as normalize_sidebar_zoom_level, NewWindowBehavior, StartupBehavior,
     WindowDimension, WindowDimensionUnit, WindowPosition, WindowPositionMode, WindowSize, CONFIG,
 };
-use crate::state::{PersistedState, Position, Size};
+use crate::state::{PersistedState, Position, SidebarPanel, Size};
 use crate::theme::Theme;
-use crate::utils::screen::{get_current_display_bounds, get_cursor_display, get_primary_display};
+use crate::utils::screen::{
+    get_current_display_bounds, get_cursor_display, get_display_bounds_for_logical_point,
+    get_primary_display,
+};
 use crate::window::main::get_last_focused_window_state;
 
 const MIN_WINDOW_DIMENSION: f64 = 100.0;
@@ -39,6 +41,7 @@ pub struct DirectoryPreference {
 
 pub struct SidebarPreference {
     pub pinned: bool,
+    pub panel: SidebarPanel,
     pub width: f64,
     pub show_all_files: bool,
     pub zoom_level: f64,
@@ -47,7 +50,7 @@ pub struct SidebarPreference {
 pub struct RightSidebarPreference {
     pub pinned: bool,
     pub width: f64,
-    pub tab: RightSidebarTab,
+    pub panel: SidebarPanel,
     pub zoom_level: f64,
 }
 
@@ -61,6 +64,12 @@ pub struct WindowPositionPreference {
 
 pub struct ZoomPreference {
     pub zoom_level: f64,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum WindowPositionSource {
+    Relative(WindowPosition),
+    Absolute(Position),
 }
 
 // ============================================================================
@@ -118,6 +127,25 @@ fn resolve_window_size(config: WindowSize, max_size: LogicalSize<u32>) -> Logica
     LogicalSize::new(width, height)
 }
 
+fn clamp_window_position_to_display(
+    position: LogicalPosition<i32>,
+    screen_origin: LogicalPosition<i32>,
+    screen_size: LogicalSize<u32>,
+    window_size: LogicalSize<u32>,
+) -> LogicalPosition<i32> {
+    let available_width_u32 = screen_size.width.saturating_sub(window_size.width);
+    let available_height_u32 = screen_size.height.saturating_sub(window_size.height);
+    let available_width = available_width_u32.min(i32::MAX as u32) as i32;
+    let available_height = available_height_u32.min(i32::MAX as u32) as i32;
+    let max_x = screen_origin.x + available_width;
+    let max_y = screen_origin.y + available_height;
+
+    LogicalPosition::new(
+        position.x.clamp(screen_origin.x, max_x),
+        position.y.clamp(screen_origin.y, max_y),
+    )
+}
+
 fn resolve_window_position(
     config: WindowPosition,
     screen_origin: LogicalPosition<i32>,
@@ -136,12 +164,21 @@ fn resolve_window_position(
 
     // Clamp position to ensure window stays on screen
     // This prevents off-screen windows when monitors are removed or repositioned
-    let max_x = screen_origin.x + available_width;
-    let max_y = screen_origin.y + available_height;
-    let clamped_x = absolute_position.x.clamp(screen_origin.x, max_x);
-    let clamped_y = absolute_position.y.clamp(screen_origin.y, max_y);
+    clamp_window_position_to_display(absolute_position, screen_origin, screen_size, window_size)
+}
 
-    LogicalPosition::new(clamped_x, clamped_y)
+fn resolve_absolute_window_position(
+    position: Position,
+    screen_origin: LogicalPosition<i32>,
+    screen_size: LogicalSize<u32>,
+    window_size: LogicalSize<u32>,
+) -> LogicalPosition<i32> {
+    clamp_window_position_to_display(
+        LogicalPosition::new(position.x, position.y),
+        screen_origin,
+        screen_size,
+        window_size,
+    )
 }
 
 fn resolve_window_position_from_cursor(
@@ -152,14 +189,28 @@ fn resolve_window_position_from_cursor(
         Mouse::Error => return None,
     };
     let display = get_cursor_display().or_else(get_primary_display)?;
-    let scale = display.scale_factor as f64;
-    if scale <= 0.0 {
-        return None;
-    }
-    let display_x = display.x as f64 / scale;
-    let display_y = display.y as f64 / scale;
-    let display_width = display.width as f64 / scale;
-    let display_height = display.height as f64 / scale;
+    #[cfg(target_os = "macos")]
+    let (display_x, display_y, display_width, display_height) = (
+        display.x as f64,
+        display.y as f64,
+        display.width as f64,
+        display.height as f64,
+    );
+
+    #[cfg(not(target_os = "macos"))]
+    let (display_x, display_y, display_width, display_height) = {
+        let scale = display.scale_factor as f64;
+        if scale <= 0.0 {
+            return None;
+        }
+        (
+            display.x as f64 / scale,
+            display.y as f64 / scale,
+            display.width as f64 / scale,
+            display.height as f64 / scale,
+        )
+    };
+
     let (cursor_x, cursor_y) = (x, y);
     let window_width = window_size.width as f64;
     let window_height = window_size.height as f64;
@@ -186,17 +237,40 @@ fn window_size_from_state(size: Size) -> WindowSize {
     }
 }
 
-fn window_position_from_state(position: Position) -> WindowPosition {
-    WindowPosition {
-        x: WindowDimension {
-            value: position.x as f64,
-            unit: WindowDimensionUnit::Pixels,
-        },
-        y: WindowDimension {
-            value: position.y as f64,
-            unit: WindowDimensionUnit::Pixels,
-        },
+fn has_persisted_window_position(persisted: &PersistedState) -> bool {
+    persisted.window_position != Position::default()
+}
+
+fn has_persisted_window_size(persisted: &PersistedState) -> bool {
+    persisted.window_size != Size::default()
+}
+
+fn should_restore_last_closed_position(
+    is_first_window: bool,
+    startup_behavior: StartupBehavior,
+    default_position_mode: WindowPositionMode,
+    persisted: &PersistedState,
+) -> bool {
+    if !is_first_window || !has_persisted_window_position(persisted) {
+        return false;
     }
+
+    matches!(startup_behavior, StartupBehavior::LastClosed)
+        || matches!(startup_behavior, StartupBehavior::Default)
+            && matches!(default_position_mode, WindowPositionMode::Coordinates)
+}
+
+fn should_restore_last_closed_size(
+    is_first_window: bool,
+    startup_behavior: StartupBehavior,
+    persisted: &PersistedState,
+) -> bool {
+    is_first_window
+        && has_persisted_window_size(persisted)
+        && matches!(
+            startup_behavior,
+            StartupBehavior::LastClosed | StartupBehavior::Default
+        )
 }
 
 /// Get window metrics from last focused window's AppState.
@@ -211,38 +285,76 @@ fn get_last_focused_metrics() -> Option<(Position, Size)> {
 
 fn resolve_window_settings(
     is_first_window: bool,
-) -> (WindowPosition, WindowPositionMode, WindowSize) {
+) -> (WindowPositionSource, WindowPositionMode, WindowSize) {
     let cfg = CONFIG.read();
-    let position = choose_by_behavior(
+    let persisted = PersistedState::load();
+    let restore_last_closed_position = should_restore_last_closed_position(
         is_first_window,
         cfg.window_position.on_startup,
-        cfg.window_position.on_new_window,
-        || cfg.window_position.default_position,
-        || {
-            get_last_focused_metrics()
-                .map(|(pos, _)| window_position_from_state(pos))
-                .unwrap_or_else(|| {
-                    window_position_from_state(PersistedState::load().window_position)
-                })
-        },
+        cfg.window_position.default_position_mode,
+        &persisted,
     );
-    let position_mode = choose_by_behavior(
+    let restore_last_closed_size =
+        should_restore_last_closed_size(is_first_window, cfg.window_size.on_startup, &persisted);
+
+    let position = if restore_last_closed_position {
+        get_last_focused_metrics()
+            .map(|(pos, _)| WindowPositionSource::Absolute(pos))
+            .unwrap_or_else(|| WindowPositionSource::Absolute(persisted.window_position))
+    } else {
+        choose_by_behavior(
+            is_first_window,
+            cfg.window_position.on_startup,
+            cfg.window_position.on_new_window,
+            || WindowPositionSource::Relative(cfg.window_position.default_position),
+            || {
+                get_last_focused_metrics()
+                    .map(|(pos, _)| WindowPositionSource::Absolute(pos))
+                    .unwrap_or_else(|| WindowPositionSource::Absolute(persisted.window_position))
+            },
+        )
+    };
+    let position_mode = if restore_last_closed_position {
+        WindowPositionMode::Coordinates
+    } else {
+        choose_by_behavior(
+            is_first_window,
+            cfg.window_position.on_startup,
+            cfg.window_position.on_new_window,
+            || cfg.window_position.default_position_mode,
+            || WindowPositionMode::Coordinates,
+        )
+    };
+    let size = if restore_last_closed_size {
+        get_last_focused_metrics()
+            .map(|(_, sz)| window_size_from_state(sz))
+            .unwrap_or_else(|| window_size_from_state(persisted.window_size))
+    } else {
+        choose_by_behavior(
+            is_first_window,
+            cfg.window_size.on_startup,
+            cfg.window_size.on_new_window,
+            || cfg.window_size.default_size,
+            || {
+                get_last_focused_metrics()
+                    .map(|(_, sz)| window_size_from_state(sz))
+                    .unwrap_or_else(|| window_size_from_state(persisted.window_size))
+            },
+        )
+    };
+
+    tracing::debug!(
         is_first_window,
-        cfg.window_position.on_startup,
-        cfg.window_position.on_new_window,
-        || cfg.window_position.default_position_mode,
-        || WindowPositionMode::Coordinates,
-    );
-    let size = choose_by_behavior(
-        is_first_window,
-        cfg.window_size.on_startup,
-        cfg.window_size.on_new_window,
-        || cfg.window_size.default_size,
-        || {
-            get_last_focused_metrics()
-                .map(|(_, sz)| window_size_from_state(sz))
-                .unwrap_or_else(|| window_size_from_state(PersistedState::load().window_size))
-        },
+        startup_position_behavior = ?cfg.window_position.on_startup,
+        startup_size_behavior = ?cfg.window_size.on_startup,
+        restore_last_closed_position,
+        restore_last_closed_size,
+        position_mode = ?position_mode,
+        position = ?position,
+        size = ?size,
+        persisted_position = ?persisted.window_position,
+        persisted_size = ?persisted.window_size,
+        "Resolved window settings"
     );
 
     (position, position_mode, size)
@@ -294,6 +406,7 @@ pub fn get_sidebar_preference(is_first_window: bool) -> SidebarPreference {
         cfg.sidebar.on_new_window,
         || SidebarPreference {
             pinned: cfg.sidebar.default_pinned,
+            panel: cfg.sidebar.default_panel,
             width: cfg.sidebar.default_width,
             show_all_files: cfg.sidebar.default_show_all_files,
             zoom_level: cfg.sidebar.default_zoom_level,
@@ -304,6 +417,7 @@ pub fn get_sidebar_preference(is_first_window: bool) -> SidebarPreference {
                     let sidebar = state.sidebar.read();
                     SidebarPreference {
                         pinned: sidebar.pinned,
+                        panel: *state.left_sidebar_panel.read(),
                         width: sidebar.width,
                         show_all_files: sidebar.show_all_files,
                         zoom_level: sidebar.zoom_level,
@@ -311,6 +425,7 @@ pub fn get_sidebar_preference(is_first_window: bool) -> SidebarPreference {
                 },
                 |persisted| SidebarPreference {
                     pinned: persisted.sidebar_pinned,
+                    panel: persisted.left_sidebar_panel,
                     width: persisted.sidebar_width,
                     show_all_files: persisted.sidebar_show_all_files,
                     zoom_level: persisted.sidebar_zoom_level,
@@ -334,7 +449,7 @@ pub fn get_right_sidebar_preference(is_first_window: bool) -> RightSidebarPrefer
         || RightSidebarPreference {
             pinned: cfg.right_sidebar.default_pinned,
             width: cfg.right_sidebar.default_width,
-            tab: cfg.right_sidebar.default_tab,
+            panel: cfg.right_sidebar.default_panel,
             zoom_level: cfg.right_sidebar.default_zoom_level,
         },
         || {
@@ -342,13 +457,13 @@ pub fn get_right_sidebar_preference(is_first_window: bool) -> RightSidebarPrefer
                 |state| RightSidebarPreference {
                     pinned: *state.right_sidebar_pinned.read(),
                     width: *state.right_sidebar_width.read(),
-                    tab: *state.right_sidebar_tab.read(),
+                    panel: *state.right_sidebar_panel.read(),
                     zoom_level: *state.right_sidebar_zoom_level.read(),
                 },
                 |persisted| RightSidebarPreference {
                     pinned: persisted.right_sidebar_pinned,
                     width: persisted.right_sidebar_width,
-                    tab: persisted.right_sidebar_tab,
+                    panel: persisted.right_sidebar_panel,
                     zoom_level: persisted.right_sidebar_zoom_level,
                 },
             )
@@ -397,12 +512,28 @@ pub fn get_window_position_preference(is_first_window: bool) -> WindowPositionPr
         .unwrap_or_else(|| (LogicalPosition::new(0, 0), LogicalSize::new(1000, 800)));
     let resolved_size = resolve_window_size(size, screen_size);
     let resolved_position = match position_mode {
-        WindowPositionMode::Coordinates => {
-            resolve_window_position(position, screen_origin, screen_size, resolved_size)
-        }
+        WindowPositionMode::Coordinates => match position {
+            WindowPositionSource::Relative(position) => {
+                resolve_window_position(position, screen_origin, screen_size, resolved_size)
+            }
+            WindowPositionSource::Absolute(position) => {
+                let persisted_point = LogicalPosition::new(position.x, position.y);
+                let (origin, size) = get_display_bounds_for_logical_point(persisted_point)
+                    .unwrap_or((screen_origin, screen_size));
+                resolve_absolute_window_position(position, origin, size, resolved_size)
+            }
+        },
         WindowPositionMode::Mouse => resolve_window_position_from_cursor(resolved_size)
             .unwrap_or_else(|| LogicalPosition::new(0, 0)),
     };
+    tracing::debug!(
+        is_first_window,
+        position_mode = ?position_mode,
+        position = ?position,
+        resolved_size = ?resolved_size,
+        resolved_position = ?resolved_position,
+        "Resolved window position preference"
+    );
     WindowPositionPreference {
         position: resolved_position,
     }
@@ -461,6 +592,53 @@ mod tests {
     }
 
     #[test]
+    fn test_should_restore_last_closed_position_for_first_window_coordinates() {
+        let persisted = PersistedState {
+            window_position: Position { x: 120, y: 80 },
+            ..Default::default()
+        };
+
+        assert!(should_restore_last_closed_position(
+            true,
+            StartupBehavior::Default,
+            WindowPositionMode::Coordinates,
+            &persisted,
+        ));
+    }
+
+    #[test]
+    fn test_should_not_restore_last_closed_position_for_mouse_mode() {
+        let persisted = PersistedState {
+            window_position: Position { x: 120, y: 80 },
+            ..Default::default()
+        };
+
+        assert!(!should_restore_last_closed_position(
+            true,
+            StartupBehavior::Default,
+            WindowPositionMode::Mouse,
+            &persisted,
+        ));
+    }
+
+    #[test]
+    fn test_should_restore_last_closed_size_for_first_window() {
+        let persisted = PersistedState {
+            window_size: Size {
+                width: 1200,
+                height: 800,
+            },
+            ..Default::default()
+        };
+
+        assert!(should_restore_last_closed_size(
+            true,
+            StartupBehavior::Default,
+            &persisted,
+        ));
+    }
+
+    #[test]
     fn test_get_theme_preference_first_window() {
         let result = get_theme_preference(true);
         // Should return a ThemePreference
@@ -501,6 +679,10 @@ mod tests {
         let result = get_sidebar_preference(true);
         // Should return a SidebarPreference
         assert!(result.width > 0.0);
+        assert!(matches!(
+            result.panel,
+            SidebarPanel::Directory | SidebarPanel::Contents | SidebarPanel::Search
+        ));
     }
 
     #[test]
@@ -508,6 +690,10 @@ mod tests {
         let result = get_sidebar_preference(false);
         // Should return a SidebarPreference
         assert!(result.width > 0.0);
+        assert!(matches!(
+            result.panel,
+            SidebarPanel::Directory | SidebarPanel::Contents | SidebarPanel::Search
+        ));
     }
 
     #[test]
@@ -516,8 +702,8 @@ mod tests {
         // Should return a RightSidebarPreference
         assert!(result.width > 0.0);
         assert!(matches!(
-            result.tab,
-            RightSidebarTab::Contents | RightSidebarTab::Search
+            result.panel,
+            SidebarPanel::Directory | SidebarPanel::Contents | SidebarPanel::Search
         ));
     }
 
@@ -527,8 +713,8 @@ mod tests {
         // Should return a RightSidebarPreference
         assert!(result.width > 0.0);
         assert!(matches!(
-            result.tab,
-            RightSidebarTab::Contents | RightSidebarTab::Search
+            result.panel,
+            SidebarPanel::Directory | SidebarPanel::Contents | SidebarPanel::Search
         ));
     }
 
@@ -629,6 +815,34 @@ mod tests {
         let resolved = resolve_window_position(position, screen_origin, screen_size, window_size);
         assert_eq!(resolved.x, -290);
         assert_eq!(resolved.y, -180);
+    }
+
+    #[test]
+    fn test_resolve_absolute_window_position_preserves_absolute_coordinates() {
+        let position = Position { x: 1200, y: 160 };
+        let screen_origin = LogicalPosition::new(1000, 0);
+        let screen_size = LogicalSize::new(800, 600);
+        let window_size = LogicalSize::new(400, 300);
+
+        let resolved =
+            resolve_absolute_window_position(position, screen_origin, screen_size, window_size);
+
+        assert_eq!(resolved.x, 1200);
+        assert_eq!(resolved.y, 160);
+    }
+
+    #[test]
+    fn test_resolve_absolute_window_position_clamps_to_display() {
+        let position = Position { x: 1700, y: 500 };
+        let screen_origin = LogicalPosition::new(1000, 0);
+        let screen_size = LogicalSize::new(800, 600);
+        let window_size = LogicalSize::new(400, 300);
+
+        let resolved =
+            resolve_absolute_window_position(position, screen_origin, screen_size, window_size);
+
+        assert_eq!(resolved.x, 1400);
+        assert_eq!(resolved.y, 300);
     }
 
     #[test]

--- a/extras/mac/Info.plist
+++ b/extras/mac/Info.plist
@@ -7,6 +7,7 @@
   <key>CFBundleExecutable</key><string>arto</string>
   <key>CFBundleIdentifier</key><string>com.lambdalisue.Arto</string>
   <key>CFBundleInfoDictionaryVersion</key><string>6.0</string>
+  <key>CFBundleIconFile</key><string>icon.icns</string>
   <key>CFBundleName</key><string>Arto</string>
   <key>CFBundlePackageType</key><string>APPL</string>
   <key>CFBundleShortVersionString</key><string>0.1.0</string>

--- a/renderer/src/render-coordinator.test.ts
+++ b/renderer/src/render-coordinator.test.ts
@@ -13,12 +13,16 @@ vi.mock("./mermaid-renderer", () => ({
 vi.mock("./code-copy", () => ({
   addCopyButtons: vi.fn(),
 }));
+vi.mock("./table-controls", () => ({
+  enhanceTables: vi.fn(),
+}));
 
 import { _internal } from "./render-coordinator";
 import * as mathRenderer from "./math-renderer";
 import * as syntaxHighlighter from "./syntax-highlighter";
 import * as mermaidRenderer from "./mermaid-renderer";
 import * as codeCopy from "./code-copy";
+import * as tableControls from "./table-controls";
 
 const { RenderCoordinator } = _internal;
 
@@ -107,6 +111,7 @@ describe("RenderCoordinator", () => {
       expect(syntaxHighlighter.highlightCodeBlocks).toHaveBeenCalledOnce();
       expect(mermaidRenderer.renderDiagrams).toHaveBeenCalledOnce();
       expect(codeCopy.addCopyButtons).toHaveBeenCalledOnce();
+      expect(tableControls.enhanceTables).toHaveBeenCalledOnce();
     });
 
     test("passes markdown-body element to each renderer", async () => {
@@ -123,6 +128,7 @@ describe("RenderCoordinator", () => {
       expect(syntaxHighlighter.highlightCodeBlocks).toHaveBeenCalledWith(markdownBody);
       expect(mermaidRenderer.renderDiagrams).toHaveBeenCalledWith(markdownBody);
       expect(codeCopy.addCopyButtons).toHaveBeenCalledWith(markdownBody);
+      expect(tableControls.enhanceTables).toHaveBeenCalledWith(markdownBody);
     });
 
     test("skips rendering when no .markdown-body exists", async () => {

--- a/renderer/src/render-coordinator.ts
+++ b/renderer/src/render-coordinator.ts
@@ -2,6 +2,7 @@ import * as mathRenderer from "./math-renderer";
 import * as mermaidRenderer from "./mermaid-renderer";
 import * as syntaxHighlighter from "./syntax-highlighter";
 import * as codeCopy from "./code-copy";
+import * as tableControls from "./table-controls";
 
 /**
  * Setup single-click listeners for Image blocks.
@@ -194,6 +195,7 @@ class RenderCoordinator {
           syntaxHighlighter.highlightCodeBlocks(markdownBody);
           await mermaidRenderer.renderDiagrams(markdownBody);
           codeCopy.addCopyButtons(markdownBody);
+          tableControls.enhanceTables(markdownBody);
           setupSpecialBlockListeners(markdownBody);
         }),
       );

--- a/renderer/src/table-controls.test.ts
+++ b/renderer/src/table-controls.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { enhanceTables } from "./table-controls";
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("enhanceTables", () => {
+  test("wraps markdown tables with controls and viewport", () => {
+    document.body.innerHTML = `
+      <div class="markdown-body">
+        <table>
+          <thead><tr><th>ID</th><th>Name</th></tr></thead>
+          <tbody><tr><td>UC-1</td><td>Example</td></tr></tbody>
+        </table>
+      </div>
+    `;
+
+    const container = document.querySelector(".markdown-body")!;
+    enhanceTables(container);
+
+    const wrapper = container.querySelector(".table-viewer");
+    const viewport = container.querySelector(".table-viewer-viewport");
+    const buttons = Array.from(container.querySelectorAll<HTMLButtonElement>(".table-viewer-button"));
+
+    expect(wrapper).not.toBeNull();
+    expect(viewport).not.toBeNull();
+    expect(viewport?.querySelector("table")).not.toBeNull();
+    expect(wrapper?.getAttribute("data-table-mode")).toBe("full");
+    expect(buttons.map((button) => button.textContent)).toEqual(["Fixed", "Full"]);
+    expect(buttons[1]?.classList.contains("active")).toBe(true);
+  });
+
+  test("switches between fixed and full modes", () => {
+    document.body.innerHTML = `
+      <div class="markdown-body">
+        <table>
+          <tr><th>ID</th><th>Name</th></tr>
+          <tr><td>UC-1</td><td>Example</td></tr>
+        </table>
+      </div>
+    `;
+
+    const container = document.querySelector(".markdown-body")!;
+    enhanceTables(container);
+
+    const wrapper = container.querySelector<HTMLElement>(".table-viewer")!;
+    const fixedButton = container.querySelector<HTMLButtonElement>('.table-viewer-button[data-mode="fixed"]')!;
+    const fullButton = container.querySelector<HTMLButtonElement>('.table-viewer-button[data-mode="full"]')!;
+
+    fixedButton.click();
+    expect(wrapper.dataset.tableMode).toBe("fixed");
+    expect(fixedButton.getAttribute("aria-pressed")).toBe("true");
+    expect(fullButton.getAttribute("aria-pressed")).toBe("false");
+
+    fullButton.click();
+    expect(wrapper.dataset.tableMode).toBe("full");
+    expect(fullButton.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  test("skips frontmatter tables", () => {
+    document.body.innerHTML = `
+      <div class="markdown-body">
+        <details class="frontmatter">
+          <table class="frontmatter-table">
+            <tr><th>ID</th><td>UC-1</td></tr>
+          </table>
+        </details>
+      </div>
+    `;
+
+    const container = document.querySelector(".markdown-body")!;
+    enhanceTables(container);
+
+    const table = container.querySelector("table")!;
+    expect(container.querySelector(".table-viewer")).toBeNull();
+    expect(table.getAttribute("data-table-controls-added")).toBe("skipped");
+  });
+
+  test("does not re-wrap a processed table", () => {
+    document.body.innerHTML = `
+      <div class="markdown-body">
+        <table>
+          <tr><th>ID</th><th>Name</th></tr>
+          <tr><td>UC-1</td><td>Example</td></tr>
+        </table>
+      </div>
+    `;
+
+    const container = document.querySelector(".markdown-body")!;
+    enhanceTables(container);
+    enhanceTables(container);
+
+    expect(container.querySelectorAll(".table-viewer")).toHaveLength(1);
+  });
+});

--- a/renderer/src/table-controls.ts
+++ b/renderer/src/table-controls.ts
@@ -1,0 +1,94 @@
+type TableMode = "fixed" | "full";
+
+const DEFAULT_MODE: TableMode = "full";
+
+/**
+ * Wrap markdown tables with a scroll viewport and a fixed/full mode toggle.
+ */
+export function enhanceTables(container: Element): void {
+  const tables = container.querySelectorAll("table:not([data-table-controls-added])");
+  if (tables.length === 0) {
+    return;
+  }
+
+  tables.forEach((table) => {
+    if (!(table instanceof HTMLTableElement)) {
+      return;
+    }
+
+    if (shouldSkipTable(table)) {
+      table.dataset.tableControlsAdded = "skipped";
+      return;
+    }
+
+    addTableControls(table);
+  });
+}
+
+function shouldSkipTable(table: HTMLTableElement): boolean {
+  return (
+    table.classList.contains("frontmatter-table") ||
+    table.classList.contains("yaml-nested-table") ||
+    table.closest(".frontmatter") !== null ||
+    table.closest(".table-viewer") !== null
+  );
+}
+
+function addTableControls(table: HTMLTableElement): void {
+  const parent = table.parentElement;
+  if (!parent) {
+    return;
+  }
+
+  table.dataset.tableControlsAdded = "yes";
+
+  const wrapper = document.createElement("div");
+  wrapper.className = "table-viewer";
+
+  const toolbar = document.createElement("div");
+  toolbar.className = "table-viewer-toolbar";
+
+  const segment = document.createElement("div");
+  segment.className = "table-viewer-segment";
+  segment.setAttribute("role", "group");
+  segment.setAttribute("aria-label", "Table view mode");
+
+  const fixedButton = createModeButton(wrapper, "fixed");
+  const fullButton = createModeButton(wrapper, "full");
+  segment.append(fixedButton, fullButton);
+  toolbar.appendChild(segment);
+
+  const viewport = document.createElement("div");
+  viewport.className = "table-viewer-viewport";
+
+  parent.insertBefore(wrapper, table);
+  viewport.appendChild(table);
+  wrapper.append(toolbar, viewport);
+
+  setMode(wrapper, DEFAULT_MODE);
+}
+
+function createModeButton(wrapper: HTMLElement, mode: TableMode): HTMLButtonElement {
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = "table-viewer-button";
+  button.dataset.mode = mode;
+  button.textContent = mode === "fixed" ? "Fixed" : "Full";
+  button.addEventListener("click", (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setMode(wrapper, mode);
+  });
+  return button;
+}
+
+function setMode(wrapper: HTMLElement, mode: TableMode): void {
+  wrapper.dataset.tableMode = mode;
+
+  wrapper.querySelectorAll<HTMLButtonElement>(".table-viewer-button").forEach((button) => {
+    const isActive = button.dataset.mode === mode;
+    button.classList.toggle("active", isActive);
+    button.setAttribute("aria-pressed", isActive ? "true" : "false");
+  });
+}
+

--- a/renderer/style/components/content.css
+++ b/renderer/style/components/content.css
@@ -1,5 +1,6 @@
 @import url("./content/frontmatter.css");
 @import url("./content/markdown-viewer.css");
+@import url("./content/table-controls.css");
 @import url("./content/no-file.css");
 
 .content {

--- a/renderer/style/components/content/markdown-viewer.css
+++ b/renderer/style/components/content/markdown-viewer.css
@@ -8,6 +8,20 @@
     margin: 0 auto;
     max-width: 960px;
 
+    /* Keep markdown tables content-sized so short IDs do not wrap under
+       container pressure; oversized tables can scroll horizontally. */
+    table {
+      width: max-content;
+      min-width: 100%;
+      max-width: none;
+    }
+
+    table th,
+    table td {
+      word-break: normal;
+      overflow-wrap: normal;
+    }
+
     /* Style markdown file links (span.md-link) to look like regular links */
     span.md-link {
       color: var(--link-color);

--- a/renderer/style/components/content/markdown-viewer.css
+++ b/renderer/style/components/content/markdown-viewer.css
@@ -8,14 +8,6 @@
     margin: 0 auto;
     max-width: 960px;
 
-    /* Keep markdown tables content-sized so short IDs do not wrap under
-       container pressure; oversized tables can scroll horizontally. */
-    table {
-      width: max-content;
-      min-width: 100%;
-      max-width: none;
-    }
-
     table th,
     table td {
       word-break: normal;

--- a/renderer/style/components/content/table-controls.css
+++ b/renderer/style/components/content/table-controls.css
@@ -1,0 +1,85 @@
+.markdown-body .table-viewer {
+  margin: 1rem 0;
+}
+
+.markdown-body .table-viewer-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 0.375rem;
+}
+
+.markdown-body .table-viewer-segment {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  background: var(--copy-button-bg);
+  overflow: hidden;
+}
+
+.markdown-body .table-viewer-button {
+  background: transparent;
+  border: 0;
+  border-right: 1px solid var(--border-color);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+  line-height: 1;
+  padding: 0.35rem 0.6rem;
+  transition:
+    background-color var(--transition-fast) ease,
+    color var(--transition-fast) ease;
+}
+
+.markdown-body .table-viewer-button:last-child {
+  border-right: 0;
+}
+
+.markdown-body .table-viewer-button:hover {
+  background: var(--copy-button-hover-bg);
+  color: var(--text-color);
+}
+
+.markdown-body .table-viewer-button.active {
+  background: var(--accent-bg);
+  color: var(--accent-fg);
+}
+
+.markdown-body .table-viewer-button:focus-visible {
+  outline: 2px solid var(--accent-bg);
+  outline-offset: -2px;
+}
+
+.markdown-body .table-viewer-viewport {
+  overflow-x: auto;
+  overflow-y: hidden;
+  max-width: 100%;
+  scrollbar-gutter: stable both-edges;
+}
+
+.markdown-body .table-viewer table {
+  display: table;
+  margin: 0;
+  max-width: none;
+}
+
+.markdown-body .table-viewer[data-table-mode="fixed"] table {
+  width: 100%;
+  table-layout: fixed;
+}
+
+.markdown-body .table-viewer[data-table-mode="fixed"] th,
+.markdown-body .table-viewer[data-table-mode="fixed"] td {
+  overflow-wrap: anywhere;
+}
+
+.markdown-body .table-viewer[data-table-mode="full"] table {
+  width: max-content;
+  min-width: 100%;
+}
+
+.markdown-body .table-viewer[data-table-mode="full"] th,
+.markdown-body .table-viewer[data-table-mode="full"] td {
+  word-break: normal;
+  overflow-wrap: normal;
+}

--- a/renderer/style/components/left-sidebar.css
+++ b/renderer/style/components/left-sidebar.css
@@ -99,8 +99,8 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 6px 0px;
-  margin: 0 0 8px 0;
+  padding: 2px 0;
+  margin: 0 0 2px 0;
 }
 
 /* History navigation buttons */

--- a/renderer/style/components/left-sidebar.css
+++ b/renderer/style/components/left-sidebar.css
@@ -32,6 +32,7 @@
   flex-direction: column;
   width: 100%;
   height: 100%;
+  min-height: 0;
 }
 
 /* Resize handle */
@@ -69,6 +70,7 @@
 /* File explorer container */
 .left-sidebar-explorer {
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
   overflow-x: hidden;
   padding: 8px;

--- a/renderer/style/components/right-sidebar.css
+++ b/renderer/style/components/right-sidebar.css
@@ -75,9 +75,26 @@
 /* Tab bar */
 .right-sidebar-tabs {
   display: flex;
-  gap: 16px;
+  align-items: center;
   padding: 12px 16px 8px;
   flex-shrink: 0;
+  gap: 8px;
+  min-width: 0;
+}
+
+.right-sidebar-tab-list {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none;
+}
+
+.right-sidebar-tab-list::-webkit-scrollbar {
+  display: none;
 }
 
 .right-sidebar-tab {
@@ -89,6 +106,8 @@
   font-weight: 400;
   color: var(--text-secondary);
   transition: font-weight var(--transition-fast);
+  flex: 0 0 auto;
+  white-space: nowrap;
 }
 
 .right-sidebar-tab.active {
@@ -172,6 +191,7 @@
   align-items: center;
   justify-content: center;
   opacity: var(--opacity-muted);
+  flex: 0 0 auto;
   transition:
     opacity var(--transition-normal),
     background-color var(--transition-fast) ease;


### PR DESCRIPTION
## Summary
- restore the last saved window geometry after a full app quit and relaunch on macOS
- fix macOS display coordinate handling and re-apply outer window position after mount for accurate restore
- allow both sidebars to swap between directory, search, and markdown contents panels
- ensure the bundled macOS app uses the correct app icon asset

## Verification
- cargo test --all-features --all-targets
- manually verified: move window, quit app, relaunch app, and confirm the window reopens at the saved position
- manually verified: left and right sidebars can switch between directory, search, and contents panels