### PR TITLE
fix(macos): ship Quick Look extension + correct app bundle metadata in the release DMG

### DIFF
--- a/desktop/justfile
+++ b/desktop/justfile
@@ -24,11 +24,18 @@ verify: fmt check test
 clean:
   cargo clean
 
+# The DMG is built AFTER the Quick Look extension is embedded, not by `dx
+# bundle` directly. `dx bundle --package-types dmg` seals the DMG from the app
+# during the same invocation, before `_embed-quicklook` mutates the app — so a
+# DMG produced that way never contains the extension (only a local `just
+# install`, which copies the mutated .app, would). Bundle the bare .app first,
+# embed the extension into it, then package the DMG from the embedded app.
 [macos]
 build:
   @rm -rf target/dx/arto/release/macos/Arto.app/Contents/Resources/assets
-  dx bundle --release --macos --package-types dmg
+  dx bundle --release --macos --package-types macos
   just _embed-quicklook
+  just _package-dmg
 
 # Build the Quick Look preview extension (Swift shim + Rust `arto_ql` static
 # library) and embed it at Contents/PlugIns/ArtoQuickLook.appex so macOS
@@ -69,6 +76,46 @@ _embed-quicklook:
     "$appex"
   codesign --force --sign - --timestamp=none "$app"
   echo "Quick Look preview extension embedded at Contents/PlugIns/ArtoQuickLook.appex"
+
+# Package the (already extension-embedded and signed) app bundle into a
+# compressed DMG. This replaces `dx bundle --package-types dmg` so the DMG is
+# built from the mutated app rather than sealed before `_embed-quicklook` runs.
+# The output path and filename mirror what `dx bundle` produced
+# (`bundle/macos/macos/Arto_<version>_<arch>.dmg`) so the CI upload glob
+# (`bundle/**/*.dmg`) and the Homebrew asset name (`Arto_<version>_aarch64.dmg`)
+# keep matching. `dx` names the arch `aarch64`, not `uname -m`'s `arm64`.
+#
+# Every stale DMG under the bundle dir is removed first: CI caches
+# `desktop/target` (which contains `bundle/`) and the `build` job also runs on
+# non-release pushes, where the version stays `0.0.0`. Without this sweep a
+# cached `Arto_0.0.0_...dmg` would be restored on a later release build and the
+# `bundle/**/*.dmg` upload glob would attach it alongside the real release DMG.
+[macos]
+[private]
+_package-dmg:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  app="target/dx/arto/release/macos/Arto.app"
+  version="$(perl -ne 'print $1 and exit if /^version = "(.*)"/' Cargo.toml)"
+  case "$(uname -m)" in
+    arm64 | aarch64) arch="aarch64" ;;
+    x86_64) arch="x86_64" ;;
+    *) arch="$(uname -m)" ;;
+  esac
+  bundle="target/dx/arto/bundle"
+  outdir="$bundle/macos/macos"
+  dmg="$outdir/Arto_${version}_${arch}.dmg"
+  mkdir -p "$outdir"
+  # Drop any stale DMG (including wrong-version ones from a restored cache) so
+  # the release upload glob only ever sees the one we build here.
+  find "$bundle" -type f -name '*.dmg' -delete
+  staging="$(mktemp -d)"
+  # `ditto` preserves the code signature and the nested extension bundle.
+  ditto "$app" "$staging/Arto.app"
+  ln -s /Applications "$staging/Applications"
+  hdiutil create -volname "Arto" -srcfolder "$staging" -format UDZO -ov "$dmg"
+  rm -rf "$staging"
+  echo "DMG with embedded Quick Look extension created at $dmg"
 
 [linux]
 build:

--- a/desktop/justfile
+++ b/desktop/justfile
@@ -34,8 +34,31 @@ clean:
 build:
   @rm -rf target/dx/arto/release/macos/Arto.app/Contents/Resources/assets
   dx bundle --release --macos --package-types macos
+  just _apply-bundle-metadata
   just _embed-quicklook
   just _package-dmg
+
+# Deterministically install the canonical Info.plist and app icon, and stamp the
+# version from Cargo.toml. The dx toolchain does not reliably apply the
+# `[bundle]` icon or `[bundle.macos] info_plist_path` from Dioxus.toml — a clean
+# build otherwise ships an app with NO `.md`/`.txt` Finder associations, a
+# missing icon, and a version that ignores the release tag. This runs before
+# `_embed-quicklook`, whose final re-sign seals these edits.
+[macos]
+[private]
+_apply-bundle-metadata:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  app="target/dx/arto/release/macos/Arto.app"
+  version="$(perl -ne 'print $1 and exit if /^version = "(.*)"/' Cargo.toml)"
+  # Canonical Info.plist carries the file-type associations and high-DPI flag.
+  cp ../extras/mac/Info.plist "$app/Contents/Info.plist"
+  # Stamp the real version (CI patches Cargo.toml for releases; local stays 0.0.0).
+  /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${version}" \
+    "$app/Contents/Info.plist"
+  # The plist references CFBundleIconFile = Arto → the bundle needs Arto.icns.
+  cp ../extras/mac/Arto.icns "$app/Contents/Resources/Arto.icns"
+  echo "Applied canonical Info.plist (version ${version}) and app icon"
 
 # Build the Quick Look preview extension (Swift shim + Rust `arto_ql` static
 # library) and embed it at Contents/PlugIns/ArtoQuickLook.appex so macOS

--- a/extras/mac/Info.plist
+++ b/extras/mac/Info.plist
@@ -10,7 +10,9 @@
   <key>CFBundleName</key><string>Arto</string>
   <key>CFBundleIconFile</key><string>Arto</string>
   <key>CFBundlePackageType</key><string>APPL</string>
-  <key>CFBundleShortVersionString</key><string>0.1.0</string>
+  <!-- Placeholder; the real version is stamped from Cargo.toml at bundle time
+       (see the `_apply-bundle-metadata` recipe in desktop/justfile). -->
+  <key>CFBundleShortVersionString</key><string>0.0.0</string>
   <key>CFBundleVersion</key><string>1</string>
   <key>NSHighResolutionCapable</key><true/>
   <key>CFBundleDocumentTypes</key>


### PR DESCRIPTION
Two related macOS packaging fixes for the release DMG. Both live in `desktop/justfile` and flow into CI automatically (the release job runs `nix develop -c just build`).

## 1. Quick Look extension missing from the DMG

The v0.30.0 DMG (and the Homebrew cask) shipped **without** the Quick Look preview extension — pressing Space on a `.md` file still showed raw Markdown.

**Root cause:** the recipe ran `dx bundle --package-types dmg` (which builds *and* seals the DMG in one invocation) and only *then* ran `_embed-quicklook`, which mutates `release/macos/Arto.app`. The DMG was already sealed, so `ArtoQuickLook.appex` never made it in. Only a local `just install` (which copies the mutated `.app`) picked it up — which is why it looked fine in local testing. Confirmed directly: the installed v0.30.0 app has no `Contents/PlugIns/`.

**Fix:** reorder so the DMG is packaged *after* the extension is embedded:

1. `dx bundle --package-types macos` — the bare `.app` only
2. `_embed-quicklook` — embed + inside-out re-sign (unchanged)
3. `_package-dmg` — package the DMG from the embedded app

`_package-dmg` mirrors dx's original output (`bundle/macos/macos/Arto_<version>_aarch64.dmg`) so the CI upload glob (`bundle/**/*.dmg`) and the Homebrew asset name keep matching, and it sweeps stale `*.dmg` first (the `build` job also runs on non-release pushes with version `0.0.0`, and CI caches `desktop/target`).

## 2. App bundle metadata: missing associations, icon, and wrong version

Investigating the above surfaced a second issue: a clean build produces an app whose `Info.plist` comes from **dx's generated defaults**, not `extras/mac/Info.plist`. That drops the `.md`/`.txt` Finder associations and the high-DPI flag, leaves the icon missing, and stamps a version that ignores the release tag (shipped v0.30.0 read `0.1.0`). dx does not reliably apply `[bundle] icon` / `[bundle.macos] info_plist_path` across the toolchain.

**Fix:** a new `_apply-bundle-metadata` recipe (run before `_embed-quicklook` so the final re-sign seals it) deterministically installs `extras/mac/Info.plist` + `Arto.icns` and stamps `CFBundleShortVersionString` from `Cargo.toml` (which CI patches per release). The plist's version is set to a `0.0.0` placeholder to match `Cargo.toml`.

## Verification

Full local release build (`just build`), then mounted the produced DMG:

- ✅ `Arto.app/Contents/PlugIns/ArtoQuickLook.appex` present in the DMG
- ✅ `Contents/Resources/Arto.icns` present; `CFBundleIconFile = Arto`
- ✅ `CFBundleShortVersionString` stamped from Cargo.toml
- ✅ `CFBundleDocumentTypes` restored (Plain Text `txt`, Markdown `md` / `net.daringfireball.markdown`)
- ✅ `codesign --verify --deep` → valid on disk / satisfies Designated Requirement
- ✅ exactly one DMG under `bundle/`, at the canonical `bundle/macos/macos/` path

## Notes

- This changes only how the DMG is built. The existing v0.30.0 install stays broken until the next release (or a local `just install`).
- The extension's actual rendering (Space → styled HTML) has not been re-exercised in this PR; the checks above confirm it is present, signed, and entitled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)