### PR TITLE
fix(macos): make the Quick Look Markdown preview load and scroll

### DIFF
--- a/ql-extension/ArtoQuickLook.entitlements
+++ b/ql-extension/ArtoQuickLook.entitlements
@@ -4,5 +4,16 @@
 <dict>
     <key>com.apple.security.app-sandbox</key><true/>
     <key>com.apple.security.files.user-selected.read-only</key><true/>
+    <!--
+      Required for WKWebView to stand up its helper processes (GPU, Networking,
+      WebContent). Without this entitlement those processes abort with
+      "Application does not have permission to communicate with network
+      resources", the WebView never finishes loading, and the Quick Look
+      preview spins forever. This grants no network access to the previewed
+      content itself: the rendered page carries a Content-Security-Policy with
+      `default-src 'none'; connect-src 'none'`, so untrusted Markdown still
+      cannot reach the network.
+    -->
+    <key>com.apple.security.network.client</key><true/>
 </dict>
 </plist>

--- a/ql-extension/PreviewViewController.swift
+++ b/ql-extension/PreviewViewController.swift
@@ -16,6 +16,12 @@ final class ArtoPreviewViewController: NSViewController, QLPreviewingController,
 
     override func loadView() {
         let configuration = WKWebViewConfiguration()
+        // Use an ephemeral (in-memory) data store. The default persistent store
+        // makes WKWebView probe an on-disk storage directory during init, which
+        // the extension's sandbox denies — leaving the WebView unable to load
+        // and the Quick Look preview stuck spinning forever. An untrusted
+        // preview also has no reason to persist cookies/cache/localStorage.
+        configuration.websiteDataStore = .nonPersistent()
         configuration.defaultWebpagePreferences.allowsContentJavaScript = true
         webView = WKWebView(frame: .zero, configuration: configuration)
         webView.navigationDelegate = self

--- a/ql-generator/src/lib.rs
+++ b/ql-generator/src/lib.rs
@@ -32,6 +32,15 @@ use std::ptr;
 /// The renderer stylesheet, embedded at compile time.
 const RENDERER_CSS: &str = include_str!("../../desktop/assets/dist/main.css");
 
+/// Quick Look-specific style overrides, applied after [`RENDERER_CSS`].
+///
+/// The shared renderer stylesheet sets `body { overflow: hidden }` because the
+/// app scrolls inside an inner `.content` container. The Quick Look document
+/// has no such container, so inheriting that rule clips long documents and
+/// leaves the preview unscrollable. Restore natural document scrolling for the
+/// standalone preview page.
+const QL_OVERRIDE_CSS: &str = "html,body{overflow:auto!important;height:auto!important;}";
+
 /// The renderer bundle (IIFE build exposing `window.ArtoRenderer`), embedded
 /// at compile time.
 const RENDERER_JS: &str = include_str!("../../desktop/assets/dist/main.iife.js");
@@ -201,7 +210,8 @@ fn build_document(body_html: &str) -> String {
         r#"<!DOCTYPE html><html><head><meta charset="utf-8">
 <meta http-equiv="Content-Security-Policy" content="{csp}">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<style>{css}</style></head>
+<style>{css}</style>
+<style>{ql_override}</style></head>
 <body data-theme="light">
 <div class="markdown-viewer"><article class="markdown-body">{body}</article></div>
 <script>{bundle}</script>
@@ -209,6 +219,7 @@ fn build_document(body_html: &str) -> String {
 </body></html>"#,
         csp = csp,
         css = RENDERER_CSS,
+        ql_override = QL_OVERRIDE_CSS,
         body = body_html,
         bundle = bundle,
         bootstrap = BOOTSTRAP_JS,
@@ -233,6 +244,11 @@ mod tests {
         // Styles and scripts are inlined.
         assert!(html.contains("<style>"));
         assert!(html.contains("</style>"));
+        // The Quick Look document has no inner `.content` scroll container, so
+        // the shared `body { overflow: hidden }` must be overridden or the
+        // preview cannot scroll long documents.
+        assert!(html.contains(QL_OVERRIDE_CSS));
+        assert!(html.contains("overflow:auto"));
         assert!(html.contains("<script>"));
         assert!(html.contains("</script>"));
         // Theme defaults are present.


### PR DESCRIPTION
## Summary

Two fixes for the Markdown Quick Look preview extension, both confirmed end-to-end against the real shipping artifacts (real Swift shim + `arto_ql` static lib, signed with these entitlements, driven via `qlmanage` + the unified log).

### 1. Preview spun forever (infinite loading)

`WKWebView` could not finish loading inside the sandboxed preview extension, so the `didFinish` navigation callback that signals Quick Look completion never fired. Two independent sandbox constraints, both required:

- **`com.apple.security.network.client` entitlement** — WKWebView's helper processes (GPU, Networking, WebContent) abort at launch (`Application does not have permission to communicate with network resources`, GPU process `reason=Crash`) without it, even though the previewed content needs no network. The page's CSP (`default-src 'none'; connect-src 'none'`) still keeps untrusted Markdown off the network.
- **`.nonPersistent()` data store** — the default persistent store makes WKWebView probe an on-disk storage directory the sandbox denies (`defaultGeneralStorageDirectory` → `contentsOfDirectory`). A non-persistent store also suits an ephemeral, untrusted preview (no persisted cookies/cache).

With both applied, the log shows `WebPageProxy::didFinishLoadForFrame … isMainFrame=1` and no GPU crash.

### 2. Long documents could not scroll

The shared renderer stylesheet sets `body { overflow: hidden }` because the app scrolls inside an inner `.content` container. The Quick Look document has no such container, so it inherited the hidden overflow and clipped everything past the first viewport. Fixed by injecting a Quick Look-only override (`html,body{overflow:auto!important;height:auto!important;}`) after the shared CSS, leaving the app's stylesheet untouched.

## Verification

- Real `PreviewViewController.swift` + real `arto_ql` compiled/linked and signed with the branch entitlements; `qlmanage` on a 200-section document → `didFinishLoadForFrame` fires, no crash.
- The real `arto_ql` library output for a tall document contains the scroll override and all content.
- `ql-generator`: `cargo test` (5 passed), `cargo fmt --check`, `cargo clippy -D warnings` all clean.
- Final appex binary `minos 12.0` (the `ld` deployment-target warnings from the Rust static archive are cosmetic; they do not affect the linked binary's minimum OS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)