### PR TITLE
feat(keybindings): support the primary modifier on Windows and Linux

### DIFF
--- a/desktop/src/components/app/keybinding_engine.rs
+++ b/desktop/src/components/app/keybinding_engine.rs
@@ -25,6 +25,14 @@ fn should_skip_keybinding(data: &KeyEventData) -> bool {
     data.search_focused && data.modifiers == 0 && data.key == "Escape"
 }
 
+/// Maximum readiness-poll attempts for the JS keyboard API before giving up.
+///
+/// The interceptor ships inside the multi-megabyte renderer bundle; on Windows
+/// a cold WebView2 start can spend several seconds parsing it, so allow a longer
+/// wait there. Each attempt sleeps 50 ms, so 200 ≈ 10 s and 50 ≈ 2.5 s. Both
+/// readiness loops (keyboard interceptor and menu accelerators) share this bound.
+const JS_KEYBOARD_READY_MAX_RETRIES: u32 = if cfg!(target_os = "windows") { 200 } else { 50 };
+
 /// Send the current native menu-accelerator chords to the JS interceptor so it
 /// skips them (the OS menu dispatches those; forwarding would double-fire).
 ///
@@ -39,12 +47,13 @@ fn push_menu_accelerators_to_js() {
         r#"
         (async () => {{
             let retries = 0;
-            while (!window.Arto?.keyboard?.setMenuAccelerators && retries++ < 50) {{
+            while (!window.Arto?.keyboard?.setMenuAccelerators && retries++ < {max}) {{
                 await new Promise(r => setTimeout(r, 50));
             }}
             window.Arto?.keyboard?.setMenuAccelerators?.({json});
         }})();
-        "#
+        "#,
+        max = JS_KEYBOARD_READY_MAX_RETRIES,
     ));
 }
 
@@ -52,6 +61,34 @@ fn push_menu_accelerators_to_js() {
 /// (see `BindingSet::into_resolved_bindings`) — there is nothing to skip.
 #[cfg(target_os = "windows")]
 fn push_menu_accelerators_to_js() {}
+
+/// Tell the JS interceptor which primary-modifier + single-letter chords the
+/// active config binds, so it does not treat them as OS-reserved and swallow
+/// them before the engine runs (e.g. the emacs `C-x` prefix / `C-v`).
+///
+/// Runs on every platform (unlike the menu-accelerator push): the reserved gate
+/// exists on all platforms — Cmd+{Q,C,V,X,A} on macOS, Ctrl+{Q,C,V,X,A} on
+/// Windows/Linux — and the primary modifier is resolved accordingly inside
+/// [`crate::keybindings::reserved_key_overrides`]. Must be called within the
+/// Dioxus runtime (component task / spawn).
+fn push_reserved_key_overrides_to_js() {
+    use crate::config::CONFIG;
+
+    let keys = crate::keybindings::reserved_key_overrides(&CONFIG.read().keybindings);
+    let json = serde_json::to_string(&keys).unwrap_or_else(|_| "[]".to_string());
+    let _ = document::eval(&format!(
+        r#"
+        (async () => {{
+            let retries = 0;
+            while (!window.Arto?.keyboard?.setReservedKeyOverrides && retries++ < {max}) {{
+                await new Promise(r => setTimeout(r, 50));
+            }}
+            window.Arto?.keyboard?.setReservedKeyOverrides?.({json});
+        }})();
+        "#,
+        max = JS_KEYBOARD_READY_MAX_RETRIES,
+    ));
+}
 
 /// Set up the keybinding engine with JS keyboard interceptor bridge.
 ///
@@ -80,28 +117,33 @@ pub(super) fn setup_keybinding_engine(
         // Keyboard event processing loop
         spawn(async move {
             // Wait for JS keyboard API to be ready, then register callback.
-            // Retries up to 50 times (2.5s) before giving up.
-            let mut eval = document::eval(
+            // Retries up to JS_KEYBOARD_READY_MAX_RETRIES times (50 ms each:
+            // ~2.5 s elsewhere, ~10 s on Windows) before giving up.
+            let mut eval = document::eval(&format!(
                 r#"
-            (async () => {
+            (async () => {{
                 let retries = 0;
-                while (!window.Arto?.keyboard?.onKeydown && retries++ < 50) {
+                while (!window.Arto?.keyboard?.onKeydown && retries++ < {max}) {{
                     await new Promise(r => setTimeout(r, 50));
-                }
-                if (!window.Arto?.keyboard?.onKeydown) {
+                }}
+                if (!window.Arto?.keyboard?.onKeydown) {{
                     console.error("Keyboard interceptor API not available after timeout");
                     return;
-                }
-                window.Arto.keyboard.onKeydown((data) => {
+                }}
+                window.Arto.keyboard.onKeydown((data) => {{
                     dioxus.send(data);
-                });
-            })();
+                }});
+            }})();
             "#,
-            );
+                max = JS_KEYBOARD_READY_MAX_RETRIES,
+            ));
 
             // Tell the interceptor which chords are native menu accelerators so
-            // it does not also forward them to the engine (double-fire guard).
+            // it does not also forward them to the engine (double-fire guard),
+            // and which primary+letter chords the config binds so it does not
+            // swallow them as OS-reserved shortcuts.
             push_menu_accelerators_to_js();
+            push_reserved_key_overrides_to_js();
 
             // If JS initialization fails (timeout), recv returns Err immediately and
             // the loop never starts. Log a warning so the issue is diagnosable.
@@ -186,6 +228,7 @@ pub(super) fn setup_keybinding_engine(
                 let new_config = CONFIG.read().keybindings.clone();
                 *engine.read().borrow_mut() = KeybindingEngine::new(&new_config);
                 push_menu_accelerators_to_js();
+                push_reserved_key_overrides_to_js();
                 tracing::debug!("Keybinding engine rebuilt after config change");
             }
         });

--- a/desktop/src/keybindings/accelerator.rs
+++ b/desktop/src/keybindings/accelerator.rs
@@ -62,6 +62,53 @@ pub fn menu_accelerator_skip_keys(bindings: &BindingSet) -> Vec<String> {
         .collect()
 }
 
+/// Letters bound as a bare primary-modifier chord anywhere in the active
+/// bindings, lowercased (e.g. `["c", "v", "x"]`).
+///
+/// The primary modifier is Cmd (`META`) on macOS and Ctrl (`CONTROL`) on
+/// Windows/Linux, matching the parse-time remap in `shortcut.rs`. A chord counts
+/// when it uses *exactly* the primary modifier (no Shift/Alt/secondary) and a
+/// single ASCII letter, in *any* position of *any* sequence, in *any* context —
+/// so the later `Ctrl+c` of emacs `Ctrl+x Ctrl+c` is included alongside the
+/// `Ctrl+x` prefix.
+///
+/// The keybinding engine forwards these to the JS interceptor, which treats a
+/// small set of primary+letter chords (Cmd/Ctrl + Q/C/V/X/A) as OS-reserved and
+/// swallows them before the engine runs. Reporting the ones the config actually
+/// binds lets the interceptor keep native clipboard/quit reserved while letting
+/// bound chords (the whole emacs `C-x` prefix system, `C-v`) reach the engine.
+pub fn reserved_key_overrides(bindings: &BindingSet) -> Vec<String> {
+    reserved_key_overrides_impl(bindings, cfg!(target_os = "macos"))
+}
+
+/// Platform-agnostic core of [`reserved_key_overrides`], extracted so both
+/// primary-modifier branches can be unit-tested from any host.
+fn reserved_key_overrides_impl(bindings: &BindingSet, is_macos: bool) -> Vec<String> {
+    let primary = if is_macos {
+        Modifiers::META
+    } else {
+        Modifiers::CONTROL
+    };
+    let mut letters = std::collections::BTreeSet::new();
+    for binding in bindings.clone().into_resolved_bindings() {
+        for chord in &binding.sequence.chords {
+            if chord.modifiers != primary {
+                continue;
+            }
+            if let Key::Character(ch) = &chord.key {
+                let mut chars = ch.chars();
+                match (chars.next(), chars.next()) {
+                    (Some(c), None) if c.is_ascii_alphabetic() => {
+                        letters.insert(c.to_ascii_lowercase().to_string());
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    letters.into_iter().collect()
+}
+
 /// Map dioxus modifier flags to muda (keyboard_types) modifiers.
 ///
 /// `META` (Cmd on macOS) maps to `SUPER`; `Accelerator::new` also normalizes
@@ -153,11 +200,26 @@ fn char_to_code(character: &str) -> Option<Code> {
 mod tests {
     use super::*;
 
+    /// muda modifier a parsed `Cmd`/`Meta` chord resolves to on the host: `SUPER`
+    /// (Cmd) on macOS, `CONTROL` on Windows/Linux where the primary modifier is
+    /// remapped META → CONTROL at parse time.
+    #[cfg(target_os = "macos")]
+    const PRIMARY_MUDA: MudaModifiers = MudaModifiers::SUPER;
+    #[cfg(not(target_os = "macos"))]
+    const PRIMARY_MUDA: MudaModifiers = MudaModifiers::CONTROL;
+
+    /// dioxus modifier bits the primary accelerator carries in a skip key:
+    /// META (0x40) on macOS, CONTROL (0x08) on Windows/Linux.
+    #[cfg(target_os = "macos")]
+    const PRIMARY_BITS: u32 = 0x40;
+    #[cfg(not(target_os = "macos"))]
+    const PRIMARY_BITS: u32 = 0x08;
+
     #[test]
-    fn cmd_letter_maps_to_super_key_code() {
+    fn cmd_letter_maps_to_primary_key_code() {
         assert_eq!(
             accelerator_for_key("Cmd+o"),
-            Some(Accelerator::new(Some(MudaModifiers::SUPER), Code::KeyO))
+            Some(Accelerator::new(Some(PRIMARY_MUDA), Code::KeyO))
         );
     }
 
@@ -166,7 +228,7 @@ mod tests {
         assert_eq!(
             accelerator_for_key("Cmd+Shift+o"),
             Some(Accelerator::new(
-                Some(MudaModifiers::SUPER | MudaModifiers::SHIFT),
+                Some(PRIMARY_MUDA | MudaModifiers::SHIFT),
                 Code::KeyO
             ))
         );
@@ -176,18 +238,15 @@ mod tests {
     fn symbol_aliases_map_to_codes() {
         assert_eq!(
             accelerator_for_key("Cmd+BracketLeft"),
-            Some(Accelerator::new(
-                Some(MudaModifiers::SUPER),
-                Code::BracketLeft
-            ))
+            Some(Accelerator::new(Some(PRIMARY_MUDA), Code::BracketLeft))
         );
         assert_eq!(
             accelerator_for_key("Cmd+Equal"),
-            Some(Accelerator::new(Some(MudaModifiers::SUPER), Code::Equal))
+            Some(Accelerator::new(Some(PRIMARY_MUDA), Code::Equal))
         );
         assert_eq!(
             accelerator_for_key("Cmd+Minus"),
-            Some(Accelerator::new(Some(MudaModifiers::SUPER), Code::Minus))
+            Some(Accelerator::new(Some(PRIMARY_MUDA), Code::Minus))
         );
     }
 
@@ -195,7 +254,7 @@ mod tests {
     fn digit_maps_to_digit_code() {
         assert_eq!(
             accelerator_for_key("Cmd+0"),
-            Some(Accelerator::new(Some(MudaModifiers::SUPER), Code::Digit0))
+            Some(Accelerator::new(Some(PRIMARY_MUDA), Code::Digit0))
         );
     }
 
@@ -212,7 +271,7 @@ mod tests {
         assert_eq!(
             accelerator_for_key("Cmd+Alt+w"),
             Some(Accelerator::new(
-                Some(MudaModifiers::SUPER | MudaModifiers::ALT),
+                Some(PRIMARY_MUDA | MudaModifiers::ALT),
                 Code::KeyW
             ))
         );
@@ -232,39 +291,41 @@ mod tests {
     // -- Skip-key canonical form (must match JS interceptor's event.code) --
     //
     // dioxus Modifiers bits: ALT=0x01, CONTROL=0x08, META=0x40, SHIFT=0x200.
-    // Key part is the physical Code (e.g. "KeyO"), not the logical glyph.
+    // Key part is the physical Code (e.g. "KeyO"), not the logical glyph. The
+    // primary modifier (Cmd) is META on macOS and remapped to CONTROL elsewhere,
+    // so the leading bits differ per platform (see PRIMARY_BITS).
 
     #[test]
     fn skip_key_cmd_letter() {
         assert_eq!(
-            menu_accelerator_skip_key("Cmd+o").as_deref(),
-            Some("64:KeyO")
+            menu_accelerator_skip_key("Cmd+o"),
+            Some(format!("{PRIMARY_BITS}:KeyO"))
         );
     }
 
     #[test]
     fn skip_key_cmd_shift_letter() {
-        // META (0x40=64) | SHIFT (0x200=512) = 576
+        // primary | SHIFT (0x200=512)
         assert_eq!(
-            menu_accelerator_skip_key("Cmd+Shift+o").as_deref(),
-            Some("576:KeyO")
+            menu_accelerator_skip_key("Cmd+Shift+o"),
+            Some(format!("{}:KeyO", PRIMARY_BITS | 0x200))
         );
     }
 
     #[test]
     fn skip_key_uses_physical_code_for_symbols() {
         assert_eq!(
-            menu_accelerator_skip_key("Cmd+BracketLeft").as_deref(),
-            Some("64:BracketLeft")
+            menu_accelerator_skip_key("Cmd+BracketLeft"),
+            Some(format!("{PRIMARY_BITS}:BracketLeft"))
         );
     }
 
     #[test]
     fn skip_key_alt_uses_stable_physical_code() {
-        // META (64) | ALT (1) = 65; physical code is immune to Option remapping.
+        // primary | ALT (1); physical code is immune to Option remapping.
         assert_eq!(
-            menu_accelerator_skip_key("Cmd+Alt+w").as_deref(),
-            Some("65:KeyW")
+            menu_accelerator_skip_key("Cmd+Alt+w"),
+            Some(format!("{}:KeyW", PRIMARY_BITS | 0x01))
         );
     }
 
@@ -290,6 +351,74 @@ mod tests {
             ],
             ..Default::default()
         };
-        assert_eq!(menu_accelerator_skip_keys(&bindings), vec!["64:KeyO"]);
+        assert_eq!(
+            menu_accelerator_skip_keys(&bindings),
+            vec![format!("{PRIMARY_BITS}:KeyO")]
+        );
+    }
+
+    // -- Reserved-key overrides (config-aware OS-reserved gate) --------------
+
+    #[test]
+    fn reserved_overrides_off_macos_include_emacs_ctrl_prefix_letters() {
+        // On Windows/Linux the primary modifier is Ctrl. The emacs preset binds
+        // Ctrl+x (prefix), Ctrl+v (page down), and Ctrl+x Ctrl+c (quit) — the
+        // reserved letters x, v, and the later-chord c must all be reported so
+        // the interceptor stops swallowing them.
+        let overrides =
+            reserved_key_overrides_impl(&crate::keybindings::presets::emacs::bindings(), false);
+        assert!(overrides.contains(&"x".to_string()));
+        assert!(overrides.contains(&"v".to_string()));
+        assert!(overrides.contains(&"c".to_string()));
+    }
+
+    #[test]
+    fn reserved_overrides_on_macos_exclude_ctrl_only_chords() {
+        // On macOS the primary modifier is Cmd, so emacs' Ctrl-based chords are
+        // not primary chords and the gate never fires on them — they must not be
+        // reported (and Cmd+C/V/X/A stay OS-reserved for native clipboard).
+        let overrides =
+            reserved_key_overrides_impl(&crate::keybindings::presets::emacs::bindings(), true);
+        assert!(!overrides.contains(&"x".to_string()));
+        assert!(!overrides.contains(&"v".to_string()));
+        assert!(!overrides.contains(&"c".to_string()));
+    }
+
+    #[test]
+    fn reserved_overrides_default_preset_leave_clipboard_reserved() {
+        // The default preset binds none of Q/C/V/X/A with the primary modifier,
+        // so on neither platform should those letters be overridden — the
+        // interceptor keeps native clipboard/select-all/quit working.
+        let bindings = crate::keybindings::default_bindings();
+        for is_macos in [true, false] {
+            let overrides = reserved_key_overrides_impl(&bindings, is_macos);
+            for reserved in ["q", "c", "v", "x", "a"] {
+                assert!(
+                    !overrides.contains(&reserved.to_string()),
+                    "default preset must not override reserved {reserved:?} (is_macos={is_macos})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn reserved_overrides_ignore_shift_and_alt_variants() {
+        use crate::config::KeyAction;
+        // Only bare primary+letter chords count; Shift/Alt variants never trip
+        // the interceptor's reserved gate, so they must not be reported.
+        let bindings = BindingSet {
+            global: vec![
+                KeyAction {
+                    key: "Ctrl+Shift+x".to_string(),
+                    action: "tab.close".to_string(),
+                },
+                KeyAction {
+                    key: "Ctrl+Alt+v".to_string(),
+                    action: "scroll.page_down".to_string(),
+                },
+            ],
+            ..Default::default()
+        };
+        assert!(reserved_key_overrides_impl(&bindings, false).is_empty());
     }
 }

--- a/desktop/src/keybindings/engine.rs
+++ b/desktop/src/keybindings/engine.rs
@@ -127,6 +127,20 @@ impl KeybindingEngine {
         KeyMatchResult::NoMatch
     }
 
+    /// Build an engine with the menu-shortcut folding decision forced, so tests
+    /// can exercise both the native-menu (macOS/Linux) and folded (Windows)
+    /// branches regardless of the host platform.
+    #[cfg(test)]
+    fn new_with_menu_folding(bindings: &BindingSet, fold_menu_shortcuts: bool) -> Self {
+        Self {
+            bindings: bindings
+                .clone()
+                .into_resolved_bindings_with(fold_menu_shortcuts),
+            state: KeySequenceState::Idle,
+            sequence_timeout: DEFAULT_SEQUENCE_TIMEOUT,
+        }
+    }
+
     /// Reset the engine state (e.g., on focus change or cancel).
     pub fn reset(&mut self) {
         self.state = KeySequenceState::Idle;
@@ -280,13 +294,52 @@ mod tests {
     }
 
     #[test]
-    fn menu_shortcut_not_matched_by_engine() {
-        // Cmd+n (window.new) is a native menu shortcut, not an engine binding,
-        // so the keybinding engine must not resolve it.
+    fn menu_shortcut_reachable_only_when_folded() {
+        // The menu-shortcut folding decision, tested on both branches from any
+        // host. Cmd+o (file.open) is a menu shortcut in the default preset.
+        // - Native-menu platforms (macOS/Linux): the OS dispatches it, so the
+        //   engine must NOT resolve it.
+        // - Windows: no native menu, so it is folded into the engine and matches.
+        // Using `chord("Cmd+o")` keeps the probe in the host's own parse space,
+        // so it lines up with the folded binding regardless of platform.
         let config = default_bindings();
-        let mut engine = KeybindingEngine::new(&config);
-        let result = engine.process_key(&chord("Cmd+n"), false, KeyContext::Content);
-        assert_eq!(result, KeyMatchResult::NoMatch);
+
+        let mut native = KeybindingEngine::new_with_menu_folding(&config, false);
+        assert_eq!(
+            native.process_key(&chord("Cmd+o"), false, KeyContext::Content),
+            KeyMatchResult::NoMatch
+        );
+
+        let mut folded = KeybindingEngine::new_with_menu_folding(&config, true);
+        assert_eq!(
+            folded.process_key(&chord("Cmd+o"), false, KeyContext::Content),
+            KeyMatchResult::Matched(Action::FileOpen)
+        );
+    }
+
+    #[test]
+    fn folded_menu_shortcut_yields_to_later_global_binding() {
+        // Menu shortcuts fold in BEFORE the `global` field, and global matches
+        // are last-wins, so an idiomatic global binding on the same chord wins
+        // over a folded menu shortcut. Keyed with Ctrl+n on both entries so the
+        // chords collide on every host (Ctrl is never remapped), isolating the
+        // fold-ordering invariant from the Cmd→Ctrl remap (covered in shortcut).
+        let set = BindingSet {
+            menu_shortcuts: vec![KeyAction {
+                key: "Ctrl+n".to_string(),
+                action: "window.new".to_string(),
+            }],
+            global: vec![KeyAction {
+                key: "Ctrl+n".to_string(),
+                action: "scroll.down".to_string(),
+            }],
+            ..Default::default()
+        };
+        let mut engine = KeybindingEngine::new_with_menu_folding(&set, true);
+        assert_eq!(
+            engine.process_key(&chord("Ctrl+n"), false, KeyContext::Content),
+            KeyMatchResult::Matched(Action::ScrollDown)
+        );
     }
 
     #[test]

--- a/desktop/src/keybindings/hint.rs
+++ b/desktop/src/keybindings/hint.rs
@@ -52,19 +52,31 @@ fn bindings_for_context(
     }
 }
 
-/// Convert keybinding notation into a menu-style shortcut hint.
+/// Convert keybinding notation into a platform-appropriate shortcut hint.
 ///
-/// Examples:
-/// - `Cmd+Shift+o` -> `⌘⇧O`
-/// - `Ctrl+w h` -> `⌃W H`
+/// macOS uses the compact menu-style symbol form; Windows/Linux use the plain
+/// text form that matches their native conventions:
+/// - `Cmd+Shift+o` -> `⌘⇧O` (macOS) / `Ctrl+Shift+O` (Windows/Linux)
+/// - `Ctrl+w h` -> `⌃W H` (macOS) / `Ctrl+W H` (Windows/Linux)
+///
+/// `Cmd`/`Meta` is the primary accelerator, so it renders as `⌘` on macOS and
+/// as `Ctrl` on Windows/Linux — mirroring the `META` -> `CONTROL` remap applied
+/// when the same chord is parsed for matching.
 pub fn format_shortcut_hint(key: &str) -> String {
+    format_shortcut_hint_impl(key, cfg!(target_os = "macos"))
+}
+
+/// Platform-agnostic core of [`format_shortcut_hint`], extracted so both the
+/// macOS symbol form and the Windows/Linux text form can be unit-tested from any
+/// host.
+fn format_shortcut_hint_impl(key: &str, is_macos: bool) -> String {
     key.split_whitespace()
-        .map(format_chord_hint)
+        .map(|chord| format_chord_hint(chord, is_macos))
         .collect::<Vec<_>>()
         .join(" ")
 }
 
-fn format_chord_hint(chord: &str) -> String {
+fn format_chord_hint(chord: &str, is_macos: bool) -> String {
     let mut parts = chord
         .split('+')
         .map(str::trim)
@@ -77,6 +89,18 @@ fn format_chord_hint(chord: &str) -> String {
     let key_part = parts.pop().unwrap();
     let mut out = String::new();
     for modifier in parts {
+        push_modifier_hint(&mut out, modifier, is_macos);
+    }
+    out.push_str(&format_key_name_hint(key_part, is_macos));
+    out
+}
+
+/// Append the rendered form of a single modifier token to `out`.
+///
+/// macOS uses the compact menu-style glyphs; Windows/Linux use plain text and
+/// collapse `Cmd`/`Meta` onto `Ctrl`, the primary accelerator there.
+fn push_modifier_hint(out: &mut String, modifier: &str, is_macos: bool) {
+    if is_macos {
         match modifier.to_ascii_lowercase().as_str() {
             "cmd" | "command" | "meta" => out.push('⌘'),
             "ctrl" | "control" => out.push('⌃'),
@@ -87,27 +111,49 @@ fn format_chord_hint(chord: &str) -> String {
                 out.push('+');
             }
         }
+    } else {
+        match modifier.to_ascii_lowercase().as_str() {
+            "cmd" | "command" | "meta" | "ctrl" | "control" => out.push_str("Ctrl+"),
+            "shift" => out.push_str("Shift+"),
+            "alt" | "option" => out.push_str("Alt+"),
+            other => {
+                out.push_str(other);
+                out.push('+');
+            }
+        }
     }
-    out.push_str(&format_key_name_hint(key_part));
-    out
 }
 
-fn format_key_name_hint(key: &str) -> String {
-    match key {
-        "ArrowUp" => "↑".to_string(),
-        "ArrowDown" => "↓".to_string(),
-        "ArrowLeft" => "←".to_string(),
-        "ArrowRight" => "→".to_string(),
-        "Backspace" => "⌫".to_string(),
-        "Enter" => "↩".to_string(),
-        "Escape" => "⎋".to_string(),
-        "Tab" => "⇥".to_string(),
-        "Space" => "␠".to_string(),
-        "PageUp" => "⇞".to_string(),
-        "PageDown" => "⇟".to_string(),
-        "Home" => "↖".to_string(),
-        "End" => "↘".to_string(),
-        _ => key.to_uppercase(),
+fn format_key_name_hint(key: &str, is_macos: bool) -> String {
+    if is_macos {
+        match key {
+            "ArrowUp" => "↑".to_string(),
+            "ArrowDown" => "↓".to_string(),
+            "ArrowLeft" => "←".to_string(),
+            "ArrowRight" => "→".to_string(),
+            "Backspace" => "⌫".to_string(),
+            "Enter" => "↩".to_string(),
+            "Escape" => "⎋".to_string(),
+            "Tab" => "⇥".to_string(),
+            "Space" => "␠".to_string(),
+            "PageUp" => "⇞".to_string(),
+            "PageDown" => "⇟".to_string(),
+            "Home" => "↖".to_string(),
+            "End" => "↘".to_string(),
+            _ => key.to_uppercase(),
+        }
+    } else {
+        match key {
+            "ArrowUp" => "Up".to_string(),
+            "ArrowDown" => "Down".to_string(),
+            "ArrowLeft" => "Left".to_string(),
+            "ArrowRight" => "Right".to_string(),
+            "Escape" => "Esc".to_string(),
+            "Backspace" | "Enter" | "Tab" | "Space" | "PageUp" | "PageDown" | "Home" | "End" => {
+                key.to_string()
+            }
+            _ => key.to_uppercase(),
+        }
     }
 }
 
@@ -116,15 +162,43 @@ mod tests {
     use super::*;
 
     #[test]
-    fn format_shortcut_hint_uses_menu_style_symbols() {
-        assert_eq!(format_shortcut_hint("Cmd+Shift+o"), "⌘⇧O");
-        assert_eq!(format_shortcut_hint("Ctrl+w h"), "⌃W H");
+    fn format_shortcut_hint_uses_menu_style_symbols_on_macos() {
+        assert_eq!(format_shortcut_hint_impl("Cmd+Shift+o", true), "⌘⇧O");
+        assert_eq!(format_shortcut_hint_impl("Ctrl+w h", true), "⌃W H");
     }
 
     #[test]
-    fn format_shortcut_hint_formats_arrow_keys() {
-        assert_eq!(format_shortcut_hint("ArrowDown"), "↓");
-        assert_eq!(format_shortcut_hint("Cmd+ArrowLeft"), "⌘←");
+    fn format_shortcut_hint_uses_text_form_off_macos() {
+        // Cmd/Meta renders as Ctrl, the primary accelerator on Windows/Linux.
+        assert_eq!(
+            format_shortcut_hint_impl("Cmd+Shift+o", false),
+            "Ctrl+Shift+O"
+        );
+        assert_eq!(format_shortcut_hint_impl("Ctrl+w h", false), "Ctrl+W H");
+    }
+
+    #[test]
+    fn format_shortcut_hint_formats_arrow_keys_on_macos() {
+        assert_eq!(format_shortcut_hint_impl("ArrowDown", true), "↓");
+        assert_eq!(format_shortcut_hint_impl("Cmd+ArrowLeft", true), "⌘←");
+    }
+
+    #[test]
+    fn format_shortcut_hint_formats_arrow_keys_off_macos() {
+        assert_eq!(format_shortcut_hint_impl("ArrowDown", false), "Down");
+        assert_eq!(
+            format_shortcut_hint_impl("Cmd+ArrowLeft", false),
+            "Ctrl+Left"
+        );
+    }
+
+    #[test]
+    fn format_shortcut_hint_delegates_to_host_platform() {
+        // The public entry point must match the impl for the host's platform.
+        assert_eq!(
+            format_shortcut_hint("Cmd+Shift+o"),
+            format_shortcut_hint_impl("Cmd+Shift+o", cfg!(target_os = "macos"))
+        );
     }
 
     #[test]

--- a/desktop/src/keybindings/presets.rs
+++ b/desktop/src/keybindings/presets.rs
@@ -125,13 +125,25 @@ pub fn resolve_bindings(bindings: &BindingSet) -> Vec<ResolvedBinding> {
 
 impl BindingSet {
     /// Flatten into resolved bindings for engine consumption.
+    ///
+    /// Platforms with a native menu (macOS/Linux) let the OS dispatch menu
+    /// shortcuts, so they are excluded. Windows has no native menu, so the
+    /// engine must own them or they would have no dispatch path at all.
     pub fn into_resolved_bindings(self) -> Vec<ResolvedBinding> {
+        self.into_resolved_bindings_with(cfg!(target_os = "windows"))
+    }
+
+    /// Core of [`into_resolved_bindings`] with the menu-shortcut folding
+    /// decision passed explicitly, so both platform branches can be exercised
+    /// from a single-host test run.
+    pub(crate) fn into_resolved_bindings_with(
+        self,
+        fold_menu_shortcuts: bool,
+    ) -> Vec<ResolvedBinding> {
         let mut result = Vec::new();
-        // Platforms with a native menu (macOS/Linux) let the OS dispatch menu
-        // shortcuts, so they are excluded here. Windows has no native menu, so
-        // the engine must own them or they would have no dispatch path at all.
-        #[cfg(target_os = "windows")]
-        resolve_field(self.menu_shortcuts, None, &mut result);
+        if fold_menu_shortcuts {
+            resolve_field(self.menu_shortcuts, None, &mut result);
+        }
         resolve_field(self.global, None, &mut result);
         resolve_field(self.content, Some(KeyContext::Content), &mut result);
         resolve_field(self.sidebar, Some(KeyContext::Sidebar), &mut result);

--- a/desktop/src/shortcut.rs
+++ b/desktop/src/shortcut.rs
@@ -240,6 +240,33 @@ impl ShortcutSequence {
     }
 }
 
+/// Rewrite the primary accelerator modifier for the current platform.
+///
+/// Config presets express the primary accelerator with `Cmd`/`Meta`
+/// (`Modifiers::META`) for a native macOS feel. On Windows/Linux the physical
+/// primary modifier is Ctrl: a `KeyboardEvent` with `ctrlKey` set produces
+/// `Modifiers::CONTROL`, and native menu accelerators use Ctrl. Rewriting
+/// `META` → `CONTROL` when a config chord is parsed makes a physical Ctrl press
+/// (which reaches the engine as `CONTROL` via [`KeyChord::from_js_event`]) match
+/// a `Cmd`-defined binding, and makes native accelerators use Ctrl. A physical
+/// Super/Windows key still yields `META` at runtime, so it intentionally matches
+/// nothing. macOS is left untouched so `Cmd` stays `META`.
+fn normalize_primary_modifier(modifiers: Modifiers) -> Modifiers {
+    remap_primary_modifier(modifiers, cfg!(target_os = "macos"))
+}
+
+/// Platform-agnostic core of [`normalize_primary_modifier`], extracted so the
+/// remap can be unit-tested for both platforms from any host.
+///
+/// Only `META` is rewritten; `CONTROL`/`ALT`/`SHIFT` are preserved so
+/// intentionally Ctrl-based chords (e.g. vim/emacs) are never altered.
+fn remap_primary_modifier(modifiers: Modifiers, is_macos: bool) -> Modifiers {
+    if is_macos || !modifiers.contains(Modifiers::META) {
+        return modifiers;
+    }
+    (modifiers - Modifiers::META) | Modifiers::CONTROL
+}
+
 fn parse_chord(token: &str) -> Result<KeyChord, ShortcutParseError> {
     let mut modifiers = Modifiers::empty();
     let mut key_part: Option<&str> = None;
@@ -266,6 +293,7 @@ fn parse_chord(token: &str) -> Result<KeyChord, ShortcutParseError> {
 
     let key_part = key_part.ok_or(ShortcutParseError::MissingKey)?;
     let key = parse_key(key_part)?;
+    let modifiers = normalize_primary_modifier(modifiers);
 
     // Apply normalization: uppercase Character + no explicit SHIFT → add SHIFT
     Ok(KeyChord { key, modifiers }.normalize())
@@ -274,6 +302,13 @@ fn parse_chord(token: &str) -> Result<KeyChord, ShortcutParseError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Modifier a parsed `Cmd`/`Meta` chord resolves to on the host platform:
+    /// `META` on macOS, `CONTROL` elsewhere (see `normalize_primary_modifier`).
+    #[cfg(target_os = "macos")]
+    const PRIMARY: Modifiers = Modifiers::META;
+    #[cfg(not(target_os = "macos"))]
+    const PRIMARY: Modifiers = Modifiers::CONTROL;
 
     // --- parse_key tests ---
 
@@ -451,12 +486,14 @@ mod tests {
 
     #[test]
     fn parse_cmd_key() {
+        // `Cmd`/`Meta` resolves to the platform primary modifier: META on
+        // macOS, CONTROL on Windows/Linux.
         let seq = ShortcutSequence::from_str("Cmd+n").unwrap();
         assert_eq!(
             seq.chords,
             vec![KeyChord {
                 key: Key::Character("n".to_string()),
-                modifiers: Modifiers::META
+                modifiers: PRIMARY
             }]
         );
     }
@@ -486,9 +523,61 @@ mod tests {
             seq.chords,
             vec![KeyChord {
                 key: Key::Character("=".to_string()),
-                modifiers: Modifiers::META
+                modifiers: PRIMARY
             }]
         );
+    }
+
+    // --- Primary modifier remap (Cmd → Ctrl on non-macOS) ---
+
+    #[test]
+    fn remap_primary_modifier_maps_meta_to_control_off_macos() {
+        assert_eq!(
+            remap_primary_modifier(Modifiers::META, false),
+            Modifiers::CONTROL
+        );
+        assert_eq!(
+            remap_primary_modifier(Modifiers::META | Modifiers::SHIFT, false),
+            Modifiers::CONTROL | Modifiers::SHIFT
+        );
+    }
+
+    #[test]
+    fn remap_primary_modifier_keeps_meta_on_macos() {
+        assert_eq!(
+            remap_primary_modifier(Modifiers::META, true),
+            Modifiers::META
+        );
+        assert_eq!(
+            remap_primary_modifier(Modifiers::META | Modifiers::SHIFT, true),
+            Modifiers::META | Modifiers::SHIFT
+        );
+    }
+
+    #[test]
+    fn remap_primary_modifier_preserves_control_chords() {
+        // Intentionally Ctrl-based chords (vim/emacs) must never be altered.
+        assert_eq!(
+            remap_primary_modifier(Modifiers::CONTROL, false),
+            Modifiers::CONTROL
+        );
+        assert_eq!(
+            remap_primary_modifier(Modifiers::CONTROL | Modifiers::ALT, false),
+            Modifiers::CONTROL | Modifiers::ALT
+        );
+    }
+
+    #[test]
+    fn cmd_binding_matches_physical_ctrl_off_macos() {
+        // A `Cmd`-defined binding must compare equal to a physical Ctrl press
+        // (from_js_event with CONTROL bits) on Windows/Linux, and stay distinct
+        // on macOS where Cmd is META.
+        let binding = parse_chord("Cmd+o").unwrap();
+        let physical_ctrl = KeyChord::from_js_event("o", Modifiers::CONTROL.bits());
+        #[cfg(not(target_os = "macos"))]
+        assert_eq!(binding, physical_ctrl);
+        #[cfg(target_os = "macos")]
+        assert_ne!(binding, physical_ctrl);
     }
 
     #[test]

--- a/renderer/src/keyboard-interceptor.test.ts
+++ b/renderer/src/keyboard-interceptor.test.ts
@@ -1,0 +1,108 @@
+import { describe, test, expect } from "vitest";
+import { shouldSwallowReservedKey } from "./keyboard-interceptor";
+
+// ============================================================================
+// shouldSwallowReservedKey
+// ============================================================================
+
+const NONE: ReadonlySet<string> = new Set();
+
+/** Build a decision input with sensible defaults for the fields under test. */
+function decision(overrides: {
+  key: string;
+  isMac?: boolean;
+  ctrlKey?: boolean;
+  metaKey?: boolean;
+  altKey?: boolean;
+  boundPrimaryKeys?: ReadonlySet<string>;
+}) {
+  return {
+    key: overrides.key,
+    isMac: overrides.isMac ?? false,
+    ctrlKey: overrides.ctrlKey ?? false,
+    metaKey: overrides.metaKey ?? false,
+    altKey: overrides.altKey ?? false,
+    boundPrimaryKeys: overrides.boundPrimaryKeys ?? NONE,
+  };
+}
+
+describe("shouldSwallowReservedKey", () => {
+  test("macOS Cmd+C is reserved (native clipboard)", () => {
+    expect(shouldSwallowReservedKey(decision({ key: "c", isMac: true, metaKey: true }))).toBe(true);
+  });
+
+  test("non-mac Ctrl+C is reserved when unbound", () => {
+    expect(shouldSwallowReservedKey(decision({ key: "c", isMac: false, ctrlKey: true }))).toBe(
+      true,
+    );
+  });
+
+  test("non-mac Ctrl+X is NOT swallowed when bound by config", () => {
+    // Emacs binds the Ctrl+x prefix; the config override must let it through.
+    expect(
+      shouldSwallowReservedKey(
+        decision({
+          key: "x",
+          isMac: false,
+          ctrlKey: true,
+          boundPrimaryKeys: new Set(["x", "v", "c"]),
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  test("non-mac Ctrl+V (bound, later chord) is NOT swallowed", () => {
+    expect(
+      shouldSwallowReservedKey(
+        decision({
+          key: "v",
+          isMac: false,
+          ctrlKey: true,
+          boundPrimaryKeys: new Set(["v"]),
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  test("non-mac uppercase key is matched case-insensitively", () => {
+    expect(shouldSwallowReservedKey(decision({ key: "C", isMac: false, ctrlKey: true }))).toBe(
+      true,
+    );
+  });
+
+  test("Super/Windows key alone is never swallowed", () => {
+    // The Windows key reads as metaKey on non-mac (the secondary modifier).
+    expect(shouldSwallowReservedKey(decision({ key: "c", isMac: false, metaKey: true }))).toBe(
+      false,
+    );
+  });
+
+  test("non-mac Ctrl+Meta (secondary also held) is not swallowed", () => {
+    expect(
+      shouldSwallowReservedKey(decision({ key: "c", isMac: false, ctrlKey: true, metaKey: true })),
+    ).toBe(false);
+  });
+
+  test("primary+Alt is not swallowed (Alt escapes the reserved gate)", () => {
+    expect(
+      shouldSwallowReservedKey(decision({ key: "v", isMac: false, ctrlKey: true, altKey: true })),
+    ).toBe(false);
+  });
+
+  test("non-reserved primary+letter is not swallowed", () => {
+    expect(shouldSwallowReservedKey(decision({ key: "n", isMac: false, ctrlKey: true }))).toBe(
+      false,
+    );
+  });
+
+  test("reserved letter without the primary modifier is not swallowed", () => {
+    expect(shouldSwallowReservedKey(decision({ key: "c", isMac: false }))).toBe(false);
+  });
+
+  test("macOS Ctrl+C (secondary modifier on mac) is not swallowed", () => {
+    // On macOS the primary modifier is Cmd; a bare Ctrl press must pass through.
+    expect(shouldSwallowReservedKey(decision({ key: "c", isMac: true, ctrlKey: true }))).toBe(
+      false,
+    );
+  });
+});

--- a/renderer/src/keyboard-interceptor.ts
+++ b/renderer/src/keyboard-interceptor.ts
@@ -24,11 +24,64 @@ const META = 0x40;
 const SHIFT = 0x200;
 
 /**
- * Cmd+Key combinations reserved for native OS behavior.
- * These must not be intercepted so the system clipboard (Cmd+C/V/X),
- * select-all (Cmd+A), and app-quit (Cmd+Q) keep working normally.
+ * True when running on macOS, where the primary accelerator is Cmd (metaKey).
+ * On Windows/Linux the primary accelerator is Ctrl (ctrlKey). Detected from the
+ * WebView user agent, which reliably reports the host OS.
  */
-const RESERVED_OS_CMD_KEYS = new Set(["q", "c", "v", "x", "a"]);
+const IS_MAC = /Mac|iPhone|iPad|iPod/.test(navigator.userAgent);
+
+/**
+ * Primary-modifier + key combinations reserved for native OS behavior.
+ * These must not be intercepted so the system clipboard (C/V/X), select-all
+ * (A), and app-quit (Q) keep working normally. The primary modifier is Cmd on
+ * macOS and Ctrl on Windows/Linux (see {@link IS_MAC}).
+ *
+ * A reserved letter is only swallowed when the active keybinding config does
+ * NOT bind it as a bare primary+letter chord (see {@link boundPrimaryKeys}) —
+ * otherwise chords like the Emacs `Ctrl+x` prefix or `Ctrl+v` would never reach
+ * the engine.
+ */
+const RESERVED_OS_PRIMARY_KEYS = new Set(["q", "c", "v", "x", "a"]);
+
+/**
+ * Lowercased single letters the active config binds as a bare primary-modifier
+ * chord (Cmd+letter on macOS, Ctrl+letter on Windows/Linux), in any position of
+ * any sequence, in any context. Populated from Rust via
+ * {@link setReservedKeyOverrides}; these letters are excluded from reserved-key
+ * swallowing so bound chords reach the keybinding engine.
+ */
+let boundPrimaryKeys = new Set<string>();
+
+/** Inputs for {@link shouldSwallowReservedKey} (pure, host-independent). */
+export interface ReservedKeyDecision {
+  key: string;
+  isMac: boolean;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  altKey: boolean;
+  boundPrimaryKeys: ReadonlySet<string>;
+}
+
+/**
+ * Decide whether a keydown is an OS-reserved primary+letter chord that must be
+ * swallowed (not forwarded to the keybinding engine) to preserve native
+ * clipboard / select-all / quit behavior.
+ *
+ * The reserved gate is per-letter, so the config-aware override is per-letter
+ * too: a letter the config binds as a bare primary+letter chord is never
+ * swallowed. Only fires for exactly the primary modifier (no secondary/Alt);
+ * a Super/Windows key press reads as the secondary modifier off macOS and so is
+ * never swallowed.
+ */
+export function shouldSwallowReservedKey(input: ReservedKeyDecision): boolean {
+  const { key, isMac, ctrlKey, metaKey, altKey } = input;
+  const primaryPressed = isMac ? metaKey : ctrlKey;
+  const secondaryPressed = isMac ? ctrlKey : metaKey;
+  if (!primaryPressed || secondaryPressed || altKey) return false;
+  const baseKey = key.toLowerCase();
+  if (!RESERVED_OS_PRIMARY_KEYS.has(baseKey)) return false;
+  return !input.boundPrimaryKeys.has(baseKey);
+}
 
 /**
  * Chords that are bound as native menu accelerators (canonical form
@@ -100,11 +153,20 @@ function handleKeydown(e: KeyboardEvent): void {
     return;
   }
 
-  // Skip OS-reserved shortcuts (Cmd+Q/C/V/X/A) — handled by PredefinedMenuItem.
-  // All other Cmd+Key combos are processed by the keybinding engine.
-  if (e.metaKey && !e.ctrlKey && !e.altKey) {
-    const baseKey = key.toLowerCase();
-    if (RESERVED_OS_CMD_KEYS.has(baseKey)) return;
+  // Skip OS-reserved shortcuts (primary+Q/C/V/X/A) unless the config binds
+  // them — handled natively. All other primary+Key combos are processed by the
+  // keybinding engine. The primary modifier is Cmd on macOS and Ctrl elsewhere.
+  if (
+    shouldSwallowReservedKey({
+      key,
+      isMac: IS_MAC,
+      ctrlKey: e.ctrlKey,
+      metaKey: e.metaKey,
+      altKey: e.altKey,
+      boundPrimaryKeys,
+    })
+  ) {
+    return;
   }
 
   const modifiers = buildModifiers(e);
@@ -145,6 +207,18 @@ export function onKeydown(callback: KeydownCallback): void {
  */
 export function setMenuAccelerators(chords: string[]): void {
   menuAccelerators = new Set(chords);
+}
+
+/**
+ * Replace the set of letters the active config binds as a bare primary-modifier
+ * chord, excluding them from OS-reserved swallowing (see
+ * {@link shouldSwallowReservedKey}).
+ *
+ * Called from Rust whenever the keybinding config changes. Each entry is a
+ * single lowercase letter produced by `reserved_key_overrides` on the Rust side.
+ */
+export function setReservedKeyOverrides(keys: string[]): void {
+  boundPrimaryKeys = new Set(keys.map((k) => k.toLowerCase()));
 }
 
 /** Pause interceptor (e.g., during key recording in Preferences). */

--- a/renderer/src/main.ts
+++ b/renderer/src/main.ts
@@ -64,6 +64,7 @@ declare global {
         pause: typeof keyboardInterceptor.pause;
         resume: typeof keyboardInterceptor.resume;
         setMenuAccelerators: typeof keyboardInterceptor.setMenuAccelerators;
+        setReservedKeyOverrides: typeof keyboardInterceptor.setReservedKeyOverrides;
       };
       scroll: {
         scrollDown: typeof scrollController.scrollDown;
@@ -280,6 +281,7 @@ export function init(): void {
       pause: keyboardInterceptor.pause,
       resume: keyboardInterceptor.resume,
       setMenuAccelerators: keyboardInterceptor.setMenuAccelerators,
+      setReservedKeyOverrides: keyboardInterceptor.setReservedKeyOverrides,
     },
     scroll: {
       scrollDown: scrollController.scrollDown,


### PR DESCRIPTION
## Summary

Makes keybindings and shortcut hints work correctly on Windows and Linux. Supersedes the earlier closed PRs #158 / #160; this is a focused reimplementation with the primary-modifier logic normalized at a single choke point plus test coverage that runs on the macOS-only CI. Relates to #17.

## Problem

Default presets and hints were hardcoded to macOS `Cmd` (`⌘⇧⌥`), so on Windows/Linux the bindings required the physical Super/Windows key and hints showed macOS symbols. The WebView2 keyboard bridge could also exceed its init timeout on cold start, silently disabling in-window shortcuts.

## Changes

- **Primary-modifier normalization**: `normalize_primary_modifier` rewrites `Cmd`/`Meta` → `Ctrl` at parse time on non-macOS (`shortcut.rs`), covering both the engine-match and native-accelerator paths from one place. A physical Super/Win key stays `META` and intentionally matches nothing.
- **Platform-native hints**: `hint.rs` renders symbols on macOS and text (`Ctrl+Shift+O`) elsewhere.
- **Init timeout**: raised via a shared constant to tolerate WebView2 cold start.
- **OS-reserved key gate**: the JS interceptor previously swallowed plain `Ctrl+{q,c,v,x,a}` on non-macOS before the engine ran, which would break preset bindings such as the Emacs `C-x` prefix and `Ctrl+v`. Rust now pushes the set of primary+letter chords the active config binds (mirroring the menu-accelerator push, but on every platform) and the interceptor only reserves letters that are **not** bound — native clipboard stays reserved for the default preset.

## Testing notes

Windows is not in CI. Platform-dependent logic is parameterized by a runtime `is_macos: bool` (mirroring `remap_primary_modifier`) so both branches are asserted from the macOS `cargo test` run, and the new pure JS decision (`shouldSwallowReservedKey`) is covered by a new `keyboard-interceptor.test.ts`.

## Test plan

- [x] `just fmt check test` passes (521 Rust + 6 doc + 69 vitest tests, incl. 11 new interceptor tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
