### PR TITLE
build: disable inherited rustc-wrapper to unblock dx bundle

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,9 @@
+# Disable any inherited rustc-wrapper (e.g. sccache from ~/.cargo/config.toml).
+#
+# The Dioxus CLI (`dx bundle`) invokes rustc through its own `.dx-wrapped`
+# wrapper. sccache fails to identify that wrapped compiler during its probe
+# (it feeds a C test file to the Rust wrapper), aborting the build with
+# "Compiler not supported". Clearing the wrapper here keeps sccache active for
+# other projects while letting Arto build.
+[build]
+rustc-wrapper = ""


### PR DESCRIPTION
## Summary
- Add a project-level `.cargo/config.toml` that clears `rustc-wrapper`, disabling any inherited wrapper (e.g. sccache) for this repository only.

## Why
`dx bundle` invokes rustc through its own `.dx-wrapped` wrapper. When a global `~/.cargo/config.toml` sets `rustc-wrapper = sccache`, sccache fails to identify that wrapped compiler during its probe — it feeds a C test file to the Rust wrapper — and aborts the build with `Compiler not supported`, so `just build` fails.

Clearing the wrapper at the project level fixes the build while leaving sccache active for other projects. For contributors and CI that never set a global wrapper, the empty value is a no-op.

## Test Plan
- [x] `just build` succeeds and produces `Arto_0.0.0_aarch64.dmg`

🤖 Generated with [Claude Code](https://claude.com/claude-code)