### PR TITLE
fix(sidebar): hoist the file-tree context menu to the app root

### DIFF
--- a/desktop/src/components/app.rs
+++ b/desktop/src/components/app.rs
@@ -22,6 +22,7 @@ use super::header::Header;
 use super::right_sidebar::RightSidebar;
 use super::right_sidebar::RightSidebarTab;
 use super::search_bar::SearchBar;
+use super::sidebar::file_explorer::SidebarContextMenuHost;
 use super::sidebar::Sidebar;
 use super::tab::TabBar;
 use crate::assets::MAIN_SCRIPT;
@@ -557,6 +558,11 @@ pub fn App(
                     },
                 }
             }
+
+            // Left-sidebar file-tree context menu (rendered at the app-container
+            // root, outside the watcher-keyed file tree, so refresh-driven
+            // remounts of the tree can no longer unmount an open menu).
+            SidebarContextMenuHost {}
         }
     }
 }

--- a/desktop/src/components/sidebar/context_menu.rs
+++ b/desktop/src/components/sidebar/context_menu.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use dioxus::desktop::tao::window::WindowId;
 use dioxus::prelude::*;
@@ -7,10 +7,146 @@ use crate::bookmarks::BOOKMARKS;
 use crate::components::icon::{Icon, IconName};
 use crate::keybindings::{shortcut_hint_for_context_action, KeyContext};
 
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum SidebarItemKind {
     File,
     Directory,
+}
+
+impl SidebarItemKind {
+    /// Whether this entry is a directory.
+    pub fn is_dir(self) -> bool {
+        matches!(self, Self::Directory)
+    }
+}
+
+/// Estimated width of the context menu (CSS `min-width: 200px` + padding/border).
+const MENU_WIDTH: i32 = 220;
+/// Estimated height of the tallest menu variant (a directory with every section).
+const MENU_HEIGHT: i32 = 360;
+/// Width of the "Open in Window" flyout (CSS `min-width: 200px` + padding/border).
+const SUBMENU_WIDTH: i32 = 208;
+/// Gap kept between the menu and the viewport edge.
+const VIEWPORT_MARGIN: i32 = 8;
+/// Estimated height of a single context-menu row (padding + line height).
+const MENU_ROW_HEIGHT: i32 = 33;
+/// Estimated vertical padding around a submenu's item list (top + bottom).
+const SUBMENU_VPADDING: i32 = 8;
+
+/// Complete state for the hoisted sidebar file-tree context menu.
+///
+/// This lives in [`crate::state::AppState`] as a single `Option` and is rendered
+/// exactly once at the `app-container` root by
+/// [`crate::components::sidebar::file_explorer::SidebarContextMenuHost`].
+/// Keeping it out of the file-tree subtree means watcher-driven remounts (keyed
+/// on `sidebar_refresh_counter`) can no longer unmount an open menu.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SidebarContextMenuData {
+    /// Viewport-clamped top-left origin, in unscaled CSS pixels.
+    pub position: (i32, i32),
+    pub path: PathBuf,
+    pub kind: SidebarItemKind,
+    /// Whether the "Open in Window" flyout opens to the left of the menu,
+    /// used near the viewport's right edge so the flyout stays on-screen.
+    pub submenu_left: bool,
+    /// Vertical offset (in unscaled CSS pixels) applied to the "Open in Window"
+    /// flyout so its full height stays within the viewport. Zero when the flyout
+    /// fits at its natural anchor; negative when it must shift up near the
+    /// viewport's bottom edge.
+    pub submenu_offset_y: i32,
+    /// Titles of the other visible windows, for the "Open in Window" submenu.
+    pub other_windows: Vec<(WindowId, String)>,
+}
+
+impl SidebarContextMenuData {
+    /// Build menu state from a raw cursor position, clamping it to the viewport
+    /// and choosing a submenu direction that keeps the flyout on-screen.
+    pub fn new(
+        cursor: (i32, i32),
+        viewport: (i32, i32),
+        path: PathBuf,
+        kind: SidebarItemKind,
+        other_windows: Vec<(WindowId, String)>,
+    ) -> Self {
+        let position =
+            clamp_menu_position(cursor, (MENU_WIDTH, MENU_HEIGHT), viewport, VIEWPORT_MARGIN);
+        let submenu_left = submenu_opens_left(
+            position.0,
+            MENU_WIDTH,
+            SUBMENU_WIDTH,
+            viewport.0,
+            VIEWPORT_MARGIN,
+        );
+        // Anchor the flyout at the "Open in Window" row and clamp its bottom into
+        // the viewport. The row count above the flyout differs by item kind (a
+        // directory adds a "Change Root Directory" row).
+        let rows_above_flyout = if kind.is_dir() { 3 } else { 2 };
+        let anchor_y = position.1 + rows_above_flyout * MENU_ROW_HEIGHT;
+        let visible_rows = other_windows.len().max(1) as i32;
+        let submenu_height = visible_rows * MENU_ROW_HEIGHT + SUBMENU_VPADDING;
+        let submenu_top = clamp_submenu_top(anchor_y, submenu_height, viewport.1, VIEWPORT_MARGIN);
+        let submenu_offset_y = submenu_top - anchor_y;
+        Self {
+            position,
+            path,
+            kind,
+            submenu_left,
+            submenu_offset_y,
+            other_windows,
+        }
+    }
+}
+
+/// Clamp a menu's top-left origin so the whole menu stays within the viewport.
+///
+/// If the menu is larger than the available space on an axis, it is pinned to
+/// `margin` on that axis (the top/left is always visible).
+fn clamp_menu_position(
+    cursor: (i32, i32),
+    menu: (i32, i32),
+    viewport: (i32, i32),
+    margin: i32,
+) -> (i32, i32) {
+    let clamp_axis = |pos: i32, size: i32, extent: i32| {
+        let max_pos = (extent - margin - size).max(margin);
+        pos.clamp(margin, max_pos)
+    };
+    (
+        clamp_axis(cursor.0, menu.0, viewport.0),
+        clamp_axis(cursor.1, menu.1, viewport.1),
+    )
+}
+
+/// Decide whether the submenu flyout should open to the left of the menu
+/// instead of the right, to avoid spilling past the viewport's right edge.
+fn submenu_opens_left(
+    menu_x: i32,
+    menu_width: i32,
+    submenu_width: i32,
+    viewport_width: i32,
+    margin: i32,
+) -> bool {
+    menu_x + menu_width + submenu_width + margin > viewport_width
+}
+
+/// Clamp the submenu flyout's top so its full height stays within the viewport.
+///
+/// Returns the top the flyout should render at: `anchor_y` when it fits, a
+/// smaller value when it would spill past the bottom edge, and `margin` when the
+/// flyout is taller than the available space (its top stays visible).
+fn clamp_submenu_top(anchor_y: i32, submenu_height: i32, viewport_height: i32, margin: i32) -> i32 {
+    let max_top = (viewport_height - margin - submenu_height).max(margin);
+    anchor_y.clamp(margin, max_top)
+}
+
+/// Whether a snapshotted context-menu action may still act on `path`.
+///
+/// The hoisted menu lives outside the watcher-keyed file tree, so it stays open
+/// when a filesystem event deletes or renames its target. Path-dependent actions
+/// (open, change root, reveal) must re-check existence at click time before
+/// acting on a possibly-stale snapshot.
+pub(super) fn context_action_should_proceed(path: &Path) -> bool {
+    path.exists()
 }
 
 #[component]
@@ -18,6 +154,8 @@ pub fn SidebarContextMenu(
     position: (i32, i32),
     path: PathBuf,
     kind: SidebarItemKind,
+    submenu_left: bool,
+    submenu_offset_y: i32,
     on_close: EventHandler<()>,
     on_open: EventHandler<()>,
     on_open_in_new_window: EventHandler<()>,
@@ -92,7 +230,8 @@ pub fn SidebarContextMenu(
 
                 if *show_submenu.read() {
                     div {
-                        class: "context-submenu",
+                        class: if submenu_left { "context-submenu flip-left" } else { "context-submenu" },
+                        style: "top: {submenu_offset_y}px;",
 
                         if other_windows.is_empty() {
                             div {
@@ -216,5 +355,128 @@ fn ContextMenuItem(props: ContextMenuItemProps) -> Element {
 fn ContextMenuSeparator() -> Element {
     rsx! {
         div { class: "context-menu-separator" }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MENU: (i32, i32) = (200, 300);
+    const VIEWPORT: (i32, i32) = (1000, 800);
+    const MARGIN: i32 = 8;
+
+    #[test]
+    fn keeps_position_unchanged_when_menu_fits() {
+        // A cursor with room for the whole menu is used as-is.
+        let pos = clamp_menu_position((100, 100), MENU, VIEWPORT, MARGIN);
+        assert_eq!(pos, (100, 100));
+    }
+
+    #[test]
+    fn shifts_left_when_menu_overflows_right_edge() {
+        // Cursor near the right edge: x is pulled in so the menu's right edge
+        // sits at viewport_width - margin.
+        let pos = clamp_menu_position((950, 100), MENU, VIEWPORT, MARGIN);
+        assert_eq!(pos.0, VIEWPORT.0 - MARGIN - MENU.0); // 1000 - 8 - 200 = 792
+        assert_eq!(pos.1, 100);
+    }
+
+    #[test]
+    fn shifts_up_when_menu_overflows_bottom_edge() {
+        // Cursor near the bottom edge: y is pulled in so the menu's bottom edge
+        // sits at viewport_height - margin.
+        let pos = clamp_menu_position((100, 780), MENU, VIEWPORT, MARGIN);
+        assert_eq!(pos.0, 100);
+        assert_eq!(pos.1, VIEWPORT.1 - MARGIN - MENU.1); // 800 - 8 - 300 = 492
+    }
+
+    #[test]
+    fn clamps_bottom_right_corner_into_view() {
+        // A corner click keeps the whole menu on-screen on both axes.
+        let pos = clamp_menu_position((999, 799), MENU, VIEWPORT, MARGIN);
+        assert_eq!(pos, (792, 492));
+    }
+
+    #[test]
+    fn pins_to_margin_when_menu_larger_than_viewport() {
+        // Degenerate viewport smaller than the menu: the top-left stays visible.
+        let tiny = (150, 150);
+        let pos = clamp_menu_position((999, 999), MENU, tiny, MARGIN);
+        assert_eq!(pos, (MARGIN, MARGIN));
+    }
+
+    #[test]
+    fn never_places_origin_before_margin() {
+        // A cursor above/left of the margin is pushed back to the margin.
+        let pos = clamp_menu_position((0, 0), MENU, VIEWPORT, MARGIN);
+        assert_eq!(pos, (MARGIN, MARGIN));
+    }
+
+    #[test]
+    fn submenu_opens_right_with_room() {
+        // Plenty of horizontal room: the flyout opens to the right.
+        assert!(!submenu_opens_left(100, 220, 208, 1000, MARGIN));
+    }
+
+    #[test]
+    fn submenu_flips_left_near_right_edge() {
+        // Menu hugging the right edge: right-side flyout would spill, so flip.
+        assert!(submenu_opens_left(700, 220, 208, 1000, MARGIN));
+    }
+
+    #[test]
+    fn submenu_top_unchanged_when_flyout_fits() {
+        // Plenty of room below the anchor: the flyout stays at its anchor.
+        let top = clamp_submenu_top(100, 200, 800, MARGIN);
+        assert_eq!(top, 100);
+    }
+
+    #[test]
+    fn submenu_top_shifts_up_near_bottom_edge() {
+        // Anchor near the bottom: the top is pulled up so the flyout's bottom
+        // sits at viewport_height - margin.
+        let top = clamp_submenu_top(700, 200, 800, MARGIN);
+        assert_eq!(top, 800 - MARGIN - 200); // 592
+    }
+
+    #[test]
+    fn submenu_top_pins_to_margin_when_taller_than_viewport() {
+        // A flyout taller than the available space keeps its top visible.
+        let top = clamp_submenu_top(700, 1000, 800, MARGIN);
+        assert_eq!(top, MARGIN);
+    }
+
+    #[test]
+    fn context_action_proceeds_only_for_existing_paths() {
+        // Existing target: the action may proceed.
+        let dir = tempfile::tempdir().unwrap();
+        let existing = dir.path().join("note.md");
+        std::fs::write(&existing, "content").unwrap();
+        assert!(context_action_should_proceed(&existing));
+
+        // Vanished target (deleted/renamed while the menu was open): no-op.
+        let missing = dir.path().join("gone.md");
+        assert!(!context_action_should_proceed(&missing));
+    }
+
+    #[test]
+    fn new_clamps_position_and_flips_submenu_at_corner() {
+        // Integration of clamp + flip through the public constructor.
+        let data = SidebarContextMenuData::new(
+            (10_000, 10_000),
+            (1000, 800),
+            PathBuf::from("/tmp/example.md"),
+            SidebarItemKind::File,
+            Vec::new(),
+        );
+        assert_eq!(
+            data.position,
+            (
+                1000 - VIEWPORT_MARGIN - MENU_WIDTH,
+                800 - VIEWPORT_MARGIN - MENU_HEIGHT
+            )
+        );
+        assert!(data.submenu_left);
     }
 }

--- a/desktop/src/components/sidebar/file_explorer.rs
+++ b/desktop/src/components/sidebar/file_explorer.rs
@@ -5,7 +5,9 @@ use std::fs;
 use std::path::PathBuf;
 use tokio::sync::oneshot;
 
-use super::context_menu::{SidebarContextMenu, SidebarItemKind};
+use super::context_menu::{
+    context_action_should_proceed, SidebarContextMenu, SidebarContextMenuData, SidebarItemKind,
+};
 use super::quick_access::QuickAccess;
 use crate::components::bookmark_button::BookmarkButton;
 use crate::components::icon::{Icon, IconName};
@@ -79,8 +81,10 @@ pub fn FileExplorer(on_pin_toggle: Option<EventHandler<()>>) -> Element {
     let state = use_context::<AppState>();
     let root_directory = state.sidebar.read().root_directory.clone();
 
-    // Refresh counter to force DirectoryTree re-render
-    let refresh_counter = use_signal(|| 0u32);
+    // Refresh counter to force DirectoryTree re-render. Sourced from AppState
+    // (not a local signal) so the hoisted context menu's "Reload" action can
+    // trigger a refresh from outside this subtree.
+    let refresh_counter = state.sidebar_refresh_counter;
 
     // Watch directory for file system changes
     use_directory_watcher(root_directory.clone(), refresh_counter);
@@ -91,7 +95,7 @@ pub fn FileExplorer(on_pin_toggle: Option<EventHandler<()>>) -> Element {
             key: "{refresh_counter}",
 
             if let Some(root) = root_directory {
-                DirectoryNavigation { current_dir: root.clone(), refresh_counter, on_pin_toggle }
+                DirectoryNavigation { current_dir: root.clone(), on_pin_toggle }
                 DirectoryTree { path: root, refresh_counter }
             } else {
                 div {
@@ -107,11 +111,7 @@ pub fn FileExplorer(on_pin_toggle: Option<EventHandler<()>>) -> Element {
 }
 
 #[component]
-fn DirectoryNavigation(
-    current_dir: PathBuf,
-    mut refresh_counter: Signal<u32>,
-    on_pin_toggle: Option<EventHandler<()>>,
-) -> Element {
+fn DirectoryNavigation(current_dir: PathBuf, on_pin_toggle: Option<EventHandler<()>>) -> Element {
     let mut state = use_context::<AppState>();
     let is_pinned = state.sidebar.read().pinned;
     let sidebar = state.sidebar.read();
@@ -144,8 +144,9 @@ fn DirectoryNavigation(
             // Set reloading state for animation
             is_reloading_write.set(true);
 
-            // Increment counter to force DirectoryTree re-render
-            refresh_counter.set(refresh_counter() + 1);
+            // Force the file tree to remount and re-read the filesystem. Funnels
+            // through the shared method so every reload path stays consistent.
+            state.bump_sidebar_refresh();
 
             // Reset reloading state after animation
             let current_dir = current_dir.clone();
@@ -399,7 +400,7 @@ fn FileTreeNode(
     path: PathBuf,
     is_dir: bool,
     depth: usize,
-    mut refresh_counter: Signal<u32>,
+    refresh_counter: Signal<u32>,
 ) -> Element {
     let mut state = use_context::<AppState>();
 
@@ -436,142 +437,45 @@ fn FileTreeNode(
     // Copy feedback state
     let mut is_copied = use_signal(|| false);
 
-    // Context menu state
-    let mut show_context_menu = use_signal(|| false);
-    let mut context_menu_position = use_signal(|| (0, 0));
-    let mut other_windows = use_signal(Vec::new);
-
-    // Handle right-click to show context menu
+    // Right-click opens the shared, hoisted context menu. The node only *sets*
+    // the menu state in AppState; `SidebarContextMenuHost` (rendered at the
+    // app-container root) owns the action handlers and the rendering. Because
+    // the menu lives outside this `refresh_counter`-keyed subtree, a watcher
+    // remount can no longer unmount an open menu.
     let handle_context_menu = {
         let path = path.clone();
         move |evt: Event<MouseData>| {
             evt.prevent_default();
             evt.stop_propagation();
-            let mouse_data = evt.data();
-            context_menu_position.set((
-                mouse_data.client_coordinates().x as i32,
-                mouse_data.client_coordinates().y as i32,
-            ));
 
-            // Refresh window list
-            let windows = crate::window::main::list_visible_main_windows();
-            let current_id = window().id();
-            other_windows.set(
-                windows
-                    .iter()
-                    .filter(|w| w.window.id() != current_id)
-                    .map(|w| (w.window.id(), w.window.title()))
-                    .collect(),
-            );
-
-            show_context_menu.set(true);
-            tracing::trace!(?path, "Context menu opened");
-        }
-    };
-
-    // Handler for "Open File" or "Open Directory"
-    let handle_open = {
-        let path = path.clone();
-        move |_| {
-            if is_dir {
-                state.set_root_directory(&path);
-            } else {
-                state.open_file(&path);
-            }
-            show_context_menu.set(false);
-        }
-    };
-
-    // Handler for "Change Root Directory"
-    let handle_change_root_directory = {
-        let path = path.clone();
-        move |_| {
-            state.set_root_directory(&path);
-            show_context_menu.set(false);
-        }
-    };
-
-    // Handler for "Open in New Window"
-    let handle_open_in_new_window = {
-        let path = path.clone();
-        move |_| {
-            let path = path.clone();
-            spawn(async move {
-                let (tab, directory) = if is_dir {
-                    (crate::state::Tab::default(), Some(path))
-                } else {
-                    (
-                        crate::state::Tab::new(&path),
-                        path.parent().map(|p| p.to_path_buf()),
-                    )
-                };
-
-                let params = crate::window::main::CreateMainWindowConfigParams {
-                    directory,
-                    ..Default::default()
-                };
-                crate::window::main::create_main_window(tab, params).await;
-            });
-            show_context_menu.set(false);
-        }
-    };
-
-    // Handler for "Open in Window" (open in existing window)
-    let handle_open_in_window = {
-        let path = path.clone();
-        move |target_id: dioxus::desktop::tao::window::WindowId| {
-            let path = path.clone();
-            let result = if is_dir {
-                // For directories, broadcast to change root directory
-                crate::events::OPEN_DIRECTORY_IN_WINDOW.send((target_id, path))
-            } else {
-                // For files, broadcast to open file
-                crate::events::OPEN_FILE_IN_WINDOW.send((target_id, path))
+            // The menu renders at the (unzoomed) app root, so client coordinates
+            // are already in unscaled viewport pixels — no zoom compensation.
+            let cursor = {
+                let coords = evt.data().client_coordinates();
+                (coords.x as i32, coords.y as i32)
             };
-            if result.is_err() {
-                tracing::warn!(
-                    ?target_id,
-                    "Failed to open in window: target window may be closed"
-                );
-                show_context_menu.set(false);
-                return;
-            }
-            // Focus the target window
-            crate::window::main::focus_window(target_id);
-            show_context_menu.set(false);
-        }
-    };
+            let viewport = {
+                let size = *state.size.read();
+                (size.width as i32, size.height as i32)
+            };
 
-    // Handler for "Copy File Path" / "Copy Directory Path"
-    let handle_copy_path = {
-        let path = path.clone();
-        move |_| {
-            crate::utils::clipboard::copy_text(path.to_string_lossy());
-            show_context_menu.set(false);
-        }
-    };
+            // Collect the other visible windows for the "Open in Window" submenu.
+            let current_id = window().id();
+            let other_windows = crate::window::main::list_visible_main_windows()
+                .iter()
+                .filter(|w| w.window.id() != current_id)
+                .map(|w| (w.window.id(), w.window.title()))
+                .collect();
 
-    // Handler for "Reveal in Finder"
-    let handle_reveal_in_finder = {
-        let path = path.clone();
-        move |_| {
-            file_operations::reveal_in_finder(&path);
-            show_context_menu.set(false);
-        }
-    };
-
-    // Handler for "Reload"
-    let handle_reload = move |_| {
-        refresh_counter.set(refresh_counter() + 1);
-        show_context_menu.set(false);
-    };
-
-    // Handler for "Toggle Bookmark"
-    let handle_toggle_bookmark = {
-        let path = path.clone();
-        move |_| {
-            crate::bookmarks::toggle_bookmark(&path);
-            show_context_menu.set(false);
+            let kind = if is_dir {
+                SidebarItemKind::Directory
+            } else {
+                SidebarItemKind::File
+            };
+            let data =
+                SidebarContextMenuData::new(cursor, viewport, path.clone(), kind, other_windows);
+            state.sidebar_context_menu.set(Some(data));
+            tracing::trace!(?path, "Sidebar context menu opened");
         }
     };
 
@@ -704,24 +608,177 @@ fn FileTreeNode(
                 DirectoryChildren { path: path.clone(), depth, refresh_counter }
             }
         }
+    }
+}
 
-        // Context menu
-        if *show_context_menu.read() {
-            SidebarContextMenu {
-                position: *context_menu_position.read(),
-                path: path.clone(),
-                kind: if is_dir { SidebarItemKind::Directory } else { SidebarItemKind::File },
-                on_close: move |_| show_context_menu.set(false),
-                on_open: handle_open,
-                on_open_in_new_window: handle_open_in_new_window,
-                on_move_to_window: handle_open_in_window,
-                on_change_root_directory: handle_change_root_directory,
-                on_toggle_bookmark: handle_toggle_bookmark,
-                on_copy_path: handle_copy_path,
-                on_reveal_in_finder: handle_reveal_in_finder,
-                on_reload: handle_reload,
-                other_windows: other_windows.read().clone(),
+/// Renders the left-sidebar file-tree context menu once, at the app-container
+/// root, driven by `AppState::sidebar_context_menu`.
+///
+/// # Why hoisted here
+///
+/// The file tree is keyed on `AppState::sidebar_refresh_counter`, which the
+/// directory watcher bumps on every filesystem event. Rendering the menu inside
+/// a tree node meant a watcher-driven remount destroyed the node — and the open
+/// menu with it. Hosting the menu here, outside every keyed subtree, makes it
+/// independent of those remounts: tree nodes only *set* the menu state, and this
+/// host owns every action handler.
+#[component]
+pub fn SidebarContextMenuHost() -> Element {
+    let mut state = use_context::<AppState>();
+
+    // Subscribe to the menu state; render nothing while the menu is closed.
+    let Some(data) = state.sidebar_context_menu.read().clone() else {
+        return rsx! {};
+    };
+
+    let path = data.path.clone();
+    let is_dir = data.kind.is_dir();
+
+    // Handler for "Open File" / "Open Directory"
+    let handle_open = {
+        let path = path.clone();
+        move |_| {
+            // The snapshotted target may have been deleted/renamed while the menu
+            // stayed open; close as a no-op instead of acting on a stale path.
+            if !context_action_should_proceed(&path) {
+                state.close_sidebar_context_menu();
+                return;
             }
+            if is_dir {
+                state.set_root_directory(&path);
+            } else {
+                state.open_file(&path);
+            }
+            state.close_sidebar_context_menu();
+        }
+    };
+
+    // Handler for "Change Root Directory"
+    let handle_change_root_directory = {
+        let path = path.clone();
+        move |_| {
+            if !context_action_should_proceed(&path) {
+                state.close_sidebar_context_menu();
+                return;
+            }
+            state.set_root_directory(&path);
+            state.close_sidebar_context_menu();
+        }
+    };
+
+    // Handler for "Open in New Window"
+    let handle_open_in_new_window = {
+        let path = path.clone();
+        move |_| {
+            if !context_action_should_proceed(&path) {
+                state.close_sidebar_context_menu();
+                return;
+            }
+            let path = path.clone();
+            spawn(async move {
+                let (tab, directory) = if is_dir {
+                    (crate::state::Tab::default(), Some(path))
+                } else {
+                    (
+                        crate::state::Tab::new(&path),
+                        path.parent().map(|p| p.to_path_buf()),
+                    )
+                };
+
+                let params = crate::window::main::CreateMainWindowConfigParams {
+                    directory,
+                    ..Default::default()
+                };
+                crate::window::main::create_main_window(tab, params).await;
+            });
+            state.close_sidebar_context_menu();
+        }
+    };
+
+    // Handler for "Open in Window" (open in an existing window)
+    let handle_open_in_window = {
+        let path = path.clone();
+        move |target_id: dioxus::desktop::tao::window::WindowId| {
+            if !context_action_should_proceed(&path) {
+                state.close_sidebar_context_menu();
+                return;
+            }
+            let path = path.clone();
+            let result = if is_dir {
+                // For directories, broadcast to change root directory
+                crate::events::OPEN_DIRECTORY_IN_WINDOW.send((target_id, path))
+            } else {
+                // For files, broadcast to open file
+                crate::events::OPEN_FILE_IN_WINDOW.send((target_id, path))
+            };
+            if result.is_err() {
+                tracing::warn!(
+                    ?target_id,
+                    "Failed to open in window: target window may be closed"
+                );
+                state.close_sidebar_context_menu();
+                return;
+            }
+            // Focus the target window
+            crate::window::main::focus_window(target_id);
+            state.close_sidebar_context_menu();
+        }
+    };
+
+    // Handler for "Copy File Path" / "Copy Directory Path"
+    let handle_copy_path = {
+        let path = path.clone();
+        move |_| {
+            crate::utils::clipboard::copy_text(path.to_string_lossy());
+            state.close_sidebar_context_menu();
+        }
+    };
+
+    // Handler for "Reveal in Finder"
+    let handle_reveal_in_finder = {
+        let path = path.clone();
+        move |_| {
+            if !context_action_should_proceed(&path) {
+                state.close_sidebar_context_menu();
+                return;
+            }
+            file_operations::reveal_in_finder(&path);
+            state.close_sidebar_context_menu();
+        }
+    };
+
+    // Handler for "Reload"
+    let handle_reload = move |_| {
+        state.bump_sidebar_refresh();
+        state.close_sidebar_context_menu();
+    };
+
+    // Handler for "Toggle Bookmark"
+    let handle_toggle_bookmark = {
+        let path = path.clone();
+        move |_| {
+            crate::bookmarks::toggle_bookmark(&path);
+            state.close_sidebar_context_menu();
+        }
+    };
+
+    rsx! {
+        SidebarContextMenu {
+            position: data.position,
+            path: path.clone(),
+            kind: data.kind,
+            submenu_left: data.submenu_left,
+            submenu_offset_y: data.submenu_offset_y,
+            on_close: move |_| state.close_sidebar_context_menu(),
+            on_open: handle_open,
+            on_open_in_new_window: handle_open_in_new_window,
+            on_move_to_window: handle_open_in_window,
+            on_change_root_directory: handle_change_root_directory,
+            on_toggle_bookmark: handle_toggle_bookmark,
+            on_copy_path: handle_copy_path,
+            on_reveal_in_finder: handle_reveal_in_finder,
+            on_reload: handle_reload,
+            other_windows: data.other_windows.clone(),
         }
     }
 }

--- a/desktop/src/state/app_state.rs
+++ b/desktop/src/state/app_state.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use crate::components::right_sidebar::RightSidebarTab;
+use crate::components::sidebar::context_menu::SidebarContextMenuData;
 use crate::config::DEFAULT_RIGHT_SIDEBAR_WIDTH;
 use crate::markdown::HeadingInfo;
 use crate::pinned_search::PinnedSearchId;
@@ -109,6 +110,17 @@ pub struct AppState {
     /// Whether the right sidebar overlay is currently shown (hover/focus triggered).
     /// Transient UI state — not persisted.
     pub right_hover_active: Signal<bool>,
+    /// Left-sidebar file-tree context menu state (position, target, window list).
+    ///
+    /// Held here — not in a tree node — so watcher-driven remounts of the file
+    /// tree cannot unmount an open menu. Rendered once at the app-container root
+    /// by `SidebarContextMenuHost`. Transient UI state — not persisted.
+    pub sidebar_context_menu: Signal<Option<SidebarContextMenuData>>,
+    /// Monotonic counter that remounts the file tree on file-system changes or
+    /// manual reload. Lives in `AppState` (rather than a local `FileExplorer`
+    /// signal) so the hoisted context menu's "Reload" action can trigger a
+    /// refresh from outside the tree subtree. Transient UI state — not persisted.
+    pub sidebar_refresh_counter: Signal<u32>,
 }
 
 impl AppState {
@@ -147,6 +159,8 @@ impl AppState {
             quick_access_cursor: Signal::new(None),
             left_hover_active: Signal::new(false),
             right_hover_active: Signal::new(false),
+            sidebar_context_menu: Signal::new(None),
+            sidebar_refresh_counter: Signal::new(0),
         }
     }
 }
@@ -277,5 +291,17 @@ impl AppState {
     /// Update pinned search matches from JavaScript callback
     pub fn update_pinned_matches(&mut self, matches: HashMap<PinnedSearchId, Vec<SearchMatch>>) {
         self.pinned_matches.set(matches);
+    }
+
+    /// Close the left-sidebar file-tree context menu.
+    pub fn close_sidebar_context_menu(&mut self) {
+        self.sidebar_context_menu.set(None);
+    }
+
+    /// Force the file tree to remount and re-read the filesystem (manual reload
+    /// or file-watcher change).
+    pub fn bump_sidebar_refresh(&mut self) {
+        let next = self.sidebar_refresh_counter.read().wrapping_add(1);
+        self.sidebar_refresh_counter.set(next);
     }
 }

--- a/renderer/style/components/context-menu/base.css
+++ b/renderer/style/components/context-menu/base.css
@@ -64,6 +64,16 @@
   z-index: var(--z-context-submenu);
 }
 
+/* Flip the submenu to the left of its parent when the menu sits near the
+   viewport's right edge, so the flyout stays on-screen. The direction is
+   decided in Rust (submenu_opens_left) from the clamped menu position. */
+.context-submenu.flip-left {
+  left: auto;
+  right: 100%;
+  margin-left: 0;
+  margin-right: 4px;
+}
+
 .submenu-arrow {
   margin-left: auto;
   padding-left: 12px;


### PR DESCRIPTION
## Summary

Reworks the sidebar file-tree right-click context menu so it no longer vanishes mid-interaction or clips off-screen. Supersedes the earlier closed PR #167 (which mixed in unrelated formatting churn); this branch is a focused, single-purpose reimplementation.

## Problem

- **Vanishing / abrupt unmount**: the menu was rendered inside the file tree, whose subtree is keyed on a refresh counter the directory watcher bumps on every filesystem event. A watcher-driven remount destroyed the open menu.
- **Off-screen clipping**: positioning used raw cursor coordinates with no viewport clamp, so the menu and its "Open in Window" submenu spilled past the right/bottom edges.

## Changes

- Move the context-menu state into per-window `AppState` (`Signal<Option<SidebarContextMenuData>>`) and render a single `SidebarContextMenuHost` at the app-container root, **outside** the watcher-keyed subtree, so refresh-driven remounts can no longer unmount it. `sidebar_refresh_counter` is hoisted into `AppState` so the hoisted menu's Reload still refreshes the tree.
- Clamp the menu (`clamp_menu_position`) and the submenu — both horizontally (`submenu_opens_left`) and vertically (`clamp_submenu_top`) — to the viewport.
- Guard actions (`context_action_should_proceed`) against a target path the watcher removed while the menu was open, so Open / Reveal / set-root no-op instead of acting on a stale path.

## Notes / follow-up

- Overlay-mode cursor alignment under a non-1.0 sidebar zoom should be confirmed on a real window (the menu now renders outside the zoomed subtree; couldn't verify in a headless session).
- Menu-size constants remain estimates rather than measured DOM rects — a possible later refinement.

## Test plan

- [x] `just fmt check test` passes (522 Rust + 6 doc + 58 renderer tests, incl. new clamp / stale-path tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
