### PR TITLE
fix: wait for window.Arto init before context menu setup, fix macOS build paths

### DIFF
--- a/desktop/justfile
+++ b/desktop/justfile
@@ -21,7 +21,6 @@ clean:
 [macos]
 build:
   @rm -rf target/dx/arto/release/macos/Arto.app/Contents/Resources/assets
-  @rm -rf target/dx/arto/bundle/macos/macos/Arto.app/Contents/Resources/assets
   dx bundle --release --macos --package-types dmg
 
 [linux]
@@ -31,7 +30,7 @@ build:
 
 [macos]
 open:
-  ./target/dx/arto/bundle/macos/macos/Arto.app/Contents/MacOS/arto
+  ./target/dx/arto/release/macos/Arto.app/Contents/MacOS/arto
 
 [linux]
 open:
@@ -41,7 +40,7 @@ open:
 [macos]
 install:
   @rm -rf /Applications/Arto.app
-  @cp -af target/dx/arto/bundle/macos/macos/Arto.app /Applications/.
+  @cp -af target/dx/arto/release/macos/Arto.app /Applications/.
 
 [windows]
 build:

--- a/desktop/src/components/content/file_viewer.rs
+++ b/desktop/src/components/content/file_viewer.rs
@@ -501,11 +501,16 @@ fn use_context_menu_handler(file: PathBuf, base_dir: PathBuf) {
         let base_dir = base_dir.clone();
 
         // Setup JS context menu handler using the exported function
+        // Wait for window.Arto to be available (init() is async)
         let mut eval_provider = document::eval(indoc::indoc! {r#"
-            // Setup context menu handler
-            window.Arto.contextMenu.setup((data) => {
-                dioxus.send(data);
-            });
+            (async () => {
+                while (!window.Arto?.contextMenu?.setup) {
+                    await new Promise(resolve => setTimeout(resolve, 10));
+                }
+                window.Arto.contextMenu.setup((data) => {
+                    dioxus.send(data);
+                });
+            })();
         "#});
 
         spawn(async move {


### PR DESCRIPTION
## Summary
- Fix race condition where context menu setup ran before `window.Arto` was
  initialized asynchronously, causing intermittent failures on mount
- Correct macOS build output path for `open` and `install` recipes in justfile

## Why
`window.Arto` is populated by `init()` which runs asynchronously after the
WebView loads. Accessing `contextMenu.setup` immediately on mount could fail
because the API object did not yet exist. The fix polls in a loop until the
API becomes available before registering the handler.

The justfile `open`/`install` recipes referenced an incorrect output path for
the macOS bundle, causing those commands to fail after a clean build.

## Test Plan
- [ ] Open a Markdown file in file viewer; confirm context menu appears correctly
      without errors in the console
- [ ] Run `just open` on macOS and confirm it opens the built app without error
- [ ] Run `just install` on macOS and confirm it installs the app correctly