### PR TITLE
chore(nix): bump fetcherVersion to 3 and update source hash

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -80,8 +80,8 @@
               # 2. Run: nix build .#renderer-assets
               # 3. Copy the expected hash from error message
               # 4. Update hash value below
-              hash = "sha256-8KytJkWmwjphWnWxLrEDTT+KKO1ooyT0iQbYmHDZtgg=";
-              fetcherVersion = 2;
+              hash = "sha256-FN1QpuLke1m8uBM1xaKver3Jfn8EfzHfCmAuGoVT/SU=";
+              fetcherVersion = 3;
             };
 
             buildPhase = ''


### PR DESCRIPTION
## Summary
- Migrate `renderer-assets`'s `fetchPnpmDeps` from `fetcherVersion = 2` to `fetcherVersion = 3` in `flake.nix`
- Regenerate the `pnpmDeps` source hash (the pnpm store layout differs between fetcherVersion 2 and 3, so the fixed-output hash changes)
- `pnpm` stays at `pnpm_9` — `fetcherVersion` is independent of the pnpm major version

## Why
nixpkgs removed `fetcherVersion = 1` and `2` from `fetchPnpmDeps` in [NixOS/nixpkgs#523933](https://github.com/NixOS/nixpkgs/pull/523933) (merged 2026-06-03, part of the 26.11 release cleanup). Since Arto tracks `nixpkgs-unstable`, evaluating Arto against a recent nixpkgs — e.g. a downstream flake using `inputs.arto.inputs.nixpkgs.follows = "nixpkgs"`, or after `nix flake update` — now fails at **evaluation time**:

```
error: fetchPnpmDeps: `fetcherVersion = 2` was removed in the 26.11 release.
Please migrate `arto-renderer-assets` to `fetcherVersion = 3` and regenerate the hash.
See https://nixos.org/manual/nixpkgs/stable/#javascript-pnpm-fetcherVersion.
```

This is an evaluation error, so it cannot be worked around via the binary cache (substituter) — the package definition itself must be updated.

## Compatibility
- `fetcherVersion = 3` has been available since [NixOS/nixpkgs#469950](https://github.com/NixOS/nixpkgs/pull/469950) (2025-12-15) and is present in the nixpkgs revision currently pinned in `flake.lock`, so consumers using the committed lock are unaffected.
- `renderer-assets` already required nixpkgs ≥ 2025-07-14 (when `fetcherVersion = 2` itself was introduced); this only shifts that floor to 2025-12-15.

## Verification
- `nix build .#renderer-assets` — succeeds on the committed lock
- `nix build .#renderer-assets --override-input nixpkgs github:NixOS/nixpkgs/nixpkgs-unstable` — succeeds on post-removal nixpkgs, logs `Using fetcherVersion: 3`, no hash mismatch (the v3 hash is stable across nixpkgs revisions)
- Confirmed the old `fetcherVersion = 2` errors with the message above on the same post-removal nixpkgs (reproduces the regression)
- `nix build .#arto` / `nix build .#default` — succeed (aarch64-darwin; CI `build-nix` also covers ubuntu-latest)

## References
- nixpkgs manual (JavaScript / pnpm fetcherVersion): https://nixos.org/manual/nixpkgs/stable/#javascript-pnpm-fetcherVersion
- Removal: NixOS/nixpkgs#523933 ・ fetcherVersion 3 introduced: NixOS/nixpkgs#469950

🤖 Generated with Claude Code