### PR TITLE
docs(readme): document Quick Look registration troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,17 @@ brew install --cask arto-app/tap/arto
 xattr -dr com.apple.quarantine /Applications/Arto.app
 ```
 
+> [!TIP]
+> **Quick Look preview not showing?** macOS normally registers the Quick Look
+> extension the first time you launch Arto. If pressing Space on a Markdown file
+> still shows no preview — or a stale one right after an upgrade — register the
+> extension manually and refresh the cache:
+>
+> ```sh
+> pluginkit -a /Applications/Arto.app/Contents/PlugIns/ArtoQuickLook.appex
+> qlmanage -r && qlmanage -r cache
+> ```
+
 Alternatively, [Nix] is also supported.
 To try it without a permanent installation:
 


### PR DESCRIPTION
## Why

The v0.31.1 sandbox fix (#202) reaches users' disks correctly — the embedded
`ArtoQuickLook.appex` carries the `network.client` entitlement and non-persistent
data store. But the preview can still fail to appear because macOS does not always
**register** the Quick Look extension after install: when the app is still
quarantined at first launch (unsigned/ad-hoc build), PluginKit lists no match and
Space renders no preview — indistinguishable from the old "doesn't load" symptom.

Removing the quarantine alone does not register the extension; the app must be
launched, or the extension registered explicitly.

## What

Add a `> [!TIP]` troubleshooting note under Installation showing the manual
recovery steps (verified on macOS 26.5):

```sh
pluginkit -a /Applications/Arto.app/Contents/PlugIns/ArtoQuickLook.appex
qlmanage -r && qlmanage -r cache
```

Framed as troubleshooting, not a required step — normal launch auto-registers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)