### PR TITLE
Build release artifacts free of the Nix build environment

### DIFF
--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -1,12 +1,22 @@
 name: "Set up build toolchain"
 description: >
-  Provision the Rust/dioxus/node toolchain for a build matrix leg. macOS and
-  Linux run through the Nix devShell (so the toolchain matches local
-  development); Windows cannot run Nix and installs the toolchain natively.
-  The nix-vs-native branch lives here once instead of being duplicated across
-  the check/test/build jobs.
+  Provision the Rust/dioxus/node toolchain for a matrix leg. Two flavours: the
+  Nix devShell (so checks and tests run the same toolchain as local
+  development), and the platform's native toolchain (so binaries published to a
+  release link against the platform's own libraries, not the Nix store).
+  Windows has no Nix and is always native. The flavour branch lives here once
+  instead of being duplicated across the check/test/build jobs.
 
 inputs:
+  toolchain:
+    description: >
+      "nix" for the devShell, "native" for the platform toolchain. Release
+      artifacts must be built with "native": a devShell build bakes absolute
+      /nix/store paths into the binary (the ELF interpreter and RUNPATH on
+      Linux, the libiconv install name on macOS), which no machine without
+      that store can resolve. Ignored on Windows, which is always native.
+    required: false
+    default: "nix"
   cachix-auth-token:
     description: "Cachix auth token. Cachix is skipped on pull requests regardless."
     required: false
@@ -17,24 +27,38 @@ runs:
   steps:
     # --- Nix toolchain (macOS + Linux) ---
     # https://zenn.dev/mierune/articles/2af7b9e447712a
-    - if: runner.os != 'Windows'
+    - if: inputs.toolchain == 'nix' && runner.os != 'Windows'
       uses: chetan/git-restore-mtime-action@v2
-    - if: runner.os != 'Windows'
+    - if: inputs.toolchain == 'nix' && runner.os != 'Windows'
       uses: nixbuild/nix-quick-install-action@v35
-    - if: runner.os != 'Windows' && github.event_name != 'pull_request'
+    - if: inputs.toolchain == 'nix' && runner.os != 'Windows' && github.event_name != 'pull_request'
       uses: cachix/cachix-action@v17
       with:
         name: arto
         authToken: ${{ inputs.cachix-auth-token }}
 
-    # --- Native toolchain (Windows) ---
+    # --- Native toolchain (every platform) ---
     # Windows-only code paths (the cfg(windows) named-pipe IPC, the hamburger
     # menu, engine-owned menu shortcuts) are invisible to the macOS/Linux legs
-    # and have regressed unnoticed before, so Windows builds natively here.
-    - if: runner.os == 'Windows'
+    # and have regressed unnoticed before, so Windows always builds natively.
+    - if: inputs.toolchain == 'native' || runner.os == 'Windows'
       uses: dtolnay/rust-toolchain@stable
       with:
         components: clippy
+    # The GTK/WebKit stack wry links against. The devShell provides these
+    # through nixpkgs, so only native Linux builds need the distro packages.
+    - name: Install GTK/WebKit development packages (Linux)
+      if: inputs.toolchain == 'native' && runner.os == 'Linux'
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install --no-install-recommends -y \
+          libwebkit2gtk-4.1-dev \
+          libgtk-3-dev \
+          libsoup-3.0-dev \
+          libssl-dev \
+          libxdo-dev \
+          pkg-config
     # `ring` (arto -> ureq -> rustls) assembles its primitives from source and
     # needs a different assembler per arch: nasm on x86_64, clang on aarch64.
     # Installed via choco (not the setup-nasm action, which still targets the
@@ -49,17 +73,38 @@ runs:
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       shell: pwsh
       run: choco install llvm --no-progress -y
-    - if: runner.os == 'Windows'
+    - if: inputs.toolchain == 'native' || runner.os == 'Windows'
       uses: actions/setup-node@v7
       with:
         node-version: 24
     # pnpm is pinned via the renderer's packageManager field.
-    - if: runner.os == 'Windows'
+    - name: Enable corepack (Unix)
+      if: inputs.toolchain == 'native' && runner.os != 'Windows'
+      shell: bash
+      run: corepack enable
+    - name: Enable corepack (Windows)
+      if: runner.os == 'Windows'
       shell: pwsh
       run: corepack enable
     # Installed from the upstream release rather than extractions/setup-just,
-    # which has no windows-aarch64 binary. just itself ships both arches.
-    - name: Install just
+    # which has no windows-aarch64 binary. just itself ships every arch we use.
+    - name: Install just (Unix)
+      if: inputs.toolchain == 'native' && runner.os != 'Windows'
+      shell: bash
+      run: |
+        ver='1.57.0'
+        case "$RUNNER_OS-$RUNNER_ARCH" in
+          macOS-ARM64) triple='aarch64-apple-darwin' ;;
+          macOS-X64) triple='x86_64-apple-darwin' ;;
+          Linux-ARM64) triple='aarch64-unknown-linux-musl' ;;
+          Linux-X64) triple='x86_64-unknown-linux-musl' ;;
+          *) echo "Unsupported runner: $RUNNER_OS-$RUNNER_ARCH" >&2; exit 1 ;;
+        esac
+        url="https://github.com/casey/just/releases/download/${ver}/just-${ver}-${triple}.tar.gz"
+        mkdir -p "$RUNNER_TEMP/just"
+        curl -fsSL "$url" | tar -xz -C "$RUNNER_TEMP/just" just
+        echo "$RUNNER_TEMP/just" >> "$GITHUB_PATH"
+    - name: Install just (Windows)
       if: runner.os == 'Windows'
       shell: pwsh
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,8 +124,10 @@ jobs:
           - target: macos
             os: macos-latest
             artifacts: ./desktop/target/dx/arto/bundle/**/*.dmg
-            # macOS builds have historically finished within 30m.
-            timeout: 30
+            # The devShell used to supply a prebuilt `dx`; building natively
+            # adds a ~10m `cargo install dioxus-cli` whenever the cache misses,
+            # which no longer fits the old 30m budget.
+            timeout: 60
           - target: ubuntu
             os: ubuntu-latest
             artifacts: ./desktop/target/dx/arto/bundle/**/*.deb
@@ -148,9 +150,13 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+      # Native, never the Nix devShell: a devShell build bakes /nix/store paths
+      # into the binary (ELF interpreter and RUNPATH on Linux, the libiconv
+      # install name on macOS), which no machine without that store can
+      # resolve. The `verify bundle` step below enforces this.
       - uses: ./.github/actions/setup-toolchain
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          toolchain: native
       - uses: actions/cache@v6
         with:
           path: |
@@ -163,12 +169,22 @@ jobs:
             desktop/target
           key: cargo-build-${{ matrix.target }}-${{ hashFiles('desktop/Cargo.lock') }}
           restore-keys: cargo-build-${{ matrix.target }}-
-      # macOS/Linux get `dx` from the Nix devShell; Windows has no Nix, so the
-      # dioxus-cli that `just build` (`dx bundle`) needs is installed natively.
-      # Version-matched to the devShell's dioxus-cli. A cached `dx` is reused
-      # only when its version matches, so bumping the pin forces a reinstall
-      # even before Cargo.lock (the cache key) changes; otherwise the ~10m
-      # rebuild is skipped.
+      # `just build` drives `dx bundle`, so every leg needs dioxus-cli.
+      # Version-matched to the devShell's dioxus-cli so local and CI bundles
+      # come out of the same tool. A cached `dx` is reused only when its
+      # version matches, so bumping the pin forces a reinstall even before
+      # Cargo.lock (the cache key) changes; otherwise the ~10m rebuild is
+      # skipped.
+      - name: Install dioxus-cli (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          want='0.7.9'
+          if dx --version 2>/dev/null | grep -qF "$want"; then
+            echo "dx $want already present, skipping install"
+          else
+            cargo install dioxus-cli --version "$want" --locked --force
+          fi
       - name: Install dioxus-cli (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
@@ -197,10 +213,13 @@ jobs:
           $v = "${{ github.event.release.tag_name }}" -replace '^v', ''
           (Get-Content desktop/Cargo.toml) -replace '^version = "0\.0\.0"', "version = `"$v`"" | Set-Content desktop/Cargo.toml
           Set-Content -NoNewline desktop/VERSION $v
-      - if: runner.os != 'Windows'
-        run: nix develop -c just build
-      - if: runner.os == 'Windows'
-        run: just build
+      - run: just build
+      # Refuse to publish a bundle that carries build-environment dependencies
+      # or that cannot start. Windows never sees a Nix toolchain, so there is
+      # nothing to check there.
+      - name: Verify bundle
+        if: runner.os != 'Windows'
+        run: just verify-bundle
       - uses: actions/upload-artifact@v7
         with:
           name: arto-${{ matrix.target }}

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ preset (Default / Vim / Emacs) from Preferences.
 
 ## Installation
 
+### macOS
+
 Use [Homebrew] tap to install. Since the application is not signed or notarized with an Apple Developer ID, you'll need to remove the quarantine attribute after installation.
 See [homebrew-tap] for more information.
 
@@ -112,7 +114,22 @@ xattr -dr com.apple.quarantine /Applications/Arto.app
 > qlmanage -r && qlmanage -r cache
 > ```
 
-Alternatively, [Nix] is also supported.
+### Linux
+
+Download the `.deb` matching your architecture from the [releases] page and
+install it with `apt`, which pulls in the GTK/WebKit libraries it declares:
+
+```
+sudo apt install ./arto_<version>_amd64.deb
+```
+
+The package is built on Ubuntu 24.04, so it requires glibc 2.39 or newer
+(Ubuntu 24.04+, Debian 13+) and WebKitGTK 4.1. On older distributions, build
+from source or use the Nix package below.
+
+### Nix
+
+[Nix] is supported on both macOS and Linux.
 To try it without a permanent installation:
 
 ```
@@ -159,6 +176,7 @@ Arto runs as a **single instance** — if Arto is already running, the command s
 
 [Homebrew]: https://brew.sh/
 [homebrew-tap]: https://github.com/arto-app/homebrew-tap
+[releases]: https://github.com/arto-app/Arto/releases
 [Nix]: https://nixos.org/
 [nix-darwin]: https://github.com/nix-darwin/nix-darwin
 [home-manager]: https://github.com/nix-community/home-manager

--- a/desktop/Dioxus.toml
+++ b/desktop/Dioxus.toml
@@ -13,6 +13,28 @@ long_description = """
 Arto is a GitHub Markdown viewer built with Dioxus.
 """
 
+# Every shared library the binary links directly (the DT_NEEDED entries, minus
+# the C runtime), so `apt install ./arto.deb` pulls them in instead of leaving
+# the user to decode a bare dynamic-linker error. Listed even where WebKitGTK
+# would drag them in anyway: relying on another package's dependencies is how a
+# package silently breaks when a distro splits or renames one. The alternatives
+# cover Ubuntu's time64 renaming, which Debian does not use.
+[bundle.deb]
+depends = [
+  "libwebkit2gtk-4.1-0",
+  "libjavascriptcoregtk-4.1-0",
+  "libgtk-3-0t64 | libgtk-3-0",
+  "libglib2.0-0t64 | libglib2.0-0",
+  "libsoup-3.0-0",
+  "libpango-1.0-0",
+  "libcairo2",
+  "libcairo-gobject2",
+  "libgdk-pixbuf-2.0-0",
+  "libxcb1",
+  "libxdo3",
+  "libssl3t64 | libssl3",
+]
+
 [bundle.macos]
 license = "../LICENSE"
 provider_short_name = "Alisue"

--- a/desktop/justfile
+++ b/desktop/justfile
@@ -145,6 +145,33 @@ build:
   @rm -rf target/dx/arto/release/linux/app/assets
   dx bundle --release --linux --package-types deb
 
+# Release artifacts are built with the platform's native toolchain, but a
+# bundle built inside the Nix devShell links against /nix/store paths and is
+# unusable on any machine without that store — a failure invisible until a user
+# launches the download. CI runs this on the artifact it is about to publish;
+# it is deliberately not part of `build`, so local devShell builds stay usable.
+
+# Reject a bundle that carries build-environment dependencies
+[macos]
+verify-bundle:
+  ../scripts/verify-macos-bundle.sh target/dx/arto/release/macos/Arto.app arto
+
+[linux]
+verify-bundle:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  # Every .deb under the bundle dir is checked, not just the newest: CI caches
+  # `desktop/target`, so a stale package from an earlier run can be sitting
+  # there, and the release upload glob would pick it up too.
+  mapfile -t debs < <(find target/dx/arto/bundle -type f -name '*.deb')
+  if [[ ${#debs[@]} -eq 0 ]]; then
+    echo "Error: no .deb found under target/dx/arto/bundle" >&2
+    exit 1
+  fi
+  for deb in "${debs[@]}"; do
+    ../scripts/verify-linux-bundle.sh "$deb" arto
+  done
+
 [macos]
 open:
   ./target/dx/arto/release/macos/Arto.app/Contents/MacOS/arto

--- a/justfile
+++ b/justfile
@@ -22,6 +22,13 @@ dev:
 
 build: renderer::assets desktop::build
 
+# Gate for release artifacts; see the desktop recipe for what it rejects.
+[macos]
+verify-bundle: desktop::verify-bundle
+
+[linux]
+verify-bundle: desktop::verify-bundle
+
 open: desktop::open
 
 [macos]

--- a/scripts/verify-linux-bundle.sh
+++ b/scripts/verify-linux-bundle.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Reject a Debian package that would not run outside the build environment.
+#
+# A package built inside the Nix devShell records an ELF interpreter and a
+# RUNPATH under /nix/store. Such a binary cannot even be exec'd on a machine
+# without that store path, so the whole package is dead on arrival.
+#
+# The packaged binary is inspected rather than the one in the build tree,
+# because the package is what gets published.
+#
+#   1. The ELF interpreter, NEEDED entries and RUNPATH/RPATH must be free of
+#      /nix/store, and no /nix/store string may survive anywhere in the binary.
+#   2. The package must declare its shared-library dependencies, so installing
+#      it pulls them in instead of leaving the user to hunt them down.
+#   3. The binary actually starts, which is the only way to confirm that the
+#      interpreter and every NEEDED library really resolve. `--version` exits
+#      immediately and needs no display.
+set -euo pipefail
+
+deb="${1:?usage: verify-linux-bundle.sh <path to .deb> <executable name>}"
+executable="${2:?usage: verify-linux-bundle.sh <path to .deb> <executable name>}"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+dpkg-deb --fsys-tarfile "$deb" | tar -x -C "$workdir"
+
+bin="$workdir/usr/bin/$executable"
+if [[ ! -x "$bin" ]]; then
+  echo "Error: $deb does not contain usr/bin/$executable" >&2
+  exit 1
+fi
+
+status=0
+
+# Captured before grepping: piping into grep under `pipefail` would let a
+# readelf failure masquerade as a clean result.
+headers="$(readelf -p .interp "$bin"; readelf -d "$bin")"
+embedded="$(strings -a "$bin")"
+
+if refs="$(grep -F /nix/store <<<"$headers")"; then
+  echo "Error: usr/bin/$executable depends on the build environment:" >&2
+  echo "$refs" >&2
+  status=1
+elif refs="$(grep -F /nix/store <<<"$embedded" | sort -u)"; then
+  echo "Error: usr/bin/$executable still embeds build environment paths:" >&2
+  echo "$refs" >&2
+  status=1
+fi
+
+depends="$(dpkg-deb -f "$deb" Depends)"
+if [[ -z "$depends" ]]; then
+  echo "Error: $deb declares no Depends, so installing it does not pull in" >&2
+  echo "       the shared libraries the binary needs." >&2
+  status=1
+elif command -v apt-cache >/dev/null; then
+  # Each declared name must exist in the distro index. A typo would otherwise
+  # surface only as an unmet dependency on a user's machine. Alternatives
+  # ("a | b") are satisfied by any one of their members, which is how the
+  # Ubuntu/Debian package renamings are expressed.
+  while IFS= read -r entry; do
+    resolved=""
+    while IFS= read -r alternative; do
+      if apt-cache show "$alternative" >/dev/null 2>&1; then
+        resolved=1
+        break
+      fi
+    done < <(tr '|' '\n' <<<"$entry" | perl -lpe 's/\(.*\)//; s/^\s+|\s+$//g')
+
+    if [[ -z "$resolved" ]]; then
+      echo "Error: dependency '$entry' matches no package in the distro index" >&2
+      status=1
+    fi
+  done < <(tr ',' '\n' <<<"$depends" | perl -lpe 's/^\s+|\s+$//g' | grep -v '^$')
+fi
+
+if [[ "$status" -ne 0 ]]; then
+  exit "$status"
+fi
+
+"$bin" --version
+echo "Package verified: no /nix/store references, dependencies declared, executable launches"

--- a/scripts/verify-macos-bundle.sh
+++ b/scripts/verify-macos-bundle.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Reject a macOS app bundle that would not launch outside the build environment.
+#
+# Release bundles must link only against libraries macOS itself ships. A bundle
+# built inside the Nix devShell instead records absolute /nix/store install
+# names (libiconv, pulled in by the `libc` crate's `#[link(name = "iconv")]`),
+# and dyld kills the app at launch on every machine without that store path.
+#
+# Two independent checks, because neither alone is sufficient:
+#
+#   1. No load command in any Mach-O of the bundle may mention /nix/store.
+#      `otool -l` (not -L) is used so LC_RPATH and LC_LOAD_WEAK_DYLIB entries
+#      are covered too, not just LC_LOAD_DYLIB.
+#   2. The executable actually starts. Only dyld can confirm that every
+#      recorded dependency resolves and satisfies its compatibility version;
+#      `--version` exercises that and exits immediately.
+set -euo pipefail
+
+app="${1:?usage: verify-macos-bundle.sh <path to .app> <executable name>}"
+executable="${2:?usage: verify-macos-bundle.sh <path to .app> <executable name>}"
+
+status=0
+while IFS= read -r -d '' bin; do
+  file -b "$bin" | grep -q '^Mach-O' || continue
+
+  # Captured before grepping: piping into grep under `pipefail` would let an
+  # otool failure masquerade as a clean result.
+  if ! load_commands="$(otool -l "$bin")"; then
+    echo "Error: cannot read load commands of ${bin#"$app"/}" >&2
+    status=1
+    continue
+  fi
+
+  if refs="$(grep -F /nix/store <<<"$load_commands")"; then
+    echo "Error: ${bin#"$app"/} depends on the build environment:" >&2
+    echo "$refs" >&2
+    status=1
+  fi
+done < <(find "$app" -type f -print0)
+
+if [[ "$status" -ne 0 ]]; then
+  exit "$status"
+fi
+
+"$app/Contents/MacOS/$executable" --version
+echo "Bundle verified: no /nix/store references, executable launches"


### PR DESCRIPTION
## Summary

- Build the release matrix (macOS, Linux x64/arm64, Windows) with each platform's native toolchain instead of the Nix devShell; `check`, `test` and `nix-check` keep running through Nix, and `flake.nix` is untouched.
- Add `just verify-bundle`, backed by `scripts/verify-macos-bundle.sh` and `scripts/verify-linux-bundle.sh`, and run it in CI on the artifact about to be published: no `/nix/store` in any load command, ELF interpreter, RUNPATH or embedded string; declared `Depends` that actually resolve; and the executable really starts.
- Declare the `.deb`'s direct shared-library dependencies in `Dioxus.toml`, so `apt install ./arto_*.deb` pulls in the GTK/WebKit stack instead of leaving the user with a bare dynamic-linker error.
- Document Linux installation and the supported distribution floor in the README.

## Why

Every published Unix artifact was unusable off the build machine, because `just build` ran inside `nix develop`.

On macOS the `libc` crate's `#[link(name = "iconv")]` resolved through the devShell's `-L /nix/store/…-libiconv/lib`, so the app recorded an absolute store path as the install name and dyld killed it at launch (#204). With the Apple toolchain the same link resolves to `/usr/lib/libiconv.2.dylib`, which every Mac has — verified locally.

Linux was worse: the shipped `arto_0.31.2_amd64.deb` records `/nix/store/…-glibc-2.42-67/lib/ld-linux-x86-64.so.2` as its ELF interpreter, so the binary cannot even be exec'd without that store, and the package declared no `Depends` at all.

Post-processing the binaries would have patched over the symptom; building natively removes the cause, and the verification gate makes a regression fail the build instead of the download.

## Test Plan

Verified locally (macOS):

- [x] Apple toolchain resolves `-liconv` to `/usr/lib/libiconv.2.dylib`
- [x] macOS verifier rejects a devShell-built `.app` and accepts one whose only libiconv reference is the system copy (launch and `codesign --verify --deep --strict` both pass)
- [x] Linux verifier rejects the published `arto_0.31.2_amd64.deb`, reporting both the `/nix/store` interpreter and the missing `Depends`
- [x] `Depends` parsing handles `a | b` alternatives and rejects a typo'd package name
- [x] `just fmt check test`

Needs a real CI run (cannot be exercised from macOS):

- [ ] Native Linux build succeeds and its `.deb` passes verification
- [ ] Native macOS build succeeds and its `.app` passes verification
- [ ] Declared Debian package names resolve against the Ubuntu 24.04 index

A re-release is required to get fixed binaries to users; the published 0.31.2 artifacts stay broken.

Closes #204