### PR TITLE
fix(mac): add CFBundleIconFile to Info.plist to display app icon

### DIFF
--- a/desktop/src/components/app.rs
+++ b/desktop/src/components/app.rs
@@ -202,12 +202,10 @@ pub fn App(
                     ..
                 },
             ..
-        } => {
-            if *button == MOUSE_BUTTON_LEFT {
-                if let Some(dragged) = drag::get_dragged_tab() {
-                    if dragged.source_window_id == window().id() && drag::is_active_drag() {
-                        handle_drag_mouse_release(state);
-                    }
+        } if *button == MOUSE_BUTTON_LEFT => {
+            if let Some(dragged) = drag::get_dragged_tab() {
+                if dragged.source_window_id == window().id() && drag::is_active_drag() {
+                    handle_drag_mouse_release(state);
                 }
             }
         }

--- a/desktop/src/lib.rs
+++ b/desktop/src/lib.rs
@@ -101,14 +101,12 @@ pub fn run(invocation: cli::CliInvocation) -> RunResult {
                     event: WindowEvent::Focused(true),
                     window_id,
                     ..
-                } => {
+                } if !window::has_preview_window() => {
                     // Skip updating LAST_FOCUSED_WINDOW while a preview window exists
                     // to prevent focus from jumping to wrong window during drag.
                     // This blocks all focus updates during drag, not just when the
                     // preview window itself gains focus.
-                    if !window::has_preview_window() {
-                        window::update_last_focused_window(*window_id);
-                    }
+                    window::update_last_focused_window(*window_id);
                 }
                 Event::MainEventsCleared => {
                     // Defense in depth: drain the IPC queue once per event-loop cycle.

--- a/extras/mac/Info.plist
+++ b/extras/mac/Info.plist
@@ -8,6 +8,7 @@
   <key>CFBundleIdentifier</key><string>com.lambdalisue.Arto</string>
   <key>CFBundleInfoDictionaryVersion</key><string>6.0</string>
   <key>CFBundleName</key><string>Arto</string>
+  <key>CFBundleIconFile</key><string>arto-app</string>
   <key>CFBundlePackageType</key><string>APPL</string>
   <key>CFBundleShortVersionString</key><string>0.1.0</string>
   <key>CFBundleVersion</key><string>1</string>

--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1770169770,
-        "narHash": "sha256-awR8qIwJxJJiOmcEGgP2KUqYmHG4v/z8XpL9z8FnT1A=",
+        "lastModified": 1776255774,
+        "narHash": "sha256-psVTpH6PK3q1htMJpmdz1hLF5pQgEshu7gQWgKO6t6Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "aa290c9891fa4ebe88f8889e59633d20cc06a5f2",
+        "rev": "566acc07c54dc807f91625bb286cb9b321b5f42a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -55,7 +55,7 @@
           appExecutableName = "arto"; # lowercase executable name
           dxBundlePath =
             if isDarwin then
-              "target/dx/${packageMeta.pname}/bundle/macos/bundle/macos"
+              "target/dx/${packageMeta.pname}/bundle/macos/macos"
             # dx build (not bundle) outputs here; bundle fails in Nix sandbox
             # due to permission errors in the .deb/.AppImage packagers.
             else

--- a/renderer/src/context-menu-handler.test.ts
+++ b/renderer/src/context-menu-handler.test.ts
@@ -182,9 +182,9 @@ describe("setup", () => {
     document.caretRangeFromPoint = () => null;
 
     window.Arto = {
-      ...(window.Arto ?? {}),
+      ...window.Arto,
       contentCursor: {
-        ...(window.Arto?.contentCursor ?? {}),
+        ...window.Arto?.contentCursor,
         clearCursor: () => {},
         setFromContextTarget: () => {},
       },


### PR DESCRIPTION
## Summary

- Add `CFBundleIconFile` key to `extras/mac/Info.plist` so macOS correctly resolves and displays the app icon
- Update `flake.lock` to the latest nixpkgs revision

## Why

Without `CFBundleIconFile` in `Info.plist`, macOS cannot locate the icon file for the application bundle, resulting in a missing or generic icon in the Dock and Finder. This fix ensures the icon is displayed correctly on macOS.

## Test Plan

- [ ] Build the macOS app bundle (`dx bundle` or equivalent)
- [ ] Verify the Arto icon appears in the Dock when the app is launched
- [ ] Verify the Arto icon appears in Finder for the `.app` bundle
- [ ] Confirm no regression in app startup behavior