### PR TITLE
Fix default window height on macOS

### DIFF
--- a/desktop/src/utils/screen.rs
+++ b/desktop/src/utils/screen.rs
@@ -64,6 +64,12 @@ fn flip_y<T: DisplayLike>(y: i32, display: &T) -> i32 {
 /// - `None` - If no displays are available or scale factor is invalid
 pub fn get_current_display_bounds() -> Option<(LogicalPosition<i32>, LogicalSize<u32>)> {
     let display = get_cursor_display().or_else(get_primary_display)?;
+    display_info_logical_bounds(&display)
+}
+
+pub fn display_info_logical_bounds(
+    display: &DisplayInfo,
+) -> Option<(LogicalPosition<i32>, LogicalSize<u32>)> {
     let scale = display.scale_factor as f64;
     if scale <= 0.0 {
         return None;
@@ -120,6 +126,13 @@ pub fn get_cursor_display() -> Option<DisplayInfo> {
         .or_else(|| displays.first().cloned())
 }
 
+#[cfg(target_os = "macos")]
+fn to_logical_size_from_parts(width: u32, height: u32, _scale: f64) -> LogicalSize<u32> {
+    // display-info uses CGDisplayBounds on macOS, which is already in points.
+    LogicalSize::new(width.max(1), height.max(1))
+}
+
+#[cfg(not(target_os = "macos"))]
 fn to_logical_size_from_parts(width: u32, height: u32, scale: f64) -> LogicalSize<u32> {
     // Use safe minimum scale factor to prevent division by zero
     let safe_scale = if scale <= 0.0 { 1.0 } else { scale };
@@ -128,6 +141,13 @@ fn to_logical_size_from_parts(width: u32, height: u32, scale: f64) -> LogicalSiz
     LogicalSize::new(width, height)
 }
 
+#[cfg(target_os = "macos")]
+fn to_logical_position_from_parts(x: i32, y: i32, _scale: f64) -> LogicalPosition<i32> {
+    // display-info uses CGDisplayBounds on macOS, which is already in points.
+    LogicalPosition::new(x, y)
+}
+
+#[cfg(not(target_os = "macos"))]
 fn to_logical_position_from_parts(x: i32, y: i32, scale: f64) -> LogicalPosition<i32> {
     // Use safe minimum scale factor to prevent division by zero
     let safe_scale = if scale <= 0.0 { 1.0 } else { scale };
@@ -237,11 +257,20 @@ mod tests {
         assert_eq!(flip_y(15, &display), 115);
     }
 
+    #[cfg(not(target_os = "macos"))]
     #[test]
     fn test_to_logical_size_from_parts_scales() {
         let size = to_logical_size_from_parts(100, 50, 2.0);
         assert_eq!(size.width, 50);
         assert_eq!(size.height, 25);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_to_logical_size_from_parts_macos_uses_display_bounds() {
+        let size = to_logical_size_from_parts(100, 50, 2.0);
+        assert_eq!(size.width, 100);
+        assert_eq!(size.height, 50);
     }
 
     #[test]
@@ -251,10 +280,19 @@ mod tests {
         assert_eq!(size.height, 1);
     }
 
+    #[cfg(not(target_os = "macos"))]
     #[test]
     fn test_to_logical_position_from_parts_scales() {
         let position = to_logical_position_from_parts(-40, 20, 2.0);
         assert_eq!(position.x, -20);
         assert_eq!(position.y, 10);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_to_logical_position_from_parts_macos_uses_display_bounds() {
+        let position = to_logical_position_from_parts(-40, 20, 2.0);
+        assert_eq!(position.x, -40);
+        assert_eq!(position.y, 20);
     }
 }

--- a/desktop/src/window/main.rs
+++ b/desktop/src/window/main.rs
@@ -29,6 +29,8 @@ const MAX_POSITION_SHIFT_ATTEMPTS: usize = 20;
 /// Create base window config from parameters
 /// This config can be further customized with .with_menu(), .with_custom_event_handler(), etc.
 pub fn create_main_window_config(params: &CreateMainWindowConfigParams) -> Config {
+    let initial_size = params.size;
+
     Config::new()
         .with_window(
             WindowBuilder::new()
@@ -36,6 +38,11 @@ pub fn create_main_window_config(params: &CreateMainWindowConfigParams) -> Confi
                 .with_position(params.position)
                 .with_inner_size(params.size),
         )
+        // Dioxus/tao can lose the requested inner height on macOS during window
+        // construction, so apply the same size once the native window exists.
+        .with_on_window(move |window, _| {
+            window.set_inner_size(initial_size);
+        })
         // Add main style in config. Otherwise the style takes time to load and
         // the window appears unstyled for a brief moment.
         .with_custom_head(indoc::formatdoc! {r#"<link rel="stylesheet" href="{MAIN_STYLE}">"#})

--- a/desktop/src/window/settings.rs
+++ b/desktop/src/window/settings.rs
@@ -10,7 +10,10 @@ use crate::config::{
 };
 use crate::state::{PersistedState, Position, Size};
 use crate::theme::Theme;
-use crate::utils::screen::{get_current_display_bounds, get_cursor_display, get_primary_display};
+use crate::utils::screen::{
+    display_info_logical_bounds, get_current_display_bounds, get_cursor_display,
+    get_primary_display,
+};
 use crate::window::main::get_last_focused_window_state;
 
 const MIN_WINDOW_DIMENSION: f64 = 100.0;
@@ -152,14 +155,11 @@ fn resolve_window_position_from_cursor(
         Mouse::Error => return None,
     };
     let display = get_cursor_display().or_else(get_primary_display)?;
-    let scale = display.scale_factor as f64;
-    if scale <= 0.0 {
-        return None;
-    }
-    let display_x = display.x as f64 / scale;
-    let display_y = display.y as f64 / scale;
-    let display_width = display.width as f64 / scale;
-    let display_height = display.height as f64 / scale;
+    let (display_origin, display_size) = display_info_logical_bounds(&display)?;
+    let display_x = display_origin.x as f64;
+    let display_y = display_origin.y as f64;
+    let display_width = display_size.width as f64;
+    let display_height = display_size.height as f64;
     let (cursor_x, cursor_y) = (x, y);
     let window_width = window_size.width as f64;
     let window_height = window_size.height as f64;


### PR DESCRIPTION
## Summary

Fixes default window size handling on macOS.

This change:
- reapplies the configured inner window size after the native window is created
- avoids double-scaling display bounds on macOS when resolving configured window size and position

Without the display-bounds fix, large configured heights could be incorrectly clamped because `display-info` already returns macOS display bounds in points, but Arto divided them by the scale factor again.

## Notes

I noticed #177 also touches window restore and macOS display coordinate handling, but this PR keeps the scope limited to honoring the configured default window size.

## Verification

- `cargo fmt --all --check`
- `cargo check --all-targets --all-features`
- targeted unit tests for screen/window settings
- bundled macOS app with `dx bundle`
- manually verified that new windows honor configured height values

---

## 日本語での補足

macOS で Preferences の Window Size に設定した height が、新規ウィンドウに正しく反映されない問題を修正しました。

原因は2つありました。

- window 作成時に指定した inner size の height が Dioxus/tao/macOS 側で失われる場合がある
- macOS では `display-info` の display bounds が既に points 単位なのに、Arto 側でさらに scale factor で割っていたため、画面サイズが実際より小さく見積もられていた

手元では `dx bundle` した macOS app で、設定した height が新規ウィンドウに反映されることを確認しました。
