### PR TITLE
ci: add Windows CI and fix Windows-only check/test failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,17 @@ jobs:
           node-version: 24
       # pnpm is pinned via the renderer's packageManager field.
       - run: corepack enable
-      - uses: extractions/setup-just@v3
+      # Installed from the upstream release rather than extractions/setup-just,
+      # which has no windows-aarch64 binary. just itself ships both arches.
+      - name: Install just
+        shell: pwsh
+        run: |
+          $ver = '1.57.0'
+          $arch = if ($env:RUNNER_ARCH -eq 'ARM64') { 'aarch64' } else { 'x86_64' }
+          $url = "https://github.com/casey/just/releases/download/$ver/just-$ver-$arch-pc-windows-msvc.zip"
+          Invoke-WebRequest $url -OutFile "$env:RUNNER_TEMP\just.zip"
+          Expand-Archive "$env:RUNNER_TEMP\just.zip" -DestinationPath "$env:RUNNER_TEMP\just"
+          "$env:RUNNER_TEMP\just" | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
       - uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,6 +73,56 @@ jobs:
           exit 1
     timeout-minutes: 30
 
+  # Windows cannot use the Nix devShell the other jobs rely on, so this job
+  # installs the toolchain natively. It exists because Windows-only code paths
+  # (the cfg(windows) named-pipe IPC, the hamburger menu, engine-owned menu
+  # shortcuts) are invisible to the macOS and Linux legs and have already
+  # regressed unnoticed.
+  check-windows:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: windows
+            os: windows-latest
+          - target: windows-arm64
+            os: windows-11-arm
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      # `ring` (arto -> ureq -> rustls) assembles its primitives from source and
+      # needs a different assembler per target: nasm on x86_64, clang on
+      # aarch64. Neither is guaranteed to be present on the runner image.
+      - uses: ilammy/setup-nasm@v1
+        if: matrix.target == 'windows'
+      - name: Install LLVM (clang, required by ring on aarch64)
+        if: matrix.target == 'windows-arm64'
+        run: choco install llvm --no-progress -y
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      # pnpm is pinned via the renderer's packageManager field.
+      - run: corepack enable
+      - uses: extractions/setup-just@v3
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            desktop/target
+          key: cargo-check-${{ matrix.target }}-${{ hashFiles('desktop/Cargo.lock') }}
+          restore-keys: cargo-check-${{ matrix.target }}-
+      # `just fmt` is deliberately omitted: oxfmt rewrites renderer CSS that is
+      # not oxfmt-clean as committed, and git's LF->CRLF conversion makes
+      # `git diff --exit-code` fail here for reasons unrelated to the change.
+      # Formatting stays gated by the macOS check job.
+      - run: just check
+      - run: just test
+    timeout-minutes: 45
+
   build:
     needs: ["check", "test"]
     runs-on: ${{ matrix.os }}

--- a/desktop/src/keybindings/accelerator.rs
+++ b/desktop/src/keybindings/accelerator.rs
@@ -37,6 +37,11 @@ pub fn accelerator_for_key(key: &str) -> Option<Accelerator> {
 ///
 /// Returns `None` unless the key is a single chord that maps to a physical
 /// code — only those are OS-dispatched and would otherwise double-fire.
+///
+/// Only reachable where the JS interceptor needs the skip list; Windows has no
+/// native menu bar, so the caller is compiled out there and the lib target would
+/// otherwise trip `dead_code`. Tests still exercise it on every platform.
+#[cfg_attr(target_os = "windows", allow(dead_code))]
 pub fn menu_accelerator_skip_key(key: &str) -> Option<String> {
     let sequence: ShortcutSequence = key.parse().ok()?;
     let [chord] = sequence.chords.as_slice() else {
@@ -53,6 +58,10 @@ pub fn menu_accelerator_skip_key(key: &str) -> Option<String> {
 /// action actually maps to a menu item are included — a shortcut bound to a
 /// non-menu action attaches to no menu item, so skipping it would leave the
 /// chord dead.
+///
+/// See [`menu_accelerator_skip_key`] for why this is exempt from `dead_code` on
+/// Windows.
+#[cfg_attr(target_os = "windows", allow(dead_code))]
 pub fn menu_accelerator_skip_keys(bindings: &BindingSet) -> Vec<String> {
     bindings
         .menu_shortcuts

--- a/desktop/src/keybindings/action.rs
+++ b/desktop/src/keybindings/action.rs
@@ -321,6 +321,11 @@ pub const MENU_ACTIONS: &[Action] = &[
 ];
 
 /// Whether an action string corresponds to a menu item (native-menu eligible).
+///
+/// Reached only through the menu-accelerator skip list, which Windows compiles
+/// out (no native menu bar), so the lib target would otherwise trip `dead_code`.
+/// Tests still exercise it on every platform.
+#[cfg_attr(target_os = "windows", allow(dead_code))]
 pub fn is_menu_action(action: &str) -> bool {
     Action::from_str(action)
         .map(|a| MENU_ACTIONS.contains(&a))


### PR DESCRIPTION
## Why

Windows is already a real target in-tree — `cfg(windows)` named-pipe IPC in `desktop/src/ipc/socket.rs`, a Windows-only `win_hamburger.rs`, and a `[windows]` recipe in `desktop/justfile` — but CI only ever ran macOS and Linux. As a result `just check test` had been broken on Windows without anyone noticing.

Both failures below were found by actually running `just check test` on a Windows 11 ARM64 machine against `main`.

## What

### 1. `fix(windows)`: unbreak `just check test`

**`dead_code` made `check` fail outright.** `menu_accelerator_skip_key`, `menu_accelerator_skip_keys` and `is_menu_action` are reachable only through `push_menu_accelerators_to_js`, which is `cfg(not(target_os = "windows"))`. On Windows the lib target sees all three as unreachable, and `-D warnings` promotes `dead_code` to a hard error. They are exempted on Windows rather than `cfg`-ed out, so the tests covering them keep compiling on every platform.

**One test encoded a macOS/Linux assumption.** `menu_shortcut_not_matched_by_engine` asserted `NoMatch` for `Cmd+n`, but `BindingSet::into_resolved_bindings` deliberately resolves `menu_shortcuts` into the engine on Windows — with no native menu bar, the engine must own them or they would have no dispatch path at all. `Matched(WindowNew)` is the correct Windows result, so the assertion is now platform-dependent.

### 2. `ci(windows)`: add a Windows check/test job

Covers both `windows-latest` and `windows-11-arm`, mirroring the existing `ubuntu`/`ubuntu-arm64` split.

Windows cannot use the Nix devShell the other jobs rely on, so the job installs the toolchain natively. `ring` (via `ureq` to `rustls`) assembles from source and needs a different assembler per target — nasm on x86_64, clang on aarch64 — which is why the two legs differ in setup.

Deliberate choices, both explained in comments:
- **`just fmt` is omitted.** oxfmt rewrites renderer CSS that is not oxfmt-clean as committed, and git's LF to CRLF conversion would make `git diff --exit-code` fail for unrelated reasons. Formatting stays gated by the macOS job.
- **Not wired into `build`'s `needs`,** so a Windows failure cannot block a macOS release.

## Verification

`just check test` on Windows 11 ARM64 (rustc 1.97.1, `aarch64-pc-windows-msvc`):

- clippy `-D warnings` + oxlint: clean
- 504 Rust unit tests, 6 doc-tests, 58 renderer tests — all passing

The CI job itself is unverified until this PR runs it; the assembler steps in particular are a best guess at what the runner images provide.

## Follow-ups (not in this PR)

- `desktop/justfile`'s `[windows] build` uses `cargo build --release`, which produces `arto.exe` with **no `assets/` directory at all** — the six `asset!()` files are never collected, so the app would run with no CSS/JS/icons. macOS and Linux both use `dx bundle`. Windows likely needs `dx build` too.
- Relaunching while an instance is running does nothing on Windows: `wake_main_thread()` is a no-op on non-macOS, so with a hidden window the queued reopen event is never processed and the process becomes an invisible zombie that swallows every subsequent launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)