### PR TITLE
ci: unify build jobs into a matrix and publish Linux release artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,13 +75,29 @@ jobs:
 
   build:
     needs: ["check", "test"]
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # macOS produces a .dmg; Linux targets produce a .deb (see justfile).
+          - target: macos
+            os: macos-latest
+            artifacts: ./desktop/target/dx/arto/bundle/**/*.dmg
+          - target: ubuntu
+            os: ubuntu-latest
+            artifacts: ./desktop/target/dx/arto/bundle/**/*.deb
+          - target: ubuntu-arm64
+            os: ubuntu-24.04-arm
+            artifacts: ./desktop/target/dx/arto/bundle/**/*.deb
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       # https://zenn.dev/mierune/articles/2af7b9e447712a
       - uses: chetan/git-restore-mtime-action@v2
+      # Run via the Nix devShell so the toolchain (rustc, dioxus-cli, node,
+      # pnpm) matches local development and produces distributable bundles.
       - uses: nixbuild/nix-quick-install-action@v35
       - uses: cachix/cachix-action@v17
         if: github.event_name != 'pull_request'
@@ -94,9 +110,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             desktop/target
-          key: cargo-build-${{ runner.os }}-${{ hashFiles('desktop/Cargo.lock') }}
-          restore-keys: cargo-build-${{ runner.os }}-
-      - name: Set package version for DMG filename
+          key: cargo-build-${{ matrix.target }}-${{ hashFiles('desktop/Cargo.lock') }}
+          restore-keys: cargo-build-${{ matrix.target }}-
+      - name: Set package version for bundle filename
         if: ${{ github.event_name == 'release' }}
         run: |
           VERSION="${{ github.event.release.tag_name }}"
@@ -106,18 +122,24 @@ jobs:
       - run: nix develop -c just build
       - uses: actions/upload-artifact@v7
         with:
-          name: arto-${{ runner.os }}
-          path: |
-            ./desktop/target/dx/arto/bundle/macos/macos
+          name: arto-${{ matrix.target }}
+          path: ${{ matrix.artifacts }}
           if-no-files-found: error
     timeout-minutes: 30
 
-  build-nix:
+  nix-check:
     needs: ["check", "test"]
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        include:
+          - target: macos
+            os: macos-latest
+          - target: ubuntu
+            os: ubuntu-latest
+          - target: ubuntu-arm64
+            os: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v7
         with:
@@ -237,7 +259,7 @@ jobs:
           tag: ${{ github.event.release.tag_name }}
           allowUpdates: true
           artifactErrorsFailBuild: true
-          artifacts: ./artifacts/**/Arto_*.dmg
+          artifacts: ./artifacts/**/*.dmg,./artifacts/**/*.deb
           removeArtifacts: true
           makeLatest: true
           bodyFile: release_body.md

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,8 +138,40 @@ jobs:
           if-no-files-found: error
     timeout-minutes: ${{ matrix.timeout }}
 
+  # Detect whether a pull request touches the Nix flake, so the expensive
+  # nix-check job can be limited to PRs that actually change it. On non-PR
+  # events the output is forced to "true" (nix-check always runs there).
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      flake: ${{ steps.detect.outputs.flake }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - id: detect
+        env:
+          EVENT: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [ "$EVENT" != "pull_request" ]; then
+            echo "flake=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- flake.nix flake.lock | grep -q .; then
+            echo "flake=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "flake=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # Verify the flake's package output (`nix build`) still builds. This is a
+  # clean, non-incremental build (~20-25m/leg), so on pull requests it runs
+  # only when the flake itself changed; every push to main and every release
+  # runs it unconditionally to catch bit-rot promptly.
   nix-check:
-    needs: ["check", "test"]
+    needs: ["check", "test", "changes"]
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.flake == 'true' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,11 @@ jobs:
   build:
     needs: ["check", "test"]
     runs-on: ${{ matrix.os }}
+    # macOS is the source of the notarized DMG and gates the Homebrew dispatch,
+    # so it must succeed. Linux bundling is newer and less proven, so a Linux
+    # failure is tolerated (visible as a red leg) and must not block the macOS
+    # release. See the release job for the matching lenient upload.
+    continue-on-error: ${{ matrix.target != 'macos' }}
     strategy:
       fail-fast: false
       matrix:
@@ -84,12 +89,18 @@ jobs:
           - target: macos
             os: macos-latest
             artifacts: ./desktop/target/dx/arto/bundle/**/*.dmg
+            # macOS builds have historically finished within 30m.
+            timeout: 30
           - target: ubuntu
             os: ubuntu-latest
             artifacts: ./desktop/target/dx/arto/bundle/**/*.deb
+            # A cold cargo cache pushes the full release build past 30m on the
+            # Linux runners (same class of build the nix-check job budgets 60m for).
+            timeout: 60
           - target: ubuntu-arm64
             os: ubuntu-24.04-arm
             artifacts: ./desktop/target/dx/arto/bundle/**/*.deb
+            timeout: 60
     steps:
       - uses: actions/checkout@v7
         with:
@@ -125,7 +136,7 @@ jobs:
           name: arto-${{ matrix.target }}
           path: ${{ matrix.artifacts }}
           if-no-files-found: error
-    timeout-minutes: 30
+    timeout-minutes: ${{ matrix.timeout }}
 
   nix-check:
     needs: ["check", "test"]
@@ -258,7 +269,11 @@ jobs:
         with:
           tag: ${{ github.event.release.tag_name }}
           allowUpdates: true
-          artifactErrorsFailBuild: true
+          # Lenient so a missing Linux .deb (tolerated build failure) does not
+          # block the release. The macOS .dmg is still effectively required:
+          # the release only runs after the mandatory macOS build, and the
+          # downstream dispatch job fails if the aarch64 DMG is absent.
+          artifactErrorsFailBuild: false
           artifacts: ./artifacts/**/*.dmg,./artifacts/**/*.deb
           removeArtifacts: true
           makeLatest: true


### PR DESCRIPTION
## What

Consolidates the build pipeline and adds Linux release artifacts.

- Collapses `build` + `build-nix (macos)` + `build-nix (ubuntu)` into a single
  `build` matrix: **`build (macos)` / `build (ubuntu)` / `build (ubuntu-arm64)`**,
  each running `nix develop -c just build` (`.dmg` on macOS, `.deb` on Linux).
- Renames the pure `nix build` verification job to **`nix-check`** and extends it
  to `ubuntu-arm64`, keeping the flake's package output covered against bit-rot.
- Attaches both `.dmg` and `.deb` to the GitHub Release.

## Robustness (from self-review)

- Cache keys and artifact names are keyed off `matrix.target`, not `runner.os`
  (both Linux legs share `runner.os == Linux` and would otherwise collide).
- The version-patch step runs for every target on release, so the `.deb` is
  versioned too.
- macOS gates the release; Linux legs are `continue-on-error` and the release
  upload is lenient, so a Linux bundling failure never blocks the proven macOS
  DMG release or the Homebrew dispatch (a failed Linux leg still shows red).
- Linux legs get a 60m timeout (cold cargo cache), macOS stays at 30m.

## ⚠️ Needs CI validation

`dx bundle --linux --package-types deb` has never run green in CI. The flake
notes that Linux bundling fails inside the Nix sandbox on packager permission
errors; the devShell is unsandboxed so it may work, but this PR is the first
real test. Watch the `build (ubuntu)` / `build (ubuntu-arm64)` legs:
- confirm the deb bundling exits 0, and
- confirm the `.deb` lands under `desktop/target/dx/arto/bundle/**` (the upload
  glob). If not, add `dpkg`/`fakeroot` to the devShell or fall back to a tarball
  of the `dx build` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)