### PR TITLE
feat(desktop): add full-width content mode toggle

### DIFF
--- a/desktop/src/components/app.rs
+++ b/desktop/src/components/app.rs
@@ -50,6 +50,7 @@ pub fn App(
     tabs: Vec<Tab>,     // Initial tabs (at least one tab must be present)
     directory: PathBuf, // Directory (resolved in create_main_window or MainApp)
     theme: Theme,       // The enum: Auto/Light/Dark
+    content_full_width: bool,
     sidebar_pinned: bool,
     sidebar_width: f64,
     sidebar_show_all_files: bool,
@@ -72,6 +73,7 @@ pub fn App(
         // Initialize with provided tabs (preserves ordering)
         app_state.tabs.set(initial_tabs);
         app_state.active_tab.set(0);
+        app_state.content_full_width.set(content_full_width);
 
         // Apply initial sidebar settings from params (including directory)
         {

--- a/desktop/src/components/content/file_viewer.rs
+++ b/desktop/src/components/content/file_viewer.rs
@@ -46,6 +46,7 @@ pub fn FileViewer(file: PathBuf) -> Element {
     rsx! {
         div {
             class: "markdown-viewer",
+            class: if *state.content_full_width.read() { "full-width" },
             article {
                 class: "markdown-body",
                 dangerous_inner_html: "{html}"

--- a/desktop/src/components/content/inline_viewer.rs
+++ b/desktop/src/components/content/inline_viewer.rs
@@ -2,9 +2,11 @@ use dioxus::prelude::*;
 use std::path::Path;
 
 use crate::markdown::render_to_html;
+use crate::state::AppState;
 
 #[component]
 pub fn InlineViewer(markdown: String) -> Element {
+    let state = use_context::<AppState>();
     let html = use_signal(String::new);
 
     // Setup component hooks
@@ -13,6 +15,7 @@ pub fn InlineViewer(markdown: String) -> Element {
     rsx! {
         div {
             class: "markdown-viewer",
+            class: if *state.content_full_width.read() { "full-width" },
             article {
                 class: "markdown-body",
                 dangerous_inner_html: "{html}"

--- a/desktop/src/components/header.rs
+++ b/desktop/src/components/header.rs
@@ -189,6 +189,18 @@ pub fn Header() -> Element {
                     Icon { name: IconName::Search, size: 20 }
                 }
 
+                // Full-width content toggle
+                button {
+                    class: "nav-button full-width-button",
+                    class: if *state.content_full_width.read() { "active" },
+                    title: if *state.content_full_width.read() { "Disable full-width content" } else { "Full-width content" },
+                    onclick: move |_| state.toggle_content_full_width(),
+                    Icon {
+                        name: if *state.content_full_width.read() { IconName::ViewportNarrow } else { IconName::ViewportWide },
+                        size: 20,
+                    }
+                }
+
                 // Theme selector
                 ThemeSelector { current_theme: state.current_theme }
             }

--- a/desktop/src/components/icon.rs
+++ b/desktop/src/components/icon.rs
@@ -48,6 +48,8 @@ pub enum IconName {
     Sun,
     SunMoon,
     Trash,
+    ViewportNarrow,
+    ViewportWide,
 }
 
 impl fmt::Display for IconName {
@@ -96,6 +98,8 @@ impl fmt::Display for IconName {
             IconName::Sun => "sun",
             IconName::SunMoon => "sun-moon",
             IconName::Trash => "trash",
+            IconName::ViewportNarrow => "viewport-narrow",
+            IconName::ViewportWide => "viewport-wide",
         };
         write!(f, "{}", name)
     }

--- a/desktop/src/components/main_app.rs
+++ b/desktop/src/components/main_app.rs
@@ -70,6 +70,7 @@ pub fn MainApp() -> Element {
     let theme_pref = settings::get_theme_preference(is_first_window);
     let sidebar_pref = settings::get_sidebar_preference(is_first_window);
     let right_sidebar_pref = settings::get_right_sidebar_preference(is_first_window);
+    let content_full_width = settings::get_content_full_width_preference();
     let zoom_pref = settings::get_zoom_preference(is_first_window);
 
     // Directory resolution: override (from event) → config → tab parent → home → root
@@ -90,6 +91,7 @@ pub fn MainApp() -> Element {
             tabs: tabs,
             directory: directory,
             theme: theme_pref.theme,
+            content_full_width,
             sidebar_pinned: sidebar_pref.pinned,
             sidebar_width: sidebar_pref.width,
             sidebar_show_all_files: sidebar_pref.show_all_files,

--- a/desktop/src/state/app_state.rs
+++ b/desktop/src/state/app_state.rs
@@ -60,6 +60,8 @@ pub struct AppState {
     pub active_tab: Signal<usize>,
     pub current_theme: Signal<Theme>,
     pub zoom_level: Signal<f64>,
+    /// Whether the content area ignores the markdown body's max-width and fills the pane.
+    pub content_full_width: Signal<bool>,
     pub sidebar: Signal<Sidebar>,
     pub right_sidebar_pinned: Signal<bool>,
     pub right_sidebar_width: Signal<f64>,
@@ -115,6 +117,7 @@ impl AppState {
             active_tab: Signal::new(0),
             current_theme: Signal::new(theme),
             zoom_level: Signal::new(1.0),
+            content_full_width: Signal::new(false),
             sidebar: Signal::new(Sidebar::default()),
             right_sidebar_pinned: Signal::new(false),
             right_sidebar_width: Signal::new(DEFAULT_RIGHT_SIDEBAR_WIDTH),
@@ -196,6 +199,13 @@ impl AppState {
         if let Some(parent) = parent {
             self.set_root_directory(parent);
         }
+    }
+
+    /// Toggle full-width content mode, which lets the markdown body ignore its
+    /// max-width and fill the entire content pane.
+    pub fn toggle_content_full_width(&mut self) {
+        let was_full_width = *self.content_full_width.read();
+        self.content_full_width.set(!was_full_width);
     }
 
     /// Toggle right sidebar between pinned (flex layout) and unpinned (overlay/hover).

--- a/desktop/src/state/persistence.rs
+++ b/desktop/src/state/persistence.rs
@@ -50,6 +50,7 @@ impl From<LogicalSize<u32>> for Size {
 pub struct PersistedState {
     pub directory: Option<PathBuf>,
     pub theme: Theme,
+    pub content_full_width: bool,
     pub sidebar_pinned: bool,
     pub sidebar_width: f64,
     pub sidebar_show_all_files: bool,
@@ -75,6 +76,7 @@ impl Default for PersistedState {
         Self {
             directory: None,
             theme: Theme::default(),
+            content_full_width: false,
             sidebar_pinned: false,
             sidebar_width: 280.0,
             sidebar_show_all_files: false,
@@ -96,6 +98,7 @@ impl From<&AppState> for PersistedState {
         Self {
             directory: sidebar.root_directory.clone(),
             theme: *state.current_theme.read(),
+            content_full_width: *state.content_full_width.read(),
             sidebar_pinned: sidebar.pinned,
             sidebar_width: sidebar.width,
             sidebar_show_all_files: sidebar.show_all_files,
@@ -154,6 +157,7 @@ impl PersistedState {
         tracing::debug!(
             path = %path.display(),
             theme = ?self.theme,
+            content_full_width = self.content_full_width,
             sidebar_pinned = self.sidebar_pinned,
             sidebar_width = self.sidebar_width,
             sidebar_show_all_files = self.sidebar_show_all_files,
@@ -263,6 +267,19 @@ mod tests {
 
         assert!(parsed.sidebar_pinned);
         assert!(parsed.right_sidebar_pinned);
+    }
+
+    #[test]
+    fn test_content_full_width_roundtrip() {
+        let state = PersistedState {
+            content_full_width: true,
+            ..Default::default()
+        };
+
+        let json = serde_json::to_string(&state).unwrap();
+        let parsed: PersistedState = serde_json::from_str(&json).unwrap();
+
+        assert!(parsed.content_full_width);
     }
 
     #[test]

--- a/desktop/src/window/main.rs
+++ b/desktop/src/window/main.rs
@@ -54,6 +54,7 @@ pub fn create_main_window_config(params: &CreateMainWindowConfigParams) -> Confi
 pub struct CreateMainWindowConfigParams {
     pub directory: Option<PathBuf>, // Auto-detect from tab/file if None
     pub theme: Theme,               // The enum: Auto/Light/Dark
+    pub content_full_width: bool,
     pub sidebar_pinned: bool,
     pub sidebar_width: f64,
     pub sidebar_show_all_files: bool,
@@ -78,6 +79,7 @@ impl CreateMainWindowConfigParams {
         let theme_pref = settings::get_theme_preference(is_first_window);
         let sidebar_pref = settings::get_sidebar_preference(is_first_window);
         let right_sidebar_pref = settings::get_right_sidebar_preference(is_first_window);
+        let content_full_width = settings::get_content_full_width_preference();
         let zoom_pref = settings::get_zoom_preference(is_first_window);
         let size_pref = settings::get_window_size_preference(is_first_window);
         let position_pref = settings::get_window_position_preference(is_first_window);
@@ -85,6 +87,7 @@ impl CreateMainWindowConfigParams {
         Self {
             directory: directory_pref.directory,
             theme: theme_pref.theme,
+            content_full_width,
             sidebar_pinned: sidebar_pref.pinned,
             sidebar_width: sidebar_pref.width,
             sidebar_show_all_files: sidebar_pref.show_all_files,
@@ -286,6 +289,7 @@ fn build_window_dom_and_config(
             tabs,
             directory,
             theme: params.theme,
+            content_full_width: params.content_full_width,
             sidebar_pinned: params.sidebar_pinned,
             sidebar_width: params.sidebar_width,
             sidebar_show_all_files: params.sidebar_show_all_files,

--- a/desktop/src/window/settings.rs
+++ b/desktop/src/window/settings.rs
@@ -361,6 +361,18 @@ pub fn get_right_sidebar_preference(is_first_window: bool) -> RightSidebarPrefer
     }
 }
 
+/// Resolve the content full-width preference.
+///
+/// Unlike theme/sidebar/directory, this has no `Config` default or startup/new-window
+/// behavior setting — it simply follows the last focused window, falling back to
+/// `PersistedState` (state.json) so it survives across app restarts.
+pub fn get_content_full_width_preference() -> bool {
+    resolve_from_state_or_persisted(
+        |state| *state.content_full_width.read(),
+        |persisted| persisted.content_full_width,
+    )
+}
+
 pub fn get_zoom_preference(is_first_window: bool) -> ZoomPreference {
     let cfg = CONFIG.read();
     let zoom_level = choose_by_behavior(

--- a/renderer/icons.json
+++ b/renderer/icons.json
@@ -41,5 +41,7 @@
   "sun",
   "sun-moon",
   "trash",
+  "viewport-narrow",
+  "viewport-wide",
   "x"
 ]

--- a/renderer/style/components/content/markdown-viewer.css
+++ b/renderer/style/components/content/markdown-viewer.css
@@ -4,6 +4,10 @@
   padding: 24px;
   background-color: var(--content-bg);
 
+  &.full-width .markdown-body {
+    max-width: none;
+  }
+
   .markdown-body {
     margin: 0 auto;
     max-width: 960px;


### PR DESCRIPTION
## Summary
- Add a `content_full_width` toggle to `AppState`, persisted like the other sidebar toggles (state.json, inherited from the last focused window on new-window creation)
- Add a header icon button between the search button and theme selector to flip the mode (arrows-maximize / arrows-minimize icon pair, newly added via the add-icon skill)
- `.markdown-viewer.full-width .markdown-body` drops the 960px max-width so wide tables/code/diagrams can use the full pane; applies to both `FileViewer` and `InlineViewer`

## Why
Some documents (wide tables, code blocks, diagrams) are cramped by the markdown body's fixed max-width. This gives readers a one-click way to fill the whole content pane when needed, without changing the default reading width for everyone else.

## Test Plan
- [x] `just fmt check test` passes (Rust unit/doc tests, clippy `-D warnings`, renderer vitest)
- [ ] Manually verify in the running app: button renders between search and theme, icon swaps on toggle, content fills full width, and the setting survives an app restart