### PR TITLE
ci: raise build-nix timeout from 30m to 60m

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,7 +147,10 @@ jobs:
           VERSION=$(git describe --tags --always)
           echo "${VERSION#v}" > desktop/VERSION
       - run: nix build
-    timeout-minutes: 30
+    # A cold cache (e.g. after a source-hash bump invalidates `arto-deps`)
+    # makes the full dependency + crate build exceed 30m on the ubuntu runner,
+    # and macOS already finishes within ~2m of the old limit. Give real headroom.
+    timeout-minutes: 60
 
   release:
     if: ${{ github.event_name == 'release' }}


### PR DESCRIPTION
## Summary
- Raise the `build-nix` job `timeout-minutes` from 30 to 60.

## Why
The `build-nix (ubuntu-latest)` job on `main` was killed by the 30m cap (`The job has exceeded the maximum execution time of 30m0s`). The trigger was commit `0e4000b chore(nix): bump fetcherVersion to 3 and update source hash`, which changed the source hash and invalidated the `arto-deps` derivation in cachix. With a cold cache the ubuntu runner has to rebuild the full dependency tree plus the final crate, which does not fit in 30m — and because the job is cancelled before finishing, it never repopulates cachix, making the failure self-perpetuating. macOS already finished at 27m50s, only ~2m under the old limit, so there was no headroom on either OS. Raising the timeout to 60m lets a cold build complete and prime the cache; subsequent builds pull `arto-deps` from cachix and stay fast.

## Test Plan
- [ ] CI `build-nix (ubuntu-latest)` completes within 60m on this PR (runs cold, since cachix push is skipped for PRs and `arto-deps` is not cached yet) — this is the empirical proof.
- [ ] `build-nix (macos-latest)` stays green.

## Note (out of scope)
The run logs also show Node.js 20 deprecation warnings for `extractions/setup-crate`, `pnpm/action-setup@v4`, and `cachix/cachix-action@v16` (forced to Node 24 as of 2026-06-16). Unrelated to this timeout failure; left for a separate change.