### PR TITLE
feat: native menu shortcuts split from engine keybindings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,29 +16,25 @@ jobs:
       - uses: actions/checkout@v7
       # https://zenn.dev/mierune/articles/2af7b9e447712a
       - uses: chetan/git-restore-mtime-action@v2
-      - uses: extractions/setup-just@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      # Run via the Nix devShell so the toolchain (rustc, clippy, rustfmt,
+      # dioxus-cli, node, pnpm) matches local development and never drifts.
+      - uses: nixbuild/nix-quick-install-action@v35
+      - uses: cachix/cachix-action@v17
+        if: github.event_name != 'pull_request'
         with:
-          components: clippy,rustfmt
-          cache-all-crates: true
-      - uses: pnpm/action-setup@v6
+          name: arto
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      - uses: actions/cache@v4
         with:
-          version: 10
-      - uses: actions/setup-node@v6
-        with:
-          cache: "pnpm"
-          cache-dependency-path: ./renderer/pnpm-lock.yaml
-      - name: Determine dx version from Cargo.lock
-        id: dx-version
-        run: |
-          version=$(grep -A1 'name = "dioxus"$' desktop/Cargo.lock | grep version | head -1 | perl -pe 's/.*"(.+?)".*/\1/')
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: dioxus-cli@${{ steps.dx-version.outputs.version }}
-      - run: just check
-      - run: just fmt && git diff --exit-code
-    timeout-minutes: 15
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            desktop/target
+          key: cargo-check-${{ runner.os }}-${{ hashFiles('desktop/Cargo.lock') }}
+          restore-keys: cargo-check-${{ runner.os }}-
+      - run: nix develop -c just check
+      - run: nix develop -c just fmt && git diff --exit-code
+    timeout-minutes: 30
 
   test:
     runs-on: macos-latest
@@ -46,31 +42,26 @@ jobs:
       - uses: actions/checkout@v7
       # https://zenn.dev/mierune/articles/2af7b9e447712a
       - uses: chetan/git-restore-mtime-action@v2
-      - uses: extractions/setup-just@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: nixbuild/nix-quick-install-action@v35
+      - uses: cachix/cachix-action@v17
+        if: github.event_name != 'pull_request'
         with:
-          cache-all-crates: true
-      - uses: pnpm/action-setup@v6
+          name: arto
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      - uses: actions/cache@v4
         with:
-          version: 10
-      - uses: actions/setup-node@v6
-        with:
-          cache: "pnpm"
-          cache-dependency-path: ./renderer/pnpm-lock.yaml
-      - name: Determine dx version from Cargo.lock
-        id: dx-version
-        run: |
-          version=$(grep -A1 'name = "dioxus"$' desktop/Cargo.lock | grep version | head -1 | perl -pe 's/.*"(.+?)".*/\1/')
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: dioxus-cli@${{ steps.dx-version.outputs.version }}
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            desktop/target
+          key: cargo-test-${{ runner.os }}-${{ hashFiles('desktop/Cargo.lock') }}
+          restore-keys: cargo-test-${{ runner.os }}-
       # Retry up to 3 times due to flaky NSScreen API tests in headless environment
       - name: Run tests
         run: |
           for i in 1 2 3; do
             echo "Attempt $i/3"
-            if just test; then
+            if nix develop -c just test; then
               exit 0
             fi
             if [ $i -lt 3 ]; then
@@ -80,7 +71,7 @@ jobs:
           done
           echo "All 3 attempts failed"
           exit 1
-    timeout-minutes: 15
+    timeout-minutes: 30
 
   build:
     needs: ["check", "test"]
@@ -91,33 +82,28 @@ jobs:
           fetch-depth: 0
       # https://zenn.dev/mierune/articles/2af7b9e447712a
       - uses: chetan/git-restore-mtime-action@v2
-      - uses: extractions/setup-just@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: nixbuild/nix-quick-install-action@v35
+      - uses: cachix/cachix-action@v17
+        if: github.event_name != 'pull_request'
         with:
-          cache-all-crates: true
-      - uses: pnpm/action-setup@v6
+          name: arto
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      - uses: actions/cache@v4
         with:
-          version: 10
-      - uses: actions/setup-node@v6
-        with:
-          cache: "pnpm"
-          cache-dependency-path: ./renderer/pnpm-lock.yaml
-      - name: Determine dx version from Cargo.lock
-        id: dx-version
-        run: |
-          version=$(grep -A1 'name = "dioxus"$' desktop/Cargo.lock | grep version | head -1 | perl -pe 's/.*"(.+?)".*/\1/')
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: dioxus-cli@${{ steps.dx-version.outputs.version }}
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            desktop/target
+          key: cargo-build-${{ runner.os }}-${{ hashFiles('desktop/Cargo.lock') }}
+          restore-keys: cargo-build-${{ runner.os }}-
       - name: Set package version for DMG filename
         if: ${{ github.event_name == 'release' }}
         run: |
           VERSION="${{ github.event.release.tag_name }}"
           VERSION="${VERSION#v}"
-          sed -i '' "s/^version = \"0.0.0\"/version = \"${VERSION}\"/" desktop/Cargo.toml
+          perl -i -pe 's/^version = "0\.0\.0"/version = "'"${VERSION}"'"/' desktop/Cargo.toml
           echo "${VERSION}" > desktop/VERSION
-      - run: just build
+      - run: nix develop -c just build
       - uses: actions/upload-artifact@v7
         with:
           name: arto-${{ runner.os }}

--- a/README.md
+++ b/README.md
@@ -64,6 +64,28 @@ Arto faithfully reproduces GitHub's Markdown rendering in a local, offline envir
 - **Preferences** — Configurable settings for sidebar, TOC, and more
 - **Context Menus** — Right-click menus for quick actions on files and content
 
+### Keyboard Shortcuts
+
+Shortcuts are stored in `mappings.json` (next to `config.json` in the app config
+directory) and come in two kinds:
+
+- **Menu shortcuts** (`menuShortcuts`) — native OS menu accelerators. Single
+  chord only (e.g. `Cmd+o`), shown in the menu bar, dispatched by the system, so
+  they work even when no window has keyboard focus (e.g. `Cmd+n` with all windows
+  closed). Keyed by a menu action such as `file.open`.
+- **Keybindings** (`global` and the per-context sections) — handled by the
+  in-window engine. Support chord sequences (e.g. vim `g g`) and per-context
+  behavior, but only fire while a document window has focus.
+
+The same action may appear in both — for example `file.open` can be a native
+`Cmd+o` menu shortcut and additionally have an in-window keybinding.
+
+**Migrating an older `mappings.json`:** files written before `menuShortcuts`
+existed still load unchanged. Menu-backed shortcuts you had under `global`
+(e.g. `Cmd+o`, `Cmd+n`) keep working via the engine, but to get native menu
+accelerators move those entries into a `menuShortcuts` section, or re-apply a
+preset (Default / Vim / Emacs) from Preferences.
+
 ## Installation
 
 Use [Homebrew] tap to install. Since the application is not signed or notarized with an Apple Developer ID, you'll need to remove the quarantine attribute after installation.

--- a/desktop/src/components/app/keybinding_engine.rs
+++ b/desktop/src/components/app/keybinding_engine.rs
@@ -25,6 +25,34 @@ fn should_skip_keybinding(data: &KeyEventData) -> bool {
     data.search_focused && data.modifiers == 0 && data.key == "Escape"
 }
 
+/// Send the current native menu-accelerator chords to the JS interceptor so it
+/// skips them (the OS menu dispatches those; forwarding would double-fire).
+///
+/// Must be called within the Dioxus runtime (component task / spawn).
+#[cfg(not(target_os = "windows"))]
+fn push_menu_accelerators_to_js() {
+    use crate::config::CONFIG;
+
+    let keys = crate::keybindings::menu_accelerator_skip_keys(&CONFIG.read().keybindings);
+    let json = serde_json::to_string(&keys).unwrap_or_else(|_| "[]".to_string());
+    let _ = document::eval(&format!(
+        r#"
+        (async () => {{
+            let retries = 0;
+            while (!window.Arto?.keyboard?.setMenuAccelerators && retries++ < 50) {{
+                await new Promise(r => setTimeout(r, 50));
+            }}
+            window.Arto?.keyboard?.setMenuAccelerators?.({json});
+        }})();
+        "#
+    ));
+}
+
+/// Windows has no native menu, so menu shortcuts are dispatched by the engine
+/// (see `BindingSet::into_resolved_bindings`) — there is nothing to skip.
+#[cfg(target_os = "windows")]
+fn push_menu_accelerators_to_js() {}
+
 /// Set up the keybinding engine with JS keyboard interceptor bridge.
 ///
 /// Creates the engine from current config, then establishes a JS → Rust bridge:
@@ -70,6 +98,10 @@ pub(super) fn setup_keybinding_engine(
             })();
             "#,
             );
+
+            // Tell the interceptor which chords are native menu accelerators so
+            // it does not also forward them to the engine (double-fire guard).
+            push_menu_accelerators_to_js();
 
             // If JS initialization fails (timeout), recv returns Err immediately and
             // the loop never starts. Log a warning so the issue is diagnosable.
@@ -153,6 +185,7 @@ pub(super) fn setup_keybinding_engine(
             while rx.recv().await.is_ok() {
                 let new_config = CONFIG.read().keybindings.clone();
                 *engine.read().borrow_mut() = KeybindingEngine::new(&new_config);
+                push_menu_accelerators_to_js();
                 tracing::debug!("Keybinding engine rebuilt after config change");
             }
         });

--- a/desktop/src/components/content/context_menu.rs
+++ b/desktop/src/components/content/context_menu.rs
@@ -335,7 +335,7 @@ pub fn ContentContextMenu(props: ContentContextMenuProps) -> Element {
                         on_close: props.on_close,
                     }
                 },
-                ContentContext::Image { src: _, .. } => rsx! {
+                ContentContext::Image { .. } => rsx! {
                     ContextMenuItem {
                         label: "Save Image As...",
                         shortcut: shortcut("file.save_image_as"),

--- a/desktop/src/components/content/preferences_view/tabs/keybindings_tab.rs
+++ b/desktop/src/components/content/preferences_view/tabs/keybindings_tab.rs
@@ -5,8 +5,22 @@ use dioxus::prelude::*;
 
 use crate::components::icon::{Icon, IconName};
 use crate::config::{BindingSet, Config, KeyAction};
-use crate::keybindings::{presets, resolve_bindings, KeyContext, ResolvedBinding, ACTION_GROUPS};
+use crate::keybindings::{
+    accelerator_for_key, presets, resolve_bindings, KeyContext, ResolvedBinding, ACTION_GROUPS,
+    MENU_ACTIONS,
+};
 use crate::shortcut::{KeyChord, ShortcutSequence};
+
+/// Which shortcut table a section edits.
+///
+/// Menu shortcuts become native OS menu accelerators (single chord, shown in the
+/// menu bar); engine bindings are handled in-window and support chord sequences
+/// and per-context behavior.
+#[derive(Clone, Copy, PartialEq)]
+enum BindingScope {
+    Menu,
+    Engine(Option<KeyContext>),
+}
 
 #[component]
 pub fn KeybindingsTab(config: Signal<Config>, has_changes: Signal<bool>) -> Element {
@@ -77,8 +91,16 @@ pub fn KeybindingsTab(config: Signal<Config>, has_changes: Signal<bool>) -> Elem
             }
 
             BindingSection {
+                title: "Menu Shortcuts",
+                scope: BindingScope::Menu,
+                bindings: keybindings.menu_shortcuts.clone(),
+                filter_query: filter_text(),
+                config,
+                has_changes,
+            }
+            BindingSection {
                 title: "Global",
-                context: None,
+                scope: BindingScope::Engine(None),
                 bindings: keybindings.global.clone(),
                 filter_query: filter_text(),
                 config,
@@ -86,7 +108,7 @@ pub fn KeybindingsTab(config: Signal<Config>, has_changes: Signal<bool>) -> Elem
             }
             BindingSection {
                 title: "Content",
-                context: Some(KeyContext::Content),
+                scope: BindingScope::Engine(Some(KeyContext::Content)),
                 bindings: keybindings.content.clone(),
                 filter_query: filter_text(),
                 config,
@@ -94,7 +116,7 @@ pub fn KeybindingsTab(config: Signal<Config>, has_changes: Signal<bool>) -> Elem
             }
             BindingSection {
                 title: "Sidebar",
-                context: Some(KeyContext::Sidebar),
+                scope: BindingScope::Engine(Some(KeyContext::Sidebar)),
                 bindings: keybindings.sidebar.clone(),
                 filter_query: filter_text(),
                 config,
@@ -102,7 +124,7 @@ pub fn KeybindingsTab(config: Signal<Config>, has_changes: Signal<bool>) -> Elem
             }
             BindingSection {
                 title: "Quick Access",
-                context: Some(KeyContext::QuickAccess),
+                scope: BindingScope::Engine(Some(KeyContext::QuickAccess)),
                 bindings: keybindings.quick_access.clone(),
                 filter_query: filter_text(),
                 config,
@@ -110,7 +132,7 @@ pub fn KeybindingsTab(config: Signal<Config>, has_changes: Signal<bool>) -> Elem
             }
             BindingSection {
                 title: "Right Sidebar",
-                context: Some(KeyContext::RightSidebar),
+                scope: BindingScope::Engine(Some(KeyContext::RightSidebar)),
                 bindings: keybindings.right_sidebar.clone(),
                 filter_query: filter_text(),
                 config,
@@ -118,7 +140,7 @@ pub fn KeybindingsTab(config: Signal<Config>, has_changes: Signal<bool>) -> Elem
             }
             BindingSection {
                 title: "Search",
-                context: Some(KeyContext::Search),
+                scope: BindingScope::Engine(Some(KeyContext::Search)),
                 bindings: keybindings.search.clone(),
                 filter_query: filter_text(),
                 config,
@@ -139,7 +161,7 @@ enum SortColumn {
 #[component]
 fn BindingSection(
     title: &'static str,
-    context: Option<KeyContext>,
+    scope: BindingScope,
     bindings: Vec<KeyAction>,
     filter_query: String,
     config: Signal<Config>,
@@ -219,7 +241,7 @@ fn BindingSection(
             h4 { class: "binding-section-title", "{title}" }
 
             if bindings.is_empty() && !*show_add_form.read() {
-                p { class: "binding-empty", "No bindings in this context." }
+                p { class: "binding-empty", "No bindings defined yet." }
             }
 
             if !bindings.is_empty() {
@@ -255,7 +277,7 @@ fn BindingSection(
                                             colspan: "2",
                                             BindingForm {
                                                 key: "edit-form-{real_idx}-{ka.key}-{ka.action}",
-                                                context,
+                                                scope,
                                                 edit_index: Some(*real_idx),
                                                 initial_key: Some(ka.key.clone()),
                                                 initial_action: Some(ka.action.clone()),
@@ -299,7 +321,7 @@ fn BindingSection(
             // Add button / inline add form (below bindings)
             if *show_add_form.read() {
                 BindingForm {
-                    context,
+                    scope,
                     edit_index: None::<usize>,
                     initial_key: None::<String>,
                     initial_action: None::<String>,
@@ -324,7 +346,7 @@ fn BindingSection(
 /// - `edit_index: Some(idx)` → Edit mode (pre-filled fields, update in place, show delete)
 #[component]
 fn BindingForm(
-    context: Option<KeyContext>,
+    scope: BindingScope,
     edit_index: Option<usize>,
     initial_key: Option<String>,
     initial_action: Option<String>,
@@ -495,17 +517,48 @@ fn BindingForm(
         if key_str.is_empty() {
             None
         } else {
-            let resolved = resolved.read();
-            if is_edit {
-                check_conflict_excluding(&resolved, &key_str, context, &orig_key, &orig_action)
-            } else {
-                check_conflict(&resolved, &key_str, context)
+            match scope {
+                BindingScope::Engine(context) => {
+                    let same_scope = {
+                        let resolved = resolved.read();
+                        if is_edit {
+                            check_conflict_excluding(
+                                &resolved,
+                                &key_str,
+                                context,
+                                &orig_key,
+                                &orig_action,
+                            )
+                        } else {
+                            check_conflict(&resolved, &key_str, context)
+                        }
+                    };
+                    // A chord owned by a native menu accelerator is consumed
+                    // before the engine, so also warn on menu-scope overlap.
+                    same_scope.or_else(|| {
+                        let menu_shortcuts = config.read().keybindings.menu_shortcuts.clone();
+                        cross_scope_conflict(&menu_shortcuts, &key_str, "Menu Shortcuts")
+                    })
+                }
+                BindingScope::Menu => {
+                    let keybindings = config.read().keybindings.clone();
+                    check_menu_conflict(&keybindings.menu_shortcuts, &key_str, is_edit, &orig_key)
+                        .or_else(|| cross_scope_conflict(&keybindings.global, &key_str, "Global"))
+                }
             }
         }
     };
 
-    let key_valid =
-        !key_input.read().is_empty() && ShortcutSequence::from_str(&key_input.read()).is_ok();
+    // Menu shortcuts must be a single chord representable as a native accelerator;
+    // engine bindings accept any valid chord sequence.
+    let key_valid = {
+        let key = key_input.read();
+        !key.is_empty()
+            && match scope {
+                BindingScope::Menu => accelerator_for_key(&key).is_some(),
+                BindingScope::Engine(_) => ShortcutSequence::from_str(&key).is_ok(),
+            }
+    };
     let action_valid = !selected_action.read().is_empty();
 
     let can_submit = if is_edit {
@@ -611,19 +664,38 @@ fn BindingForm(
                         selected: selected_action_value.is_empty(),
                         "Select action..."
                     }
-                    for (group_label, actions) in ACTION_GROUPS {
-                        optgroup {
-                            label: *group_label,
-                            for action in *actions {
-                                {
-                                    let action_value = action.to_string();
-                                    let is_selected = selected_action_value == action_value;
-                                    rsx! {
-                                option {
-                                            key: "{action_value}",
-                                            value: "{action_value}",
-                                            selected: is_selected,
-                                            "{action_label(&action_value)}"
+                    // Menu shortcuts may only target menu-backed actions; engine
+                    // bindings can target any action (grouped by category).
+                    if scope == BindingScope::Menu {
+                        for action in MENU_ACTIONS {
+                            {
+                                let action_value = action.to_string();
+                                let is_selected = selected_action_value == action_value;
+                                rsx! {
+                                    option {
+                                        key: "{action_value}",
+                                        value: "{action_value}",
+                                        selected: is_selected,
+                                        "{action_label(&action_value)}"
+                                    }
+                                }
+                            }
+                        }
+                    } else {
+                        for (group_label, actions) in ACTION_GROUPS {
+                            optgroup {
+                                label: *group_label,
+                                for action in *actions {
+                                    {
+                                        let action_value = action.to_string();
+                                        let is_selected = selected_action_value == action_value;
+                                        rsx! {
+                                    option {
+                                                key: "{action_value}",
+                                                value: "{action_value}",
+                                                selected: is_selected,
+                                                "{action_label(&action_value)}"
+                                            }
                                         }
                                     }
                                 }
@@ -657,7 +729,7 @@ fn BindingForm(
                             return;
                         }
                         let mut cfg = config.write();
-                        let bindings = bindings_mut(&mut cfg.keybindings, context);
+                        let bindings = bindings_mut(&mut cfg.keybindings, scope);
                         if let Some(idx) = edit_index {
                             if let Some(binding) = bindings.get_mut(idx) {
                                 binding.key = key;
@@ -686,12 +758,11 @@ fn BindingForm(
                     button {
                         class: "binding-form-delete",
                         onclick: {
-                            let context = context;
                             let key_to_remove = orig_key.clone();
                             move |_| {
                                 bindings_mut(
                                     &mut config.write().keybindings,
-                                    context,
+                                    scope,
                                 ).retain(|b| b.key != key_to_remove);
                                 has_changes.set(true);
                                 on_close.call(());
@@ -709,19 +780,77 @@ fn BindingForm(
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// Get mutable reference to the bindings for a given context.
-fn bindings_mut(
-    set: &mut crate::config::BindingSet,
-    ctx: Option<KeyContext>,
-) -> &mut Vec<KeyAction> {
-    match ctx {
-        None => &mut set.global,
-        Some(KeyContext::Content) => &mut set.content,
-        Some(KeyContext::Sidebar) => &mut set.sidebar,
-        Some(KeyContext::QuickAccess) => &mut set.quick_access,
-        Some(KeyContext::RightSidebar) => &mut set.right_sidebar,
-        Some(KeyContext::Search) => &mut set.search,
+/// Get mutable reference to the bindings for a given scope.
+fn bindings_mut(set: &mut crate::config::BindingSet, scope: BindingScope) -> &mut Vec<KeyAction> {
+    match scope {
+        BindingScope::Menu => &mut set.menu_shortcuts,
+        BindingScope::Engine(None) => &mut set.global,
+        BindingScope::Engine(Some(KeyContext::Content)) => &mut set.content,
+        BindingScope::Engine(Some(KeyContext::Sidebar)) => &mut set.sidebar,
+        BindingScope::Engine(Some(KeyContext::QuickAccess)) => &mut set.quick_access,
+        BindingScope::Engine(Some(KeyContext::RightSidebar)) => &mut set.right_sidebar,
+        BindingScope::Engine(Some(KeyContext::Search)) => &mut set.search,
     }
+}
+
+/// Check a menu-shortcut key for validity and duplicates.
+///
+/// Menu shortcuts must be a single chord representable as a native accelerator,
+/// and each chord may be bound only once (one chord = one owner).
+fn check_menu_conflict(
+    menu_shortcuts: &[KeyAction],
+    new_key: &str,
+    is_edit: bool,
+    exclude_key: &str,
+) -> Option<BindingNotice> {
+    if accelerator_for_key(new_key).is_none() {
+        return Some(BindingNotice::Conflict(
+            "Menu shortcuts must be a single chord (e.g. Cmd+K)".to_string(),
+        ));
+    }
+
+    let new_seq = ShortcutSequence::from_str(new_key).ok()?.to_string();
+    for ka in menu_shortcuts {
+        if is_edit && ka.key == exclude_key {
+            continue;
+        }
+        let existing = ShortcutSequence::from_str(&ka.key)
+            .map(|s| s.to_string())
+            .unwrap_or_default();
+        if existing == new_seq {
+            return Some(BindingNotice::Conflict(format!(
+                "Conflicts with \"{}\" (Menu Shortcuts)",
+                action_label(&ka.action)
+            )));
+        }
+    }
+    None
+}
+
+/// Detect a same-chord collision against a flat binding list from the OTHER
+/// shortcut scope.
+///
+/// A chord owned by both a native menu accelerator and an engine binding leaves
+/// one permanently unreachable (the OS menu / interceptor consumes the chord
+/// before the engine sees it), so surface it as a conflict in both editors.
+fn cross_scope_conflict(
+    other: &[KeyAction],
+    new_key: &str,
+    other_label: &str,
+) -> Option<BindingNotice> {
+    let new_seq = ShortcutSequence::from_str(new_key).ok()?.to_string();
+    for ka in other {
+        let existing = ShortcutSequence::from_str(&ka.key)
+            .map(|s| s.to_string())
+            .unwrap_or_default();
+        if existing == new_seq {
+            return Some(BindingNotice::Conflict(format!(
+                "Also bound as \"{}\" ({other_label}) — one will shadow the other",
+                action_label(&ka.action)
+            )));
+        }
+    }
+    None
 }
 
 /// Convert an action string like "scroll.down" to a human-readable label "Scroll Down".
@@ -959,6 +1088,61 @@ mod tests {
         }];
         let result = check_conflict(&resolved, "k", None);
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn menu_conflict_rejects_multi_chord() {
+        let result = check_menu_conflict(&[], "g g", false, "");
+        assert!(matches!(result, Some(BindingNotice::Conflict(_))));
+    }
+
+    #[test]
+    fn menu_conflict_detects_duplicate_chord() {
+        let existing = vec![KeyAction {
+            key: "Cmd+o".to_string(),
+            action: "file.open".to_string(),
+        }];
+        let result = check_menu_conflict(&existing, "Cmd+o", false, "");
+        assert!(matches!(result, Some(BindingNotice::Conflict(_))));
+    }
+
+    #[test]
+    fn menu_conflict_allows_unique_single_chord() {
+        let existing = vec![KeyAction {
+            key: "Cmd+o".to_string(),
+            action: "file.open".to_string(),
+        }];
+        assert!(check_menu_conflict(&existing, "Cmd+k", false, "").is_none());
+    }
+
+    #[test]
+    fn cross_scope_conflict_detects_overlap() {
+        let global = vec![KeyAction {
+            key: "Cmd+r".to_string(),
+            action: "window.reload".to_string(),
+        }];
+        // Adding Cmd+r as a menu shortcut collides with the global engine binding.
+        let result = cross_scope_conflict(&global, "Cmd+r", "Global");
+        assert!(matches!(result, Some(BindingNotice::Conflict(_))));
+    }
+
+    #[test]
+    fn cross_scope_conflict_ignores_distinct_chords() {
+        let menu = vec![KeyAction {
+            key: "Cmd+o".to_string(),
+            action: "file.open".to_string(),
+        }];
+        assert!(cross_scope_conflict(&menu, "Cmd+k", "Menu Shortcuts").is_none());
+    }
+
+    #[test]
+    fn menu_conflict_excludes_edited_entry() {
+        let existing = vec![KeyAction {
+            key: "Cmd+o".to_string(),
+            action: "file.open".to_string(),
+        }];
+        // Editing the same entry (orig_key = "Cmd+o") should not self-conflict.
+        assert!(check_menu_conflict(&existing, "Cmd+o", true, "Cmd+o").is_none());
     }
 
     #[test]

--- a/desktop/src/components/main_app.rs
+++ b/desktop/src/components/main_app.rs
@@ -40,6 +40,16 @@ pub fn MainApp() -> Element {
         crate::menu::handle_menu_event_global(event);
     });
 
+    // Keep native menu accelerators in sync with the keybinding config.
+    // Runs on the main thread (required for muda menu mutation).
+    #[cfg(not(target_os = "windows"))]
+    use_future(move || async move {
+        let mut rx = crate::config::CONFIG_CHANGED_BROADCAST.subscribe();
+        while rx.recv().await.is_ok() {
+            crate::menu::refresh_menu_accelerators();
+        }
+    });
+
     // Pop the first event from IPC queue (CLI path pushed by main.rs before launch)
     let first_event = crate::ipc::try_pop_first_event();
     if first_event.is_some() {

--- a/desktop/src/components/search_bar.rs
+++ b/desktop/src/components/search_bar.rs
@@ -91,6 +91,9 @@ pub fn SearchBar() -> Element {
     let match_count = *state.search_match_count.read();
     let current_index = *state.search_current_index.read();
     let initial_text = state.search_initial_text.read().clone();
+    // Bumped on every open-search request so re-pressing the shortcut refocuses
+    // the input even when the bar is already open.
+    let focus_request = *state.search_focus_request.read();
     let mut has_input = use_signal(|| false);
 
     // Local signal for pinned searches (updated via broadcast)
@@ -116,8 +119,11 @@ pub fn SearchBar() -> Element {
         }
     });
 
-    // Handle focus and initial text when search bar opens
-    use_effect(use_reactive!(|is_open, initial_text| {
+    // Handle focus and initial text when search bar opens.
+    // `focus_request` is a reactive trigger: it re-runs this effect on every
+    // open-search request, even when `is_open`/`initial_text` are unchanged.
+    use_effect(use_reactive!(|is_open, initial_text, focus_request| {
+        let _ = focus_request;
         if is_open {
             if let Some(ref text) = initial_text {
                 if !text.is_empty() {

--- a/desktop/src/config/app_config/keybindings_config.rs
+++ b/desktop/src/config/app_config/keybindings_config.rs
@@ -2,12 +2,23 @@ use serde::{Deserialize, Serialize};
 
 /// Per-context keybinding definition stored in `mappings.json`.
 ///
+/// Two distinct kinds of shortcut live here, differing by capability:
+///
+/// - `menu_shortcuts`: native OS menu accelerators. Single-chord only, shown in
+///   the menu bar, dispatched by the OS (so they work even when no window has
+///   keyboard focus). Keyed by a menu-backed [`crate::keybindings::Action`].
+/// - Everything else (`global` + per-context): keybindings handled by the
+///   in-window engine. Support chord sequences and per-context resolution but
+///   only fire while a WebView has focus.
+///
 /// `global` bindings are always visible (fallback for all contexts).
-/// Other fields hold bindings active only in that specific context.
+/// Other context fields hold bindings active only in that specific context.
 /// Presets are loaded on demand from the UI, not stored as a field.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct BindingSet {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub menu_shortcuts: Vec<KeyAction>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub global: Vec<KeyAction>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -36,6 +47,7 @@ mod tests {
     #[test]
     fn default_is_empty() {
         let set = BindingSet::default();
+        assert!(set.menu_shortcuts.is_empty());
         assert!(set.global.is_empty());
         assert!(set.content.is_empty());
         assert!(set.sidebar.is_empty());
@@ -103,5 +115,42 @@ mod tests {
             ..Default::default()
         };
         assert!(!set.global.is_empty());
+    }
+
+    #[test]
+    fn menu_shortcuts_roundtrip() {
+        let set = BindingSet {
+            menu_shortcuts: vec![KeyAction {
+                key: "Cmd+o".to_string(),
+                action: "file.open".to_string(),
+            }],
+            ..Default::default()
+        };
+
+        let json = serde_json::to_string_pretty(&set).unwrap();
+        assert!(json.contains("menuShortcuts"));
+        let parsed: BindingSet = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, set);
+    }
+
+    #[test]
+    fn menu_shortcuts_skipped_when_empty() {
+        let json = serde_json::to_string(&BindingSet::default()).unwrap();
+        assert!(!json.contains("menuShortcuts"));
+    }
+
+    /// Legacy `mappings.json` files (written before `menuShortcuts` existed)
+    /// must keep loading: the new field defaults to empty, and existing
+    /// per-context sections are preserved.
+    #[test]
+    fn legacy_json_without_menu_shortcuts_loads() {
+        let json = r#"{
+            "global": [{"key": "Cmd+o", "action": "file.open"}],
+            "sidebar": [{"key": "j", "action": "cursor.down"}]
+        }"#;
+        let set: BindingSet = serde_json::from_str(json).unwrap();
+        assert!(set.menu_shortcuts.is_empty());
+        assert_eq!(set.global.len(), 1);
+        assert_eq!(set.sidebar.len(), 1);
     }
 }

--- a/desktop/src/keybindings.rs
+++ b/desktop/src/keybindings.rs
@@ -1,3 +1,4 @@
+mod accelerator;
 mod action;
 mod context;
 pub mod dispatcher;
@@ -5,6 +6,7 @@ mod engine;
 mod hint;
 pub mod presets;
 
+pub use accelerator::*;
 pub use action::*;
 pub use context::*;
 pub use engine::*;

--- a/desktop/src/keybindings/accelerator.rs
+++ b/desktop/src/keybindings/accelerator.rs
@@ -1,0 +1,295 @@
+use dioxus::html::{Key, Modifiers};
+use dioxus_desktop::muda::accelerator::{Accelerator, Code, Modifiers as MudaModifiers};
+
+use crate::config::BindingSet;
+use crate::shortcut::ShortcutSequence;
+
+/// Convert a single-chord config key string into a native muda `Accelerator`.
+///
+/// Menu shortcuts are dispatched by the OS via muda accelerators, which only
+/// support a single modifier+key chord. This returns `None` for:
+/// - multi-chord sequences (e.g. vim `g g`)
+/// - keys with no physical `Code` mapping
+///
+/// In those cases the caller keeps the cosmetic menu hint and lets the
+/// keybinding engine handle the shortcut instead.
+pub fn accelerator_for_key(key: &str) -> Option<Accelerator> {
+    let sequence: ShortcutSequence = key.parse().ok()?;
+    let [chord] = sequence.chords.as_slice() else {
+        // Only single-chord shortcuts can become native accelerators.
+        return None;
+    };
+
+    let code = key_to_code(&chord.key)?;
+    let modifiers = modifiers_to_muda(chord.modifiers);
+    let modifiers = (!modifiers.is_empty()).then_some(modifiers);
+    Some(Accelerator::new(modifiers, code))
+}
+
+/// Canonical skip key (`"<modifier-bits>:<physical-code>"`) for a menu shortcut,
+/// matching the JS interceptor's `canonicalChord`.
+///
+/// The key part is the **physical** `Code` (e.g. `"KeyW"`), matching how muda
+/// dispatches accelerators, not the logical key. This is required because
+/// Alt/Option remaps `KeyboardEvent.key` on macOS (e.g. `Cmd+Alt+w` reports a
+/// different glyph), which would break a logical-key comparison; `event.code`
+/// is modifier-stable.
+///
+/// Returns `None` unless the key is a single chord that maps to a physical
+/// code — only those are OS-dispatched and would otherwise double-fire.
+pub fn menu_accelerator_skip_key(key: &str) -> Option<String> {
+    let sequence: ShortcutSequence = key.parse().ok()?;
+    let [chord] = sequence.chords.as_slice() else {
+        return None;
+    };
+    let code = key_to_code(&chord.key)?;
+    Some(format!("{}:{}", chord.modifiers.bits(), code))
+}
+
+/// Canonical skip keys for all native menu shortcuts in a binding set.
+///
+/// The keybinding engine forwards these to the JS interceptor so it can avoid
+/// double-dispatching chords the OS menu already handles. Only entries whose
+/// action actually maps to a menu item are included — a shortcut bound to a
+/// non-menu action attaches to no menu item, so skipping it would leave the
+/// chord dead.
+pub fn menu_accelerator_skip_keys(bindings: &BindingSet) -> Vec<String> {
+    bindings
+        .menu_shortcuts
+        .iter()
+        .filter(|ka| super::is_menu_action(&ka.action))
+        .filter_map(|ka| menu_accelerator_skip_key(&ka.key))
+        .collect()
+}
+
+/// Map dioxus modifier flags to muda (keyboard_types) modifiers.
+///
+/// `META` (Cmd on macOS) maps to `SUPER`; `Accelerator::new` also normalizes
+/// `META` to `SUPER` internally, so this keeps the two representations aligned.
+fn modifiers_to_muda(modifiers: Modifiers) -> MudaModifiers {
+    let mut out = MudaModifiers::empty();
+    if modifiers.contains(Modifiers::CONTROL) {
+        out |= MudaModifiers::CONTROL;
+    }
+    if modifiers.contains(Modifiers::ALT) {
+        out |= MudaModifiers::ALT;
+    }
+    if modifiers.contains(Modifiers::SHIFT) {
+        out |= MudaModifiers::SHIFT;
+    }
+    if modifiers.contains(Modifiers::META) {
+        out |= MudaModifiers::SUPER;
+    }
+    out
+}
+
+/// Map a logical `Key` to a physical muda `Code`, or `None` when unmappable.
+fn key_to_code(key: &Key) -> Option<Code> {
+    let code = match key {
+        Key::Character(c) => return char_to_code(c),
+        Key::Enter => Code::Enter,
+        Key::Escape => Code::Escape,
+        Key::Tab => Code::Tab,
+        Key::Backspace => Code::Backspace,
+        Key::Delete => Code::Delete,
+        Key::ArrowUp => Code::ArrowUp,
+        Key::ArrowDown => Code::ArrowDown,
+        Key::ArrowLeft => Code::ArrowLeft,
+        Key::ArrowRight => Code::ArrowRight,
+        Key::Home => Code::Home,
+        Key::End => Code::End,
+        Key::PageUp => Code::PageUp,
+        Key::PageDown => Code::PageDown,
+        Key::F1 => Code::F1,
+        Key::F2 => Code::F2,
+        Key::F3 => Code::F3,
+        Key::F4 => Code::F4,
+        Key::F5 => Code::F5,
+        Key::F6 => Code::F6,
+        Key::F7 => Code::F7,
+        Key::F8 => Code::F8,
+        Key::F9 => Code::F9,
+        Key::F10 => Code::F10,
+        Key::F11 => Code::F11,
+        Key::F12 => Code::F12,
+        _ => return None,
+    };
+    Some(code)
+}
+
+/// Map a single logical character to a physical `Code`.
+///
+/// Letters/digits reuse the W3C UI Events code names via `Code`'s `FromStr`
+/// (e.g. `"KeyO"`, `"Digit0"`); symbols map explicitly.
+fn char_to_code(character: &str) -> Option<Code> {
+    let mut chars = character.chars();
+    let ch = chars.next()?;
+    if chars.next().is_some() {
+        // Multi-character logical keys have no single physical code.
+        return None;
+    }
+
+    match ch {
+        'a'..='z' => format!("Key{}", ch.to_ascii_uppercase()).parse().ok(),
+        'A'..='Z' => format!("Key{ch}").parse().ok(),
+        '0'..='9' => format!("Digit{ch}").parse().ok(),
+        '[' => Some(Code::BracketLeft),
+        ']' => Some(Code::BracketRight),
+        '=' => Some(Code::Equal),
+        '-' => Some(Code::Minus),
+        '/' => Some(Code::Slash),
+        '\\' => Some(Code::Backslash),
+        ',' => Some(Code::Comma),
+        '.' => Some(Code::Period),
+        ';' => Some(Code::Semicolon),
+        '\'' => Some(Code::Quote),
+        '`' => Some(Code::Backquote),
+        ' ' => Some(Code::Space),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cmd_letter_maps_to_super_key_code() {
+        assert_eq!(
+            accelerator_for_key("Cmd+o"),
+            Some(Accelerator::new(Some(MudaModifiers::SUPER), Code::KeyO))
+        );
+    }
+
+    #[test]
+    fn cmd_shift_letter_includes_shift() {
+        assert_eq!(
+            accelerator_for_key("Cmd+Shift+o"),
+            Some(Accelerator::new(
+                Some(MudaModifiers::SUPER | MudaModifiers::SHIFT),
+                Code::KeyO
+            ))
+        );
+    }
+
+    #[test]
+    fn symbol_aliases_map_to_codes() {
+        assert_eq!(
+            accelerator_for_key("Cmd+BracketLeft"),
+            Some(Accelerator::new(
+                Some(MudaModifiers::SUPER),
+                Code::BracketLeft
+            ))
+        );
+        assert_eq!(
+            accelerator_for_key("Cmd+Equal"),
+            Some(Accelerator::new(Some(MudaModifiers::SUPER), Code::Equal))
+        );
+        assert_eq!(
+            accelerator_for_key("Cmd+Minus"),
+            Some(Accelerator::new(Some(MudaModifiers::SUPER), Code::Minus))
+        );
+    }
+
+    #[test]
+    fn digit_maps_to_digit_code() {
+        assert_eq!(
+            accelerator_for_key("Cmd+0"),
+            Some(Accelerator::new(Some(MudaModifiers::SUPER), Code::Digit0))
+        );
+    }
+
+    #[test]
+    fn no_modifier_named_key() {
+        assert_eq!(
+            accelerator_for_key("ArrowDown"),
+            Some(Accelerator::new(None, Code::ArrowDown))
+        );
+    }
+
+    #[test]
+    fn ctrl_alt_combination() {
+        assert_eq!(
+            accelerator_for_key("Cmd+Alt+w"),
+            Some(Accelerator::new(
+                Some(MudaModifiers::SUPER | MudaModifiers::ALT),
+                Code::KeyW
+            ))
+        );
+    }
+
+    #[test]
+    fn multi_chord_sequence_is_not_an_accelerator() {
+        assert_eq!(accelerator_for_key("g g"), None);
+    }
+
+    #[test]
+    fn invalid_key_returns_none() {
+        assert_eq!(accelerator_for_key("no_such_key"), None);
+        assert_eq!(accelerator_for_key(""), None);
+    }
+
+    // -- Skip-key canonical form (must match JS interceptor's event.code) --
+    //
+    // dioxus Modifiers bits: ALT=0x01, CONTROL=0x08, META=0x40, SHIFT=0x200.
+    // Key part is the physical Code (e.g. "KeyO"), not the logical glyph.
+
+    #[test]
+    fn skip_key_cmd_letter() {
+        assert_eq!(
+            menu_accelerator_skip_key("Cmd+o").as_deref(),
+            Some("64:KeyO")
+        );
+    }
+
+    #[test]
+    fn skip_key_cmd_shift_letter() {
+        // META (0x40=64) | SHIFT (0x200=512) = 576
+        assert_eq!(
+            menu_accelerator_skip_key("Cmd+Shift+o").as_deref(),
+            Some("576:KeyO")
+        );
+    }
+
+    #[test]
+    fn skip_key_uses_physical_code_for_symbols() {
+        assert_eq!(
+            menu_accelerator_skip_key("Cmd+BracketLeft").as_deref(),
+            Some("64:BracketLeft")
+        );
+    }
+
+    #[test]
+    fn skip_key_alt_uses_stable_physical_code() {
+        // META (64) | ALT (1) = 65; physical code is immune to Option remapping.
+        assert_eq!(
+            menu_accelerator_skip_key("Cmd+Alt+w").as_deref(),
+            Some("65:KeyW")
+        );
+    }
+
+    #[test]
+    fn skip_key_none_for_sequence() {
+        assert_eq!(menu_accelerator_skip_key("g g"), None);
+    }
+
+    #[test]
+    fn skip_keys_collects_only_representable_menu_shortcuts() {
+        use crate::config::KeyAction;
+        let bindings = BindingSet {
+            menu_shortcuts: vec![
+                KeyAction {
+                    key: "Cmd+o".to_string(),
+                    action: "file.open".to_string(),
+                },
+                // A hand-edited non-representable entry is skipped, not panicked.
+                KeyAction {
+                    key: "g g".to_string(),
+                    action: "history.back".to_string(),
+                },
+            ],
+            ..Default::default()
+        };
+        assert_eq!(menu_accelerator_skip_keys(&bindings), vec!["64:KeyO"]);
+    }
+}

--- a/desktop/src/keybindings/action.rs
+++ b/desktop/src/keybindings/action.rs
@@ -287,6 +287,46 @@ pub(crate) const ACTION_GROUPS: &[(&str, &[Action])] = &[
     ("Cancel", &[Action::Cancel]),
 ];
 
+/// Actions that have a corresponding menu item and can therefore be bound as a
+/// native menu shortcut.
+///
+/// Kept in sync with `menu::menu_action_for_id` (a drift-guard test in `menu.rs`
+/// asserts every menu item's action appears here).
+pub const MENU_ACTIONS: &[Action] = &[
+    Action::WindowNew,
+    Action::TabNew,
+    Action::FileOpen,
+    Action::FileOpenDirectory,
+    Action::CopyFilePath,
+    Action::FileRevealInFinder,
+    Action::TabClose,
+    Action::TabCloseAll,
+    Action::WindowClose,
+    Action::FilePrint,
+    Action::FilePreferences,
+    Action::AppAbout,
+    Action::SearchOpen,
+    Action::SearchNext,
+    Action::SearchPrev,
+    Action::WindowToggleSidebar,
+    Action::WindowToggleRightSidebar,
+    Action::ZoomReset,
+    Action::ZoomIn,
+    Action::ZoomOut,
+    Action::HistoryBack,
+    Action::HistoryForward,
+    Action::WindowCloseAllChildWindows,
+    Action::WindowCloseAllWindows,
+    Action::AppGoToHomepage,
+];
+
+/// Whether an action string corresponds to a menu item (native-menu eligible).
+pub fn is_menu_action(action: &str) -> bool {
+    Action::from_str(action)
+        .map(|a| MENU_ACTIONS.contains(&a))
+        .unwrap_or(false)
+}
+
 /// Generate `Display` and `FromStr` impls from a single mapping table.
 ///
 /// This ensures the string representation is always consistent between

--- a/desktop/src/keybindings/engine.rs
+++ b/desktop/src/keybindings/engine.rs
@@ -271,11 +271,22 @@ mod tests {
     }
 
     #[test]
-    fn default_binding_cmd_n() {
+    fn default_global_binding_cmd_r() {
+        // Cmd+r (window.reload) stays an engine keybinding in the default preset.
+        let config = default_bindings();
+        let mut engine = KeybindingEngine::new(&config);
+        let result = engine.process_key(&chord("Cmd+r"), false, KeyContext::Content);
+        assert_eq!(result, KeyMatchResult::Matched(Action::WindowReload));
+    }
+
+    #[test]
+    fn menu_shortcut_not_matched_by_engine() {
+        // Cmd+n (window.new) is a native menu shortcut, not an engine binding,
+        // so the keybinding engine must not resolve it.
         let config = default_bindings();
         let mut engine = KeybindingEngine::new(&config);
         let result = engine.process_key(&chord("Cmd+n"), false, KeyContext::Content);
-        assert_eq!(result, KeyMatchResult::Matched(Action::WindowNew));
+        assert_eq!(result, KeyMatchResult::NoMatch);
     }
 
     #[test]
@@ -375,14 +386,14 @@ mod tests {
     }
 
     #[test]
-    fn user_overrides_default_cmd_n() {
-        // User edits Cmd+n from window.new to tab.new in their config
+    fn user_overrides_default_global_binding() {
+        // User edits Cmd+r from window.reload to tab.new in their global config.
         let mut custom = crate::keybindings::default_bindings();
-        let cmd_n = custom.global.iter_mut().find(|b| b.key == "Cmd+n").unwrap();
-        cmd_n.action = "tab.new".to_string();
+        let cmd_r = custom.global.iter_mut().find(|b| b.key == "Cmd+r").unwrap();
+        cmd_r.action = "tab.new".to_string();
 
         let mut engine = KeybindingEngine::new(&custom);
-        let result = engine.process_key(&chord("Cmd+n"), false, KeyContext::Content);
+        let result = engine.process_key(&chord("Cmd+r"), false, KeyContext::Content);
         assert_eq!(result, KeyMatchResult::Matched(Action::TabNew));
     }
 

--- a/desktop/src/keybindings/hint.rs
+++ b/desktop/src/keybindings/hint.rs
@@ -3,18 +3,23 @@ use crate::keybindings::KeyContext;
 
 /// Return a formatted shortcut hint for the given action.
 ///
-/// Context bindings are preferred over global when both exist.
+/// Lookup order: context binding → global keybinding → menu shortcut.
 pub fn shortcut_hint_for_action(action: &str, context: Option<KeyContext>) -> Option<String> {
     let config = CONFIG.read();
     let bindings = &config.keybindings;
 
     let key = context
         .and_then(|ctx| find_key_for_action(bindings_for_context(bindings, ctx), action))
-        .or_else(|| find_key_for_action(&bindings.global, action))?;
+        .or_else(|| find_key_for_action(&bindings.global, action))
+        .or_else(|| find_key_for_action(&bindings.menu_shortcuts, action))?;
     Some(format_shortcut_hint(key))
 }
 
-/// Return a formatted shortcut hint from global keybindings.
+/// Return a formatted shortcut hint from global (and menu) keybindings.
+///
+/// Only referenced by the Windows in-app menu (`win_hamburger`); platforms with
+/// a native menu (macOS/Linux) derive accelerators from `menu_shortcuts`.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
 pub fn shortcut_hint_for_global_action(action: &str) -> Option<String> {
     shortcut_hint_for_action(action, None)
 }

--- a/desktop/src/keybindings/presets.rs
+++ b/desktop/src/keybindings/presets.rs
@@ -86,6 +86,33 @@ fn validate_preset_bindings(name: &str, bindings: &BindingSet) {
             );
         }
     }
+
+    validate_menu_shortcuts(name, &bindings.menu_shortcuts);
+}
+
+/// Menu shortcuts have stricter requirements than engine keybindings: they
+/// become native OS accelerators, which must be a single chord representable
+/// as a muda `Accelerator`.
+fn validate_menu_shortcuts(name: &str, actions: &[KeyAction]) {
+    let mut seen_sequences = HashSet::new();
+    for ka in actions {
+        Action::from_str(&ka.action).unwrap_or_else(|e| {
+            panic!(
+                "{name} preset has unknown action in menu_shortcuts: action={:?}, error={}",
+                ka.action, e
+            )
+        });
+        assert!(
+            super::accelerator_for_key(&ka.key).is_some(),
+            "{name} preset menu shortcut is not a valid single-chord accelerator: key={:?}",
+            ka.key
+        );
+        let normalized = ShortcutSequence::from_str(&ka.key).unwrap().to_string();
+        assert!(
+            seen_sequences.insert(normalized.clone()),
+            "{name} preset has duplicate menu shortcut: {normalized:?}"
+        );
+    }
 }
 
 /// Resolve bindings from configuration for engine consumption.
@@ -100,6 +127,11 @@ impl BindingSet {
     /// Flatten into resolved bindings for engine consumption.
     pub fn into_resolved_bindings(self) -> Vec<ResolvedBinding> {
         let mut result = Vec::new();
+        // Platforms with a native menu (macOS/Linux) let the OS dispatch menu
+        // shortcuts, so they are excluded here. Windows has no native menu, so
+        // the engine must own them or they would have no dispatch path at all.
+        #[cfg(target_os = "windows")]
+        resolve_field(self.menu_shortcuts, None, &mut result);
         resolve_field(self.global, None, &mut result);
         resolve_field(self.content, Some(KeyContext::Content), &mut result);
         resolve_field(self.sidebar, Some(KeyContext::Sidebar), &mut result);

--- a/desktop/src/keybindings/presets/default.json
+++ b/desktop/src/keybindings/presets/default.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./preset.schema.json",
-  "global": [
+  "menuShortcuts": [
     {
       "key": "Cmd+n",
       "action": "window.new"
@@ -12,6 +12,14 @@
     {
       "key": "Cmd+w",
       "action": "tab.close"
+    },
+    {
+      "key": "Cmd+Alt+w",
+      "action": "tab.close_all"
+    },
+    {
+      "key": "Cmd+Shift+w",
+      "action": "window.close"
     },
     {
       "key": "Cmd+o",
@@ -26,8 +34,12 @@
       "action": "file.reveal_in_finder"
     },
     {
-      "key": "Cmd+Shift+w",
-      "action": "window.close"
+      "key": "Cmd+p",
+      "action": "file.print"
+    },
+    {
+      "key": "Cmd+Comma",
+      "action": "file.preferences"
     },
     {
       "key": "Cmd+f",
@@ -40,10 +52,6 @@
     {
       "key": "Cmd+Shift+g",
       "action": "search.prev"
-    },
-    {
-      "key": "Cmd+r",
-      "action": "window.reload"
     },
     {
       "key": "Cmd+b",
@@ -72,18 +80,12 @@
     {
       "key": "Cmd+BracketRight",
       "action": "history.forward"
-    },
+    }
+  ],
+  "global": [
     {
-      "key": "Cmd+p",
-      "action": "file.print"
-    },
-    {
-      "key": "Cmd+Comma",
-      "action": "file.preferences"
-    },
-    {
-      "key": "Cmd+Alt+w",
-      "action": "tab.close_all"
+      "key": "Cmd+r",
+      "action": "window.reload"
     },
     {
       "key": "Cmd+Alt+Shift+w",
@@ -100,6 +102,10 @@
     {
       "key": "Cmd+Shift+Enter",
       "action": "file.open_link_in_new_tab"
+    },
+    {
+      "key": "Cmd+d",
+      "action": "file.toggle_bookmark"
     },
     {
       "key": "Cmd+Slash",
@@ -152,10 +158,6 @@
     {
       "key": "Escape",
       "action": "cancel"
-    },
-    {
-      "key": "Cmd+d",
-      "action": "file.toggle_bookmark"
     }
   ],
   "content": [
@@ -230,14 +232,6 @@
     {
       "key": "Backspace",
       "action": "directory.parent"
-    },
-    {
-      "key": "Cmd+BracketLeft",
-      "action": "directory.back"
-    },
-    {
-      "key": "Cmd+BracketRight",
-      "action": "directory.forward"
     },
     {
       "key": "Ctrl+ArrowLeft",

--- a/desktop/src/keybindings/presets/emacs.json
+++ b/desktop/src/keybindings/presets/emacs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./preset.schema.json",
-  "global": [
+  "menuShortcuts": [
     {
       "key": "Cmd+n",
       "action": "window.new"
@@ -42,10 +42,6 @@
       "action": "search.prev"
     },
     {
-      "key": "Cmd+r",
-      "action": "window.reload"
-    },
-    {
       "key": "Cmd+b",
       "action": "window.toggle_sidebar"
     },
@@ -76,6 +72,12 @@
     {
       "key": "Cmd+Comma",
       "action": "file.preferences"
+    }
+  ],
+  "global": [
+    {
+      "key": "Cmd+r",
+      "action": "window.reload"
     },
     {
       "key": "Cmd+Slash",
@@ -266,14 +268,6 @@
     {
       "key": "Backspace",
       "action": "directory.parent"
-    },
-    {
-      "key": "Cmd+BracketLeft",
-      "action": "directory.back"
-    },
-    {
-      "key": "Cmd+BracketRight",
-      "action": "directory.forward"
     },
     {
       "key": "Ctrl+x o",

--- a/desktop/src/keybindings/presets/preset.schema.json
+++ b/desktop/src/keybindings/presets/preset.schema.json
@@ -5,6 +5,7 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "menuShortcuts": { "$ref": "#/$defs/bindings" },
     "global": { "$ref": "#/$defs/bindings" },
     "content": { "$ref": "#/$defs/bindings" },
     "sidebar": { "$ref": "#/$defs/bindings" },

--- a/desktop/src/keybindings/presets/vim.json
+++ b/desktop/src/keybindings/presets/vim.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./preset.schema.json",
-  "global": [
+  "menuShortcuts": [
     {
       "key": "Cmd+n",
       "action": "window.new"
@@ -32,10 +32,6 @@
     {
       "key": "Cmd+f",
       "action": "search.open"
-    },
-    {
-      "key": "Cmd+r",
-      "action": "window.reload"
     },
     {
       "key": "Cmd+b",
@@ -72,6 +68,12 @@
     {
       "key": "Cmd+Comma",
       "action": "file.preferences"
+    }
+  ],
+  "global": [
+    {
+      "key": "Cmd+r",
+      "action": "window.reload"
     },
     {
       "key": "Cmd+Slash",

--- a/desktop/src/menu.rs
+++ b/desktop/src/menu.rs
@@ -1,14 +1,14 @@
-use dioxus::document;
-use dioxus::prelude::{spawn, ReadableExt, WritableExt};
+use dioxus::prelude::ReadableExt;
 use dioxus_desktop::muda::accelerator::Accelerator;
 use dioxus_desktop::muda::{Menu, MenuEvent, MenuItem, PredefinedMenuItem, Submenu};
 use dioxus_desktop::window;
-use std::path::PathBuf;
+use std::cell::RefCell;
 
-use crate::components::content::set_preferences_tab_to_about;
-use crate::keybindings::shortcut_hint_for_global_action;
+use crate::config::CONFIG;
+use crate::keybindings::dispatcher::dispatch_action;
+use crate::keybindings::{accelerator_for_key, format_shortcut_hint, Action};
 use crate::state::AppState;
-use crate::window::{self, settings::normalize_zoom_level, CreateMainWindowConfigParams};
+use crate::window::{self, CreateMainWindowConfigParams};
 
 /// Menu identifier enum
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -105,26 +105,80 @@ impl MenuId {
     }
 }
 
-/// Helper to create a menu item without an accelerator.
-///
-/// All keyboard shortcuts are handled by the keybinding engine, not muda.
-fn create_menu_item(id: MenuId, label: &str) -> MenuItem {
-    let display_label = menu_label_with_shortcut(id, label);
-    MenuItem::with_id(id.as_str(), &display_label, true, None::<Accelerator>)
+thread_local! {
+    /// Menu items whose accelerator/label is derived from the keybinding config.
+    ///
+    /// Retained so their native accelerators can be refreshed on the main thread
+    /// when the config changes at runtime (see [`refresh_menu_accelerators`]).
+    static MENU_ITEMS: RefCell<Vec<RegisteredMenuItem>> = const { RefCell::new(Vec::new()) };
 }
 
-/// Build a menu label with a right-aligned shortcut hint (without muda Accelerator).
+struct RegisteredMenuItem {
+    id: MenuId,
+    item: MenuItem,
+    base_label: &'static str,
+}
+
+/// Create a menu item, deriving its native accelerator (or cosmetic hint) from
+/// the current menu-shortcut config, and register it for later refresh.
+fn create_menu_item(id: MenuId, label: &'static str) -> MenuItem {
+    let item = MenuItem::with_id(id.as_str(), label, true, None::<Accelerator>);
+    apply_menu_shortcut(id, &item, label);
+    MENU_ITEMS.with(|items| {
+        items.borrow_mut().push(RegisteredMenuItem {
+            id,
+            item: item.clone(),
+            base_label: label,
+        });
+    });
+    item
+}
+
+/// Apply the configured menu shortcut to a menu item.
 ///
-/// We intentionally avoid `with_accelerator()` because keyboard handling is owned by
-/// the keybinding engine. This only mirrors the hint in the menu UI.
-fn menu_label_with_shortcut(id: MenuId, base_label: &str) -> String {
-    let Some(action) = menu_action_for_id(id) else {
-        return base_label.to_string();
-    };
-    let Some(shortcut) = shortcut_hint_for_global_action(action) else {
-        return base_label.to_string();
-    };
-    format!("{base_label}\t{shortcut}")
+/// Menu shortcuts come solely from `config.keybindings.menu_shortcuts`. A
+/// single-chord binding representable as a muda `Accelerator` becomes a native
+/// OS accelerator (rendered by the menu bar, works without window focus).
+/// Anything else falls back to a right-aligned cosmetic hint; no binding means
+/// no shortcut shown.
+fn apply_menu_shortcut(id: MenuId, item: &MenuItem, base_label: &str) {
+    let key = menu_action_for_id(id).and_then(menu_shortcut_key_for_action);
+    let accelerator = key.as_deref().and_then(accelerator_for_key);
+
+    if accelerator.is_some() {
+        item.set_text(base_label);
+        let _ = item.set_accelerator(accelerator);
+    } else {
+        let text = match &key {
+            Some(k) => format!("{base_label}\t{}", format_shortcut_hint(k)),
+            None => base_label.to_string(),
+        };
+        item.set_text(text);
+        let _ = item.set_accelerator(None);
+    }
+}
+
+/// Look up the configured menu-shortcut key string for an action.
+fn menu_shortcut_key_for_action(action: &str) -> Option<String> {
+    CONFIG
+        .read()
+        .keybindings
+        .menu_shortcuts
+        .iter()
+        .find(|ka| ka.action == action)
+        .map(|ka| ka.key.clone())
+}
+
+/// Re-apply native accelerators and hint labels to every registered menu item
+/// from the current keybinding config.
+///
+/// Must be called on the main thread (muda menu items are not `Send`/`Sync`).
+pub fn refresh_menu_accelerators() {
+    MENU_ITEMS.with(|items| {
+        for registered in items.borrow().iter() {
+            apply_menu_shortcut(registered.id, &registered.item, registered.base_label);
+        }
+    });
 }
 
 /// Map menu items to keybinding actions for hint display.
@@ -162,6 +216,9 @@ fn menu_action_for_id(id: MenuId) -> Option<&'static str> {
 pub fn build_menu() -> Menu {
     #[cfg(target_os = "macos")]
     disable_automatic_window_tabbing();
+
+    // Reset the registry so a rebuilt menu does not retain stale item handles.
+    MENU_ITEMS.with(|items| items.borrow_mut().clear());
 
     let menu = Menu::new();
 
@@ -390,144 +447,41 @@ pub fn handle_menu_event_with_state(event: &MenuEvent, state: &mut AppState) -> 
         None => return false,
     };
 
-    match id {
-        MenuId::About => {
-            // Set the preferences tab to About before opening
-            set_preferences_tab_to_about();
-            state.open_preferences();
-        }
-        MenuId::Preferences => {
-            state.open_preferences();
-        }
-        MenuId::NewTab => {
-            state.add_empty_tab(true);
-        }
-        MenuId::Open => {
-            if let Some(file) = pick_markdown_file() {
-                state.open_file(file);
-            }
-        }
-        MenuId::OpenDirectory => {
-            if let Some(dir) = pick_directory() {
-                state.set_root_directory(dir);
-            }
-        }
-        MenuId::CloseTab => {
-            let active_tab = *state.active_tab.read();
-            state.close_tab(active_tab);
-        }
-        MenuId::CloseAllTabs => {
-            // Close all tabs except one, then clear it
-            let mut tabs = state.tabs.write();
-            tabs.clear();
-            tabs.push(crate::state::Tab::default());
-            state.active_tab.set(0);
-        }
-        MenuId::CloseWindow => {
-            window().close();
-        }
-        MenuId::ToggleLeftSidebar => {
-            state.toggle_sidebar();
-        }
-        MenuId::ToggleRightSidebar => {
-            state.toggle_right_sidebar();
-        }
-        MenuId::ActualSize => {
-            state.zoom_level.set(1.0);
-        }
-        MenuId::ZoomIn => {
-            let current = normalize_zoom_level(*state.zoom_level.read());
-            let next = normalize_zoom_level(current + 0.1);
-            state.zoom_level.set(next);
-        }
-        MenuId::ZoomOut => {
-            let current = normalize_zoom_level(*state.zoom_level.read());
-            let next = normalize_zoom_level(current - 0.1);
-            state.zoom_level.set(next);
-        }
-        MenuId::GoBack => {
-            state.save_scroll_and_go_back();
-        }
-        MenuId::GoForward => {
-            state.save_scroll_and_go_forward();
-        }
-        MenuId::RevealInFinder => {
-            if let Some(file) = get_current_file(state) {
-                crate::utils::file_operations::reveal_in_finder(&file);
-            }
-        }
-        MenuId::CopyFilePath => {
-            if let Some(file) = get_current_file(state) {
-                crate::utils::clipboard::copy_text(file.to_string_lossy());
-            }
-        }
-        MenuId::Print => {
-            crate::utils::print::print_window(get_current_file(state));
-        }
-        MenuId::Find => {
-            // None = get selected text from JavaScript
-            state.open_search_with_text(None);
-        }
-        MenuId::FindNext => {
-            spawn(async move {
-                let _ = document::eval("window.Arto.search.navigate('next')").await;
-            });
-        }
-        MenuId::FindPrevious => {
-            spawn(async move {
-                let _ = document::eval("window.Arto.search.navigate('prev')").await;
-            });
-        }
+    // Map the menu item to its action and dispatch through the shared
+    // dispatcher, so a menu click and its keyboard shortcut run the exact same
+    // effect (single source of truth). GoBack/GoForward are context-polymorphic:
+    // the single "Back"/"Forward" item resolves to directory or document history
+    // depending on the focused panel.
+    let is_left_sidebar = *state.focused_panel.read() == crate::state::FocusedPanel::LeftSidebar;
+    let action = match id {
+        MenuId::About => Action::AppAbout,
+        MenuId::Preferences => Action::FilePreferences,
+        MenuId::NewTab => Action::TabNew,
+        MenuId::Open => Action::FileOpen,
+        MenuId::OpenDirectory => Action::FileOpenDirectory,
+        MenuId::CloseTab => Action::TabClose,
+        MenuId::CloseAllTabs => Action::TabCloseAll,
+        MenuId::CloseWindow => Action::WindowClose,
+        MenuId::ToggleLeftSidebar => Action::WindowToggleSidebar,
+        MenuId::ToggleRightSidebar => Action::WindowToggleRightSidebar,
+        MenuId::ActualSize => Action::ZoomReset,
+        MenuId::ZoomIn => Action::ZoomIn,
+        MenuId::ZoomOut => Action::ZoomOut,
+        MenuId::GoBack if is_left_sidebar => Action::DirectoryBack,
+        MenuId::GoBack => Action::HistoryBack,
+        MenuId::GoForward if is_left_sidebar => Action::DirectoryForward,
+        MenuId::GoForward => Action::HistoryForward,
+        MenuId::RevealInFinder => Action::FileRevealInFinder,
+        MenuId::CopyFilePath => Action::CopyFilePath,
+        MenuId::Print => Action::FilePrint,
+        MenuId::Find => Action::SearchOpen,
+        MenuId::FindNext => Action::SearchNext,
+        MenuId::FindPrevious => Action::SearchPrev,
         _ => return false,
-    }
+    };
 
+    dispatch_action(&action, *state);
     true
-}
-
-/// Get the current file path from state if viewing a file
-fn get_current_file(state: &AppState) -> Option<PathBuf> {
-    let tabs = state.tabs.read();
-    let active_tab = *state.active_tab.read();
-    tabs.get(active_tab).and_then(|tab| {
-        if let crate::state::TabContent::File(path) = &tab.content {
-            Some(path.clone())
-        } else {
-            None
-        }
-    })
-}
-
-/// Show file picker dialog and return selected file
-fn pick_markdown_file() -> Option<PathBuf> {
-    use rfd::FileDialog;
-
-    tracing::debug!("Opening file picker dialog...");
-    let start = std::time::Instant::now();
-
-    let file = FileDialog::new()
-        .add_filter("Markdown", &["md", "markdown"])
-        .set_directory(std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/")))
-        .pick_file();
-
-    tracing::debug!("File picker completed in {:?}", start.elapsed());
-
-    file
-}
-
-/// Show directory picker dialog and return selected directory
-fn pick_directory() -> Option<PathBuf> {
-    use rfd::FileDialog;
-
-    tracing::debug!("Opening directory picker dialog...");
-    let start = std::time::Instant::now();
-
-    let dir = FileDialog::new()
-        .set_directory(std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/")))
-        .pick_folder();
-
-    tracing::debug!("Directory picker completed in {:?}", start.elapsed());
-
-    dir
 }
 
 #[cfg(target_os = "macos")]
@@ -583,6 +537,46 @@ mod tests {
                 parsed.unwrap().as_str(),
                 *id_str,
                 "Roundtrip failed for {id_str}"
+            );
+        }
+    }
+
+    /// Every menu item's action must be listed in `MENU_ACTIONS` so the
+    /// Preferences UI and the interceptor skip-list stay in sync with the menu.
+    #[test]
+    fn menu_actions_cover_all_menu_items() {
+        let all_ids = [
+            MenuId::About,
+            MenuId::NewWindow,
+            MenuId::NewTab,
+            MenuId::Open,
+            MenuId::OpenDirectory,
+            MenuId::RevealInFinder,
+            MenuId::CopyFilePath,
+            MenuId::CloseTab,
+            MenuId::CloseAllTabs,
+            MenuId::CloseWindow,
+            MenuId::CloseAllChildWindows,
+            MenuId::CloseAllWindows,
+            MenuId::Print,
+            MenuId::Preferences,
+            MenuId::Find,
+            MenuId::FindNext,
+            MenuId::FindPrevious,
+            MenuId::ToggleLeftSidebar,
+            MenuId::ToggleRightSidebar,
+            MenuId::ActualSize,
+            MenuId::ZoomIn,
+            MenuId::ZoomOut,
+            MenuId::GoBack,
+            MenuId::GoForward,
+            MenuId::GoToHomepage,
+        ];
+        for id in all_ids {
+            let action = menu_action_for_id(id).expect("menu item has an action");
+            assert!(
+                crate::keybindings::is_menu_action(action),
+                "MENU_ACTIONS is missing {action:?} for {id:?}"
             );
         }
     }

--- a/desktop/src/state/app_state.rs
+++ b/desktop/src/state/app_state.rs
@@ -76,6 +76,9 @@ pub struct AppState {
     pub search_current_index: Signal<usize>,
     /// Initial search text to populate when opening search bar
     pub search_initial_text: Signal<Option<String>>,
+    /// Monotonic counter bumped on every open-search request, so the search
+    /// input is (re)focused even when the bar is already open.
+    pub search_focus_request: Signal<u64>,
     /// Current search query string (for display in Search tab)
     pub search_query: Signal<Option<String>>,
     /// All search matches with context (for Search tab display)
@@ -131,6 +134,7 @@ impl AppState {
             search_match_count: Signal::new(0),
             search_current_index: Signal::new(0),
             search_initial_text: Signal::new(None),
+            search_focus_request: Signal::new(0),
             search_query: Signal::new(None),
             search_matches: Signal::new(Vec::new()),
             pinned_matches: Signal::new(HashMap::new()),
@@ -263,6 +267,11 @@ impl AppState {
         self.search_initial_text.set(text);
         // Open search bar
         self.search_open.set(true);
+        // Request focus even if the bar is already open and the text is
+        // unchanged — otherwise no signal changes and the input keeps focus
+        // wherever it currently is.
+        let next = self.search_focus_request.read().wrapping_add(1);
+        self.search_focus_request.set(next);
     }
 
     /// Update pinned search matches from JavaScript callback

--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1782821651,
-        "narHash": "sha256-D5jO0ME1lA9bDHnd5kVawBwItG/N4oZr3FlXmMzLec8=",
+        "lastModified": 1784453100,
+        "narHash": "sha256-zpGZb8FYui+i8KLtC0nlcmb0voR2zB80Qn8pe7lzIbk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e52c192be9d7b2c4bd4aed326c8731b35f8bb75c",
+        "rev": "b471514bed69eff5255c8e63c1f80e5fe56c616f",
         "type": "github"
       },
       "original": {

--- a/renderer/src/keyboard-interceptor.ts
+++ b/renderer/src/keyboard-interceptor.ts
@@ -30,6 +30,28 @@ const SHIFT = 0x200;
  */
 const RESERVED_OS_CMD_KEYS = new Set(["q", "c", "v", "x", "a"]);
 
+/**
+ * Chords that are bound as native menu accelerators (canonical form
+ * `"<modifier-bits>:<physical-code>"`, matching {@link canonicalChord}).
+ *
+ * These are dispatched by the OS via the menu bar, so the interceptor must NOT
+ * forward them to the keybinding engine — otherwise the shortcut fires twice
+ * (once by the OS menu, once by the engine). Populated from Rust via
+ * {@link setMenuAccelerators}.
+ */
+let menuAccelerators = new Set<string>();
+
+/**
+ * Build the canonical chord key for an event, matching the Rust side.
+ *
+ * Uses the physical `KeyboardEvent.code` (e.g. `"KeyW"`) rather than `.key`,
+ * because Alt/Option remaps the produced glyph on macOS; `.code` is stable and
+ * matches how muda dispatches native accelerators.
+ */
+function canonicalChord(code: string, modifiers: number): string {
+  return `${modifiers}:${code}`;
+}
+
 /** Minimum mouse movement (px) to switch from keyboard to mouse mode. */
 const MOUSE_MOVE_THRESHOLD_SQ = 5 * 5;
 
@@ -87,6 +109,10 @@ function handleKeydown(e: KeyboardEvent): void {
 
   const modifiers = buildModifiers(e);
 
+  // Skip chords owned by a native menu accelerator: the OS menu already
+  // dispatches them, so forwarding to the engine would double-fire.
+  if (menuAccelerators.has(canonicalChord(e.code, modifiers))) return;
+
   if (!isKeyboardMode) {
     isKeyboardMode = true;
     mouseAnchorX = lastMouseX;
@@ -109,6 +135,16 @@ function handleCompositionEnd(): void {
 /** Register a callback for keydown events. */
 export function onKeydown(callback: KeydownCallback): void {
   currentCallback = callback;
+}
+
+/**
+ * Replace the set of chords owned by native menu accelerators.
+ *
+ * Called from Rust whenever the menu-shortcut config changes. Each entry is the
+ * canonical `"<modifier-bits>:<lowercased-key>"` form produced by the Rust side.
+ */
+export function setMenuAccelerators(chords: string[]): void {
+  menuAccelerators = new Set(chords);
 }
 
 /** Pause interceptor (e.g., during key recording in Preferences). */

--- a/renderer/src/main.ts
+++ b/renderer/src/main.ts
@@ -63,6 +63,7 @@ declare global {
         onKeydown: typeof keyboardInterceptor.onKeydown;
         pause: typeof keyboardInterceptor.pause;
         resume: typeof keyboardInterceptor.resume;
+        setMenuAccelerators: typeof keyboardInterceptor.setMenuAccelerators;
       };
       scroll: {
         scrollDown: typeof scrollController.scrollDown;
@@ -278,6 +279,7 @@ export function init(): void {
       onKeydown: keyboardInterceptor.onKeydown,
       pause: keyboardInterceptor.pause,
       resume: keyboardInterceptor.resume,
+      setMenuAccelerators: keyboardInterceptor.setMenuAccelerators,
     },
     scroll: {
       scrollDown: scrollController.scrollDown,


### PR DESCRIPTION

<img width="684" height="442" alt="CleanShot 2026-07-20 at 15 19 56" src="https://github.com/user-attachments/assets/914998db-4322-4ff1-80c4-165b2b874df3" />
<img width="944" height="1102" alt="CleanShot 2026-07-20 at 15 20 44" src="https://github.com/user-attachments/assets/0fce5876-a17d-4c13-9ddd-bd1433286dbc" />


## Why

The in-window keybinding engine reads keys from the WebView, so it cannot dispatch a shortcut when **no window has focus** — most visibly, `⌘N` did nothing with all windows closed (#187). It also reimplemented shortcuts the OS menu could handle natively, leaving menu accelerators as cosmetic hint text rather than real OS accelerators.

Native menu accelerators are the only mechanism that can fire without WebView focus. This PR introduces them without creating a second shortcut matcher.

## What

Shortcuts are split into two explicit kinds sharing **one action vocabulary** and **one effect layer** (`dispatch_action`):

- **Menu shortcuts** (new `BindingSet.menuShortcuts`): single-chord, derived into native `muda` accelerators, shown in the menu bar, dispatched by the OS — so they work without window focus.
- **Keybindings** (`global` + per-context): the unchanged in-window engine, keeping chord sequences (vim `g g`) and per-context behavior.

The same action may live in both tables (e.g. `file.open` as native `⌘O` plus an extra in-window keybinding).

### Double-dispatch prevention (two layers)
1. Menu-backed actions are **moved out** of the engine's `global`/context tables into `menuShortcuts`, so a native accelerator has no competing engine binding (this is what actually kills the `⌘T`-opens-two-tabs problem that stalled a prior attempt).
2. The JS interceptor additionally **skips** chords owned by native menu accelerators (defense-in-depth), matched via a canonical `"<modifier-bits>:<lowercased-key>"` string shared with Rust.

### Other changes
- `⌘[` / `⌘]` are context-polymorphic in the menu handler: directory history when the file explorer is focused, document history otherwise (one chord = one owner).
- Menu accelerators live-reload on config change (`CONFIG_CHANGED_BROADCAST` → `set_accelerator`).
- The menu event handler is now a thin `MenuId → Action → dispatch_action` router, removing duplicated effect code (zoom, pickers, `get_current_file`) and **fixing two regressions** the native-accelerator routing would otherwise introduce: `⌘F` losing selection prefill, and `⌘B`/`⌘⇧B` losing focus-return.
- Preferences → Keybindings gains a **Menu Shortcuts** editing section (single-chord, menu-backed actions only, one-chord-one-owner check).
- **Backward compatible**: `menuShortcuts` is a new top-level field, so older `mappings.json` files keep loading (documented migration in README).

## Testing

`just fmt check test` green: clippy `-D warnings` clean, oxlint clean, 506 lib + 6 doc + 58 renderer tests.

Unit tests cover parts in isolation; the behavioral contract still needs a manual pass:

- [ ] `⌘N` with all windows closed → new window opens
- [ ] `⌘T` once → exactly one tab (double-fire regression)
- [ ] Menu bar shows native right-aligned accelerators (`⌘O` etc.)
- [ ] `⌘[` in content = history back; with file explorer focused = directory back
- [ ] `⌘F` opens search prefilled with the current selection
- [ ] `⌘B` while sidebar focused → sidebar closes and focus returns to content
- [ ] Change a menu shortcut in Preferences → menu updates without restart
- [ ] Apply Vim preset → `g g` still works; accelerators update
- [ ] A pre-`menuShortcuts` `mappings.json` launches without error
- [ ] `⌘⌥W` (macOS Option-dead-key edge) still triggers Close All Tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Windows:** native accelerators are a follow-up (see #194). This PR keeps Windows non-broken by resolving `menuShortcuts` into the in-window engine there.
