### PR TITLE
fix(directory): don't open the home directory when no default is configured

### DIFF
--- a/desktop/src/components/app.rs
+++ b/desktop/src/components/app.rs
@@ -47,9 +47,12 @@ const MOUSE_BUTTON_LEFT: u32 = 0;
 
 #[component]
 pub fn App(
-    tabs: Vec<Tab>,     // Initial tabs (at least one tab must be present)
-    directory: PathBuf, // Directory (resolved in create_main_window or MainApp)
-    theme: Theme,       // The enum: Auto/Light/Dark
+    tabs: Vec<Tab>, // Initial tabs (at least one tab must be present)
+    // Directory to root the file explorer at (resolved in create_main_window or
+    // MainApp). None means no directory is opened, so the sidebar shows its
+    // empty/welcome state instead of scanning an arbitrary directory.
+    directory: Option<PathBuf>,
+    theme: Theme, // The enum: Auto/Light/Dark
     content_full_width: bool,
     sidebar_pinned: bool,
     sidebar_width: f64,
@@ -78,8 +81,10 @@ pub fn App(
         // Apply initial sidebar settings from params (including directory)
         {
             let mut sidebar = app_state.sidebar.write();
-            sidebar.root_directory = Some(directory.clone());
-            sidebar.push_to_history(directory);
+            sidebar.root_directory = directory.clone();
+            if let Some(directory) = directory {
+                sidebar.push_to_history(directory);
+            }
             sidebar.pinned = sidebar_pinned;
             sidebar.width = sidebar_width;
             sidebar.show_all_files = sidebar_show_all_files;

--- a/desktop/src/components/main_app.rs
+++ b/desktop/src/components/main_app.rs
@@ -5,7 +5,6 @@ use crate::window::settings;
 use dioxus::desktop::use_muda_event_handler;
 use dioxus::desktop::{window, WindowCloseBehaviour};
 use dioxus::prelude::*;
-use std::path::PathBuf;
 
 // ============================================================================
 // MainApp component
@@ -83,15 +82,11 @@ pub fn MainApp() -> Element {
     let content_full_width = settings::get_content_full_width_preference();
     let zoom_pref = settings::get_zoom_preference(is_first_window);
 
-    // Directory resolution: override (from event) → config → tab parent → home → root
-    let directory = directory_override
-        .or(directory_pref.directory)
-        .or_else(|| {
-            tabs.iter()
-                .find_map(|tab| tab.file().and_then(|p| p.parent().map(|p| p.to_path_buf())))
-        })
-        .or_else(dirs::home_dir)
-        .unwrap_or_else(|| PathBuf::from("/"));
+    // Directory resolution: override (from event) → config default → parent of an
+    // explicitly opened file. Stays None on a blank config with no opened file so
+    // the sidebar shows its empty/welcome state instead of scanning home.
+    let params_directory = directory_override.or(directory_pref.directory);
+    let directory = crate::window::main::resolve_directory(params_directory, &tabs);
 
     // Render App component with initial state
     // Subsequent system events are handled by custom_event_handler (main.rs)

--- a/desktop/src/window/main.rs
+++ b/desktop/src/window/main.rs
@@ -230,17 +230,23 @@ pub fn shutdown_all_windows() -> usize {
 // Shared helpers for window creation (used by both sync and async paths)
 // ============================================================================
 
-/// Resolve the directory for a new window.
+/// Resolve the directory to root the file explorer at for a new window.
 ///
-/// Priority: params.directory → tab parent → home dir → root
-fn resolve_directory(params_directory: Option<PathBuf>, tabs: &[Tab]) -> PathBuf {
-    params_directory
-        .or_else(|| {
-            tabs.iter()
-                .find_map(|tab| tab.file().and_then(|p| p.parent().map(|p| p.to_path_buf())))
-        })
-        .or_else(dirs::home_dir)
-        .unwrap_or_else(|| PathBuf::from("/"))
+/// Priority: explicit directory (config default or explicitly requested) → parent
+/// of an explicitly opened file.
+///
+/// Returns `None` when no directory is configured and no file was explicitly
+/// opened. In that case the sidebar renders its empty/welcome state instead of
+/// scanning an arbitrary directory (e.g. the user's home), which on macOS would
+/// trigger unnecessary TCC permission prompts.
+pub(crate) fn resolve_directory(
+    params_directory: Option<PathBuf>,
+    tabs: &[Tab],
+) -> Option<PathBuf> {
+    params_directory.or_else(|| {
+        tabs.iter()
+            .find_map(|tab| tab.file().and_then(|p| p.parent().map(|p| p.to_path_buf())))
+    })
 }
 
 /// Compute the shifted position for a new window, avoiding overlap with existing windows.
@@ -494,6 +500,46 @@ fn shift_position_if_needed(
 mod tests {
     use super::*;
     use dioxus::desktop::tao::dpi::{LogicalPosition, LogicalSize};
+
+    #[test]
+    fn test_resolve_directory_none_when_no_config_and_no_file() {
+        // Blank config (no explicit directory) with a no-file/welcome tab must
+        // yield None so the sidebar shows the empty/welcome state instead of
+        // scanning an arbitrary directory such as the user's home.
+        let tabs = vec![Tab::default()];
+        assert_eq!(resolve_directory(None, &tabs), None);
+    }
+
+    #[test]
+    fn test_resolve_directory_uses_explicit_directory() {
+        let tabs = vec![Tab::default()];
+        let explicit = PathBuf::from("/explicit/dir");
+        assert_eq!(
+            resolve_directory(Some(explicit.clone()), &tabs),
+            Some(explicit)
+        );
+    }
+
+    #[test]
+    fn test_resolve_directory_falls_back_to_opened_file_parent() {
+        // Opening a file explicitly (no configured directory) roots the sidebar
+        // at the file's parent directory.
+        let tabs = vec![Tab::new(PathBuf::from("/some/project/README.md"))];
+        assert_eq!(
+            resolve_directory(None, &tabs),
+            Some(PathBuf::from("/some/project"))
+        );
+    }
+
+    #[test]
+    fn test_resolve_directory_prefers_explicit_over_file_parent() {
+        let tabs = vec![Tab::new(PathBuf::from("/some/project/README.md"))];
+        let explicit = PathBuf::from("/explicit/dir");
+        assert_eq!(
+            resolve_directory(Some(explicit.clone()), &tabs),
+            Some(explicit)
+        );
+    }
 
     #[test]
     fn test_shift_position_if_needed_no_offset() {

--- a/desktop/src/window/settings.rs
+++ b/desktop/src/window/settings.rs
@@ -277,10 +277,19 @@ pub fn get_directory_preference(is_first_window: bool) -> DirectoryPreference {
         cfg.directory.on_new_window,
         || cfg.directory.default_directory.clone(),
         || {
-            get_last_focused_window_state()
-                .and_then(|state| state.sidebar.read().root_directory.clone())
-                .or_else(|| PersistedState::load().directory)
-                .or_else(|| cfg.directory.default_directory.clone())
+            // When a focused window exists, inherit its directory verbatim -
+            // including `None` (welcome state), so a new window also opens no
+            // directory. Only fall back to persisted state / config default
+            // when there is no focused window to inherit from.
+            resolve_from_state_or_persisted(
+                |state| state.sidebar.read().root_directory.clone(),
+                |persisted| {
+                    persisted
+                        .directory
+                        .clone()
+                        .or_else(|| cfg.directory.default_directory.clone())
+                },
+            )
         },
     );
     DirectoryPreference { directory }


### PR DESCRIPTION
## Summary

Fixes #127. When `default_directory` is unset, window creation previously forced a fallback to the home directory and rooted the file explorer there. On macOS this triggered repeated TCC permission prompts (Documents / Downloads / media library) for first-time users just by launching the app.

This resolves the directory as `Option<PathBuf>` end to end so a blank configuration opens **no** directory and shows the welcome screen (VS Code style) instead of scanning home.

## Changes

- `window/main.rs`: `resolve_directory` returns `Option<PathBuf>`; drops the `dirs::home_dir()` / `/` fallback while keeping the explicit-directory → opened-file-parent chain. Now `pub(crate)` so `main_app.rs` shares the one resolution seam (removing duplicated logic). +4 unit tests.
- `components/app.rs`: `App` prop `directory` becomes `Option<PathBuf>`; `sidebar.root_directory` is set from it directly, and history is only pushed when `Some`.
- `components/main_app.rs`: replaces the inline home/root fallback with the shared `resolve_directory`.
- `window/settings.rs`: the `last_focused` new-window path now inherits the focused window's directory verbatim — including `None` (welcome state) — and only falls back to persisted state / config default when there is no focused window.

## Behavior

- **Blank config** → no directory scanned, welcome screen shown (no permission prompts).
- **Configured default dir** → unchanged, roots there.
- **Explicit file/dir open** (CLI / IPC / File menu) → unchanged, still roots correctly.

## Test plan

- [x] `just fmt check test` passes (513 Rust + 6 doc + 58 renderer tests, incl. 4 new `resolve_directory` tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
