### PR TITLE
refactor: unify sidebar state shape, context menus, and zoom normalization

### DIFF
--- a/desktop/src/components.rs
+++ b/desktop/src/components.rs
@@ -1,6 +1,7 @@
 pub mod app;
 pub mod bookmark_button;
 pub mod content;
+pub mod context_menu;
 pub mod header;
 pub mod icon;
 pub mod image_window;

--- a/desktop/src/components/app.rs
+++ b/desktop/src/components/app.rs
@@ -93,17 +93,16 @@ pub fn App(
 
         // Apply initial right sidebar settings from params
         {
-            app_state.right_sidebar_pinned.set(right_sidebar_pinned);
-            app_state.right_sidebar_width.set(right_sidebar_width);
-            app_state.right_sidebar_tab.set(right_sidebar_tab);
+            let mut right_sidebar = app_state.right_sidebar.write();
+            right_sidebar.pinned = right_sidebar_pinned;
+            right_sidebar.width = right_sidebar_width;
+            right_sidebar.tab = right_sidebar_tab;
         }
 
         // Apply initial zoom levels from params (already normalized in window::settings)
         {
             app_state.sidebar.write().zoom_level = sidebar_zoom_level;
-            app_state
-                .right_sidebar_zoom_level
-                .set(right_sidebar_zoom_level);
+            app_state.right_sidebar.write().zoom_level = right_sidebar_zoom_level;
             app_state.zoom_level.set(zoom_level);
         }
 
@@ -328,7 +327,7 @@ pub fn App(
     let mut right_mouse_inside = use_signal(|| false);
 
     let left_pinned = state.sidebar.read().pinned;
-    let right_pinned = *state.right_sidebar_pinned.read();
+    let right_pinned = state.right_sidebar.read().pinned;
 
     // Delay in milliseconds before auto-hiding the overlay sidebar.
     // 300ms is the standard "Hover Intent" delay (Nielsen Norman Group),
@@ -393,7 +392,7 @@ pub fn App(
                 RightSidebar {
                     headings: state.right_sidebar_headings.read().clone(),
                     on_pin_toggle: move |_| {
-                        state.right_sidebar_pinned.set(false);
+                        state.right_sidebar.write().pinned = false;
                         right_hover_active.set(true);
                     },
                 }
@@ -497,7 +496,7 @@ pub fn App(
                     RightSidebar {
                         headings: state.right_sidebar_headings.read().clone(),
                         on_pin_toggle: move |_| {
-                            state.right_sidebar_pinned.set(true);
+                            state.right_sidebar.write().pinned = true;
                             right_hover_active.set(false);
                         },
                         on_resize_change: move |resizing: bool| {

--- a/desktop/src/components/content/context_menu.rs
+++ b/desktop/src/components/content/context_menu.rs
@@ -4,7 +4,6 @@ mod copy_path_as;
 mod copy_table_as;
 mod data;
 mod image_ops;
-mod menu_item;
 mod source_ops;
 
 pub use data::*;
@@ -12,6 +11,7 @@ pub use data::*;
 use dioxus::document;
 use dioxus::prelude::*;
 
+use crate::components::context_menu::{ContextMenuItem, ContextMenuSeparator};
 use crate::components::icon::IconName;
 use crate::keybindings::dispatcher::dispatch_action;
 use crate::keybindings::{shortcut_hint_for_context_action, Action, KeyContext};
@@ -20,7 +20,6 @@ use copy_code_as::CopyCodeAsSubmenu;
 use copy_path_as::CopyPathAsSubmenu;
 use copy_table_as::CopyTableAsSubmenu;
 use image_ops::{CopyImageAsSubmenu, CopySpecialBlockAsSubmenu};
-use menu_item::{ContextMenuItem, ContextMenuSeparator};
 use source_ops::LinkContextItems;
 
 #[component]

--- a/desktop/src/components/content/context_menu/copy_as.rs
+++ b/desktop/src/components/content/context_menu/copy_as.rs
@@ -1,7 +1,7 @@
 use dioxus::prelude::*;
 use std::path::PathBuf;
 
-use super::menu_item::{ContextMenuItem, ContextMenuSubmenu};
+use crate::components::context_menu::{ContextMenuItem, ContextMenuSubmenu};
 
 /// "Copy As..." submenu: Text / Markdown
 #[component]

--- a/desktop/src/components/content/context_menu/copy_code_as.rs
+++ b/desktop/src/components/content/context_menu/copy_code_as.rs
@@ -1,8 +1,8 @@
 use dioxus::prelude::*;
 use std::path::PathBuf;
 
-use super::menu_item::{ContextMenuItem, ContextMenuSubmenu};
 use super::source_ops::build_path_with_range;
+use crate::components::context_menu::{ContextMenuItem, ContextMenuSubmenu};
 
 /// "Copy Code As..." submenu: Code / Markdown / Path with Range
 #[component]

--- a/desktop/src/components/content/context_menu/copy_path_as.rs
+++ b/desktop/src/components/content/context_menu/copy_path_as.rs
@@ -1,7 +1,7 @@
 use dioxus::prelude::*;
 use std::path::PathBuf;
 
-use super::menu_item::{ContextMenuItem, ContextMenuSubmenu};
+use crate::components::context_menu::{ContextMenuItem, ContextMenuSubmenu};
 
 /// "Copy Path As..." submenu: Path / Path with Line / Path with Range
 #[component]

--- a/desktop/src/components/content/context_menu/copy_table_as.rs
+++ b/desktop/src/components/content/context_menu/copy_table_as.rs
@@ -1,8 +1,8 @@
 use dioxus::prelude::*;
 use std::path::PathBuf;
 
-use super::menu_item::{ContextMenuItem, ContextMenuSubmenu};
 use super::source_ops::build_path_with_range;
+use crate::components::context_menu::{ContextMenuItem, ContextMenuSubmenu};
 
 /// "Copy Table As..." submenu: TSV / CSV / Markdown / Path with Range
 #[component]

--- a/desktop/src/components/content/context_menu/image_ops.rs
+++ b/desktop/src/components/content/context_menu/image_ops.rs
@@ -1,6 +1,6 @@
 use dioxus::prelude::*;
 
-use super::menu_item::{ContextMenuItem, ContextMenuSubmenu};
+use crate::components::context_menu::{ContextMenuItem, ContextMenuSubmenu};
 use crate::keybindings::{shortcut_hint_for_context_action, KeyContext};
 
 /// "Copy Image As..." submenu: Image / Image with Background / Markdown / Path

--- a/desktop/src/components/content/context_menu/source_ops.rs
+++ b/desktop/src/components/content/context_menu/source_ops.rs
@@ -1,7 +1,7 @@
 use dioxus::prelude::*;
 use std::path::PathBuf;
 
-use super::menu_item::ContextMenuItem;
+use crate::components::context_menu::ContextMenuItem;
 use crate::components::icon::IconName;
 use crate::keybindings::dispatcher::dispatch_action;
 use crate::keybindings::{shortcut_hint_for_context_action, Action, KeyContext};

--- a/desktop/src/components/content/preferences_view/tabs/right_sidebar_tab.rs
+++ b/desktop/src/components/content/preferences_view/tabs/right_sidebar_tab.rs
@@ -1,6 +1,9 @@
 use super::super::form_controls::{OptionCardItem, OptionCards, SliderInput};
 use crate::components::right_sidebar::RightSidebarTab as RightSidebarTabKind;
-use crate::config::{normalize_zoom_level, Config, NewWindowBehavior, StartupBehavior};
+use crate::config::{
+    normalize_sidebar_zoom, Config, NewWindowBehavior, StartupBehavior, MAX_SIDEBAR_ZOOM,
+    MIN_SIDEBAR_ZOOM, ZOOM_STEP,
+};
 use crate::state::AppState;
 use dioxus::prelude::*;
 
@@ -12,8 +15,8 @@ pub fn RightSidebarTab(
 ) -> Element {
     // Extract values upfront to avoid holding read guard across closures
     let right_sidebar_cfg = config.read().right_sidebar.clone();
-    let current_width = *state.right_sidebar_width.read();
-    let current_zoom = *state.right_sidebar_zoom_level.read();
+    let current_width = state.right_sidebar.read().width;
+    let current_zoom = state.right_sidebar.read().zoom_level;
 
     rsx! {
         div {
@@ -30,14 +33,14 @@ pub fn RightSidebarTab(
                 }
                 SliderInput {
                     value: current_zoom,
-                    min: 0.5,
-                    max: 2.0,
-                    step: 0.1,
+                    min: MIN_SIDEBAR_ZOOM,
+                    max: MAX_SIDEBAR_ZOOM,
+                    step: ZOOM_STEP,
                     unit: "x".to_string(),
                     decimals: 1,
                     on_change: move |new_zoom| {
                         // Normalize to 0.1 step and clamp to valid range
-                        state.right_sidebar_zoom_level.set(normalize_zoom_level(new_zoom));
+                        state.right_sidebar.write().zoom_level = normalize_sidebar_zoom(new_zoom);
                     },
                     default_value: Some(right_sidebar_cfg.default_zoom_level),
                 }
@@ -137,9 +140,9 @@ pub fn RightSidebarTab(
                 }
                 SliderInput {
                     value: right_sidebar_cfg.default_zoom_level,
-                    min: 0.5,
-                    max: 2.0,
-                    step: 0.1,
+                    min: MIN_SIDEBAR_ZOOM,
+                    max: MAX_SIDEBAR_ZOOM,
+                    step: ZOOM_STEP,
                     unit: "x".to_string(),
                     decimals: 1,
                     on_change: move |new_zoom| {

--- a/desktop/src/components/content/preferences_view/tabs/sidebar_tab.rs
+++ b/desktop/src/components/content/preferences_view/tabs/sidebar_tab.rs
@@ -1,5 +1,8 @@
 use super::super::form_controls::{OptionCardItem, OptionCards, SliderInput};
-use crate::config::{normalize_zoom_level, Config, NewWindowBehavior, StartupBehavior};
+use crate::config::{
+    normalize_sidebar_zoom, Config, NewWindowBehavior, StartupBehavior, MAX_SIDEBAR_ZOOM,
+    MIN_SIDEBAR_ZOOM, ZOOM_STEP,
+};
 use crate::state::AppState;
 use dioxus::prelude::*;
 
@@ -29,14 +32,14 @@ pub fn SidebarTab(
                 }
                 SliderInput {
                     value: current_zoom,
-                    min: 0.5,
-                    max: 2.0,
-                    step: 0.1,
+                    min: MIN_SIDEBAR_ZOOM,
+                    max: MAX_SIDEBAR_ZOOM,
+                    step: ZOOM_STEP,
                     unit: "x".to_string(),
                     decimals: 1,
                     on_change: move |new_zoom| {
                         // Normalize to 0.1 step and clamp to valid range
-                        state.sidebar.write().zoom_level = normalize_zoom_level(new_zoom);
+                        state.sidebar.write().zoom_level = normalize_sidebar_zoom(new_zoom);
                     },
                     default_value: Some(sidebar_cfg.default_zoom_level),
                 }
@@ -105,9 +108,9 @@ pub fn SidebarTab(
                 }
                 SliderInput {
                     value: sidebar_cfg.default_zoom_level,
-                    min: 0.5,
-                    max: 2.0,
-                    step: 0.1,
+                    min: MIN_SIDEBAR_ZOOM,
+                    max: MAX_SIDEBAR_ZOOM,
+                    step: ZOOM_STEP,
                     unit: "x".to_string(),
                     decimals: 1,
                     on_change: move |new_zoom| {

--- a/desktop/src/components/context_menu.rs
+++ b/desktop/src/components/context_menu.rs
@@ -1,0 +1,14 @@
+//! Shared building blocks for every menu in the app.
+//!
+//! Each menu owns its own contents, but they all render the same
+//! item/separator/submenu markup and clamp themselves into the viewport the
+//! same way. Consumers include the tab bar, the sidebar file tree, the markdown
+//! content area, and the Windows hamburger menu — the last of which is
+//! `cfg`-gated, so a grep or build on another platform will not surface it.
+//! Check it too before assuming a menu change is complete.
+
+mod menu_item;
+mod position;
+
+pub use menu_item::*;
+pub use position::*;

--- a/desktop/src/components/context_menu/menu_item.rs
+++ b/desktop/src/components/context_menu/menu_item.rs
@@ -3,7 +3,7 @@ use dioxus::prelude::*;
 use crate::components::icon::{Icon, IconName};
 
 #[derive(Props, Clone, PartialEq)]
-pub(super) struct ContextMenuItemProps {
+pub struct ContextMenuItemProps {
     #[props(into)]
     label: String,
     #[props(default)]
@@ -16,7 +16,7 @@ pub(super) struct ContextMenuItemProps {
 }
 
 #[component]
-pub(super) fn ContextMenuItem(props: ContextMenuItemProps) -> Element {
+pub fn ContextMenuItem(props: ContextMenuItemProps) -> Element {
     rsx! {
         div {
             class: if props.disabled { "context-menu-item disabled" } else { "context-menu-item" },
@@ -44,7 +44,7 @@ pub(super) fn ContextMenuItem(props: ContextMenuItemProps) -> Element {
 }
 
 #[component]
-pub(super) fn ContextMenuSeparator() -> Element {
+pub fn ContextMenuSeparator() -> Element {
     rsx! {
         div { class: "context-menu-separator" }
     }
@@ -52,7 +52,7 @@ pub(super) fn ContextMenuSeparator() -> Element {
 
 /// Reusable submenu component with hover-to-open behavior.
 #[component]
-pub(super) fn ContextMenuSubmenu(label: String, children: Element) -> Element {
+pub fn ContextMenuSubmenu(label: String, children: Element) -> Element {
     let mut show = use_signal(|| false);
 
     rsx! {

--- a/desktop/src/components/context_menu/position.rs
+++ b/desktop/src/components/context_menu/position.rs
@@ -1,0 +1,138 @@
+//! Viewport clamping for context menus and their submenu flyouts.
+
+/// Clamp a menu's top-left origin so the whole menu stays within the viewport.
+///
+/// If the menu is larger than the available space on an axis, it is pinned to
+/// `margin` on that axis (the top/left is always visible).
+pub fn clamp_menu_position(
+    cursor: (i32, i32),
+    menu: (i32, i32),
+    viewport: (i32, i32),
+    margin: i32,
+) -> (i32, i32) {
+    let clamp_axis = |pos: i32, size: i32, extent: i32| {
+        let max_pos = (extent - margin - size).max(margin);
+        pos.clamp(margin, max_pos)
+    };
+    (
+        clamp_axis(cursor.0, menu.0, viewport.0),
+        clamp_axis(cursor.1, menu.1, viewport.1),
+    )
+}
+
+/// Decide whether the submenu flyout should open to the left of the menu
+/// instead of the right, to avoid spilling past the viewport's right edge.
+pub fn submenu_opens_left(
+    menu_x: i32,
+    menu_width: i32,
+    submenu_width: i32,
+    viewport_width: i32,
+    margin: i32,
+) -> bool {
+    menu_x + menu_width + submenu_width + margin > viewport_width
+}
+
+/// Clamp the submenu flyout's top so its full height stays within the viewport.
+///
+/// Returns the top the flyout should render at: `anchor_y` when it fits, a
+/// smaller value when it would spill past the bottom edge, and `margin` when the
+/// flyout is taller than the available space (its top stays visible).
+pub fn clamp_submenu_top(
+    anchor_y: i32,
+    submenu_height: i32,
+    viewport_height: i32,
+    margin: i32,
+) -> i32 {
+    let max_top = (viewport_height - margin - submenu_height).max(margin);
+    anchor_y.clamp(margin, max_top)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MENU: (i32, i32) = (200, 300);
+    const VIEWPORT: (i32, i32) = (1000, 800);
+    const MARGIN: i32 = 8;
+
+    #[test]
+    fn keeps_position_unchanged_when_menu_fits() {
+        // A cursor with room for the whole menu is used as-is.
+        let pos = clamp_menu_position((100, 100), MENU, VIEWPORT, MARGIN);
+        assert_eq!(pos, (100, 100));
+    }
+
+    #[test]
+    fn shifts_left_when_menu_overflows_right_edge() {
+        // Cursor near the right edge: x is pulled in so the menu's right edge
+        // sits at viewport_width - margin.
+        let pos = clamp_menu_position((950, 100), MENU, VIEWPORT, MARGIN);
+        assert_eq!(pos.0, VIEWPORT.0 - MARGIN - MENU.0); // 1000 - 8 - 200 = 792
+        assert_eq!(pos.1, 100);
+    }
+
+    #[test]
+    fn shifts_up_when_menu_overflows_bottom_edge() {
+        // Cursor near the bottom edge: y is pulled in so the menu's bottom edge
+        // sits at viewport_height - margin.
+        let pos = clamp_menu_position((100, 780), MENU, VIEWPORT, MARGIN);
+        assert_eq!(pos.0, 100);
+        assert_eq!(pos.1, VIEWPORT.1 - MARGIN - MENU.1); // 800 - 8 - 300 = 492
+    }
+
+    #[test]
+    fn clamps_bottom_right_corner_into_view() {
+        // A corner click keeps the whole menu on-screen on both axes.
+        let pos = clamp_menu_position((999, 799), MENU, VIEWPORT, MARGIN);
+        assert_eq!(pos, (792, 492));
+    }
+
+    #[test]
+    fn pins_to_margin_when_menu_larger_than_viewport() {
+        // Degenerate viewport smaller than the menu: the top-left stays visible.
+        let tiny = (150, 150);
+        let pos = clamp_menu_position((999, 999), MENU, tiny, MARGIN);
+        assert_eq!(pos, (MARGIN, MARGIN));
+    }
+
+    #[test]
+    fn never_places_origin_before_margin() {
+        // A cursor above/left of the margin is pushed back to the margin.
+        let pos = clamp_menu_position((0, 0), MENU, VIEWPORT, MARGIN);
+        assert_eq!(pos, (MARGIN, MARGIN));
+    }
+
+    #[test]
+    fn submenu_opens_right_with_room() {
+        // Plenty of horizontal room: the flyout opens to the right.
+        assert!(!submenu_opens_left(100, 220, 208, 1000, MARGIN));
+    }
+
+    #[test]
+    fn submenu_flips_left_near_right_edge() {
+        // Menu hugging the right edge: right-side flyout would spill, so flip.
+        assert!(submenu_opens_left(700, 220, 208, 1000, MARGIN));
+    }
+
+    #[test]
+    fn submenu_top_unchanged_when_flyout_fits() {
+        // Plenty of room below the anchor: the flyout stays at its anchor.
+        let top = clamp_submenu_top(100, 200, 800, MARGIN);
+        assert_eq!(top, 100);
+    }
+
+    #[test]
+    fn submenu_top_shifts_up_near_bottom_edge() {
+        // Anchor near the bottom: the top is pulled up so the flyout's bottom
+        // sits at viewport_height - margin.
+        let top = clamp_submenu_top(700, 200, 800, MARGIN);
+        assert_eq!(top, 800 - MARGIN - 200); // 592
+    }
+
+    #[test]
+    fn submenu_top_pins_to_margin_when_taller_than_viewport() {
+        // A flyout taller than the available space keeps its top visible.
+        let top = clamp_submenu_top(700, 1000, 800, MARGIN);
+        assert_eq!(top, MARGIN);
+    }
+}

--- a/desktop/src/components/right_sidebar.rs
+++ b/desktop/src/components/right_sidebar.rs
@@ -30,9 +30,14 @@ pub struct RightSidebarProps {
 #[component]
 pub fn RightSidebar(props: RightSidebarProps) -> Element {
     let mut state = use_context::<AppState>();
-    let width = *state.right_sidebar_width.read();
-    let active_tab = *state.right_sidebar_tab.read();
-    let zoom_level = *state.right_sidebar_zoom_level.read();
+    let (width, active_tab, zoom_level) = {
+        let right_sidebar = state.right_sidebar.read();
+        (
+            right_sidebar.width,
+            right_sidebar.tab,
+            right_sidebar.zoom_level,
+        )
+    };
     let is_panel_focused = *state.focused_panel.read() == FocusedPanel::RightSidebar;
     let toc_cursor = *state.toc_cursor.read();
     let is_resizing = use_signal(|| false);
@@ -103,7 +108,7 @@ fn RightSidebarResizeHandle(
                     handler.call(true);
                 }
                 let start_x = evt.page_coordinates().x;
-                let start_width = *state.right_sidebar_width.read();
+                let start_width = state.right_sidebar.read().width;
 
                 spawn(async move {
                     #[derive(serde::Deserialize)]

--- a/desktop/src/components/right_sidebar/tab_bar.rs
+++ b/desktop/src/components/right_sidebar/tab_bar.rs
@@ -11,7 +11,7 @@ pub fn TabBar(
     on_pin_toggle: Option<EventHandler<()>>,
 ) -> Element {
     let state = use_context::<AppState>();
-    let is_pinned = *state.right_sidebar_pinned.read();
+    let is_pinned = state.right_sidebar.read().pinned;
     rsx! {
         div {
             class: "right-sidebar-tabs",

--- a/desktop/src/components/sidebar/context_menu.rs
+++ b/desktop/src/components/sidebar/context_menu.rs
@@ -4,6 +4,10 @@ use dioxus::desktop::tao::window::WindowId;
 use dioxus::prelude::*;
 
 use crate::bookmarks::BOOKMARKS;
+use crate::components::context_menu::{
+    clamp_menu_position, clamp_submenu_top, submenu_opens_left, ContextMenuItem,
+    ContextMenuSeparator,
+};
 use crate::components::icon::{Icon, IconName};
 use crate::keybindings::{shortcut_hint_for_context_action, KeyContext};
 
@@ -95,48 +99,6 @@ impl SidebarContextMenuData {
             other_windows,
         }
     }
-}
-
-/// Clamp a menu's top-left origin so the whole menu stays within the viewport.
-///
-/// If the menu is larger than the available space on an axis, it is pinned to
-/// `margin` on that axis (the top/left is always visible).
-fn clamp_menu_position(
-    cursor: (i32, i32),
-    menu: (i32, i32),
-    viewport: (i32, i32),
-    margin: i32,
-) -> (i32, i32) {
-    let clamp_axis = |pos: i32, size: i32, extent: i32| {
-        let max_pos = (extent - margin - size).max(margin);
-        pos.clamp(margin, max_pos)
-    };
-    (
-        clamp_axis(cursor.0, menu.0, viewport.0),
-        clamp_axis(cursor.1, menu.1, viewport.1),
-    )
-}
-
-/// Decide whether the submenu flyout should open to the left of the menu
-/// instead of the right, to avoid spilling past the viewport's right edge.
-fn submenu_opens_left(
-    menu_x: i32,
-    menu_width: i32,
-    submenu_width: i32,
-    viewport_width: i32,
-    margin: i32,
-) -> bool {
-    menu_x + menu_width + submenu_width + margin > viewport_width
-}
-
-/// Clamp the submenu flyout's top so its full height stays within the viewport.
-///
-/// Returns the top the flyout should render at: `anchor_y` when it fits, a
-/// smaller value when it would spill past the bottom edge, and `margin` when the
-/// flyout is taller than the available space (its top stays visible).
-fn clamp_submenu_top(anchor_y: i32, submenu_height: i32, viewport_height: i32, margin: i32) -> i32 {
-    let max_top = (viewport_height - margin - submenu_height).max(margin);
-    anchor_y.clamp(margin, max_top)
 }
 
 /// Whether a snapshotted context-menu action may still act on `path`.
@@ -307,145 +269,9 @@ pub fn SidebarContextMenu(
     }
 }
 
-// ============================================================================
-// Helper Components
-// ============================================================================
-
-#[derive(Props, Clone, PartialEq)]
-struct ContextMenuItemProps {
-    label: &'static str,
-    #[props(default)]
-    shortcut: Option<String>,
-    #[props(default)]
-    icon: Option<IconName>,
-    #[props(default = false)]
-    disabled: bool,
-    on_click: EventHandler<()>,
-}
-
-#[component]
-fn ContextMenuItem(props: ContextMenuItemProps) -> Element {
-    rsx! {
-        div {
-            class: if props.disabled { "context-menu-item disabled" } else { "context-menu-item" },
-            onclick: move |_| {
-                if !props.disabled {
-                    props.on_click.call(());
-                }
-            },
-
-            if let Some(icon) = props.icon {
-                Icon {
-                    name: icon,
-                    size: 14,
-                    class: "context-menu-icon",
-                }
-            }
-
-            span { class: "context-menu-label", "{props.label}" }
-
-            if let Some(shortcut) = props.shortcut {
-                span { class: "context-menu-shortcut", "{shortcut}" }
-            }
-        }
-    }
-}
-
-#[component]
-fn ContextMenuSeparator() -> Element {
-    rsx! {
-        div { class: "context-menu-separator" }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    const MENU: (i32, i32) = (200, 300);
-    const VIEWPORT: (i32, i32) = (1000, 800);
-    const MARGIN: i32 = 8;
-
-    #[test]
-    fn keeps_position_unchanged_when_menu_fits() {
-        // A cursor with room for the whole menu is used as-is.
-        let pos = clamp_menu_position((100, 100), MENU, VIEWPORT, MARGIN);
-        assert_eq!(pos, (100, 100));
-    }
-
-    #[test]
-    fn shifts_left_when_menu_overflows_right_edge() {
-        // Cursor near the right edge: x is pulled in so the menu's right edge
-        // sits at viewport_width - margin.
-        let pos = clamp_menu_position((950, 100), MENU, VIEWPORT, MARGIN);
-        assert_eq!(pos.0, VIEWPORT.0 - MARGIN - MENU.0); // 1000 - 8 - 200 = 792
-        assert_eq!(pos.1, 100);
-    }
-
-    #[test]
-    fn shifts_up_when_menu_overflows_bottom_edge() {
-        // Cursor near the bottom edge: y is pulled in so the menu's bottom edge
-        // sits at viewport_height - margin.
-        let pos = clamp_menu_position((100, 780), MENU, VIEWPORT, MARGIN);
-        assert_eq!(pos.0, 100);
-        assert_eq!(pos.1, VIEWPORT.1 - MARGIN - MENU.1); // 800 - 8 - 300 = 492
-    }
-
-    #[test]
-    fn clamps_bottom_right_corner_into_view() {
-        // A corner click keeps the whole menu on-screen on both axes.
-        let pos = clamp_menu_position((999, 799), MENU, VIEWPORT, MARGIN);
-        assert_eq!(pos, (792, 492));
-    }
-
-    #[test]
-    fn pins_to_margin_when_menu_larger_than_viewport() {
-        // Degenerate viewport smaller than the menu: the top-left stays visible.
-        let tiny = (150, 150);
-        let pos = clamp_menu_position((999, 999), MENU, tiny, MARGIN);
-        assert_eq!(pos, (MARGIN, MARGIN));
-    }
-
-    #[test]
-    fn never_places_origin_before_margin() {
-        // A cursor above/left of the margin is pushed back to the margin.
-        let pos = clamp_menu_position((0, 0), MENU, VIEWPORT, MARGIN);
-        assert_eq!(pos, (MARGIN, MARGIN));
-    }
-
-    #[test]
-    fn submenu_opens_right_with_room() {
-        // Plenty of horizontal room: the flyout opens to the right.
-        assert!(!submenu_opens_left(100, 220, 208, 1000, MARGIN));
-    }
-
-    #[test]
-    fn submenu_flips_left_near_right_edge() {
-        // Menu hugging the right edge: right-side flyout would spill, so flip.
-        assert!(submenu_opens_left(700, 220, 208, 1000, MARGIN));
-    }
-
-    #[test]
-    fn submenu_top_unchanged_when_flyout_fits() {
-        // Plenty of room below the anchor: the flyout stays at its anchor.
-        let top = clamp_submenu_top(100, 200, 800, MARGIN);
-        assert_eq!(top, 100);
-    }
-
-    #[test]
-    fn submenu_top_shifts_up_near_bottom_edge() {
-        // Anchor near the bottom: the top is pulled up so the flyout's bottom
-        // sits at viewport_height - margin.
-        let top = clamp_submenu_top(700, 200, 800, MARGIN);
-        assert_eq!(top, 800 - MARGIN - 200); // 592
-    }
-
-    #[test]
-    fn submenu_top_pins_to_margin_when_taller_than_viewport() {
-        // A flyout taller than the available space keeps its top visible.
-        let top = clamp_submenu_top(700, 1000, 800, MARGIN);
-        assert_eq!(top, MARGIN);
-    }
 
     #[test]
     fn context_action_proceeds_only_for_existing_paths() {

--- a/desktop/src/components/tab/context_menu.rs
+++ b/desktop/src/components/tab/context_menu.rs
@@ -3,7 +3,8 @@ use std::path::PathBuf;
 use dioxus::desktop::tao::window::WindowId;
 use dioxus::prelude::*;
 
-use crate::components::icon::{Icon, IconName};
+use crate::components::context_menu::{ContextMenuItem, ContextMenuSeparator};
+use crate::components::icon::IconName;
 use crate::keybindings::{shortcut_hint_for_context_action, KeyContext};
 
 #[component]
@@ -163,57 +164,5 @@ pub fn TabContextMenu(
                 on_click: move |_| on_reload.call(()),
             }
         }
-    }
-}
-
-// ============================================================================
-// Helper Components
-// ============================================================================
-
-#[derive(Props, Clone, PartialEq)]
-struct ContextMenuItemProps {
-    #[props(into)]
-    label: String,
-    #[props(default)]
-    shortcut: Option<String>,
-    #[props(default)]
-    icon: Option<IconName>,
-    #[props(default = false)]
-    disabled: bool,
-    on_click: EventHandler<()>,
-}
-
-#[component]
-fn ContextMenuItem(props: ContextMenuItemProps) -> Element {
-    rsx! {
-        div {
-            class: if props.disabled { "context-menu-item disabled" } else { "context-menu-item" },
-            onclick: move |_| {
-                if !props.disabled {
-                    props.on_click.call(());
-                }
-            },
-
-            if let Some(icon) = props.icon {
-                Icon {
-                    name: icon,
-                    size: 14,
-                    class: "context-menu-icon",
-                }
-            }
-
-            span { class: "context-menu-label", "{props.label}" }
-
-            if let Some(shortcut) = props.shortcut {
-                span { class: "context-menu-shortcut", "{shortcut}" }
-            }
-        }
-    }
-}
-
-#[component]
-fn ContextMenuSeparator() -> Element {
-    rsx! {
-        div { class: "context-menu-separator" }
     }
 }

--- a/desktop/src/components/win_hamburger.rs
+++ b/desktop/src/components/win_hamburger.rs
@@ -1,6 +1,7 @@
 #![cfg(target_os = "windows")]
 
-use crate::components::icon::{Icon, IconName};
+use crate::components::context_menu::{ContextMenuItem, ContextMenuSeparator, ContextMenuSubmenu};
+use crate::components::icon::IconName;
 use crate::state::AppState;
 use dioxus::prelude::*;
 
@@ -35,228 +36,152 @@ pub fn WindowsMenu(on_close: EventHandler<()>) -> Element {
             onclick: move |evt| evt.stop_propagation(),
 
             // === Arto (App) ===
-            HeaderMenuItem { label: "About Arto", shortcut: shortcut("app.about"), on_click: move |_| {
+            ContextMenuItem { label: "About Arto", shortcut: shortcut("app.about"), on_click: move |_| {
                 crate::components::content::set_preferences_tab_to_about();
                 state.open_preferences();
                 close();
             } }
-            HeaderMenuItem { label: "Preferences...", shortcut: shortcut("file.preferences"), icon: Some(IconName::Gear), on_click: move |_| {
+            ContextMenuItem { label: "Preferences...", shortcut: shortcut("file.preferences"), icon: Some(IconName::Gear), on_click: move |_| {
                 state.open_preferences();
                 close();
             } }
 
-            HeaderMenuSeparator {}
+            ContextMenuSeparator {}
 
             // === File ===
-            HeaderSubmenu { label: "File",
-                HeaderMenuItem { label: "New Window", shortcut: shortcut("window.new"), on_click: move |_| {
+            ContextMenuSubmenu { label: "File",
+                ContextMenuItem { label: "New Window", shortcut: shortcut("window.new"), on_click: move |_| {
                     crate::window::create_main_window_sync(&dioxus::desktop::window(), crate::state::Tab::default(), crate::window::CreateMainWindowConfigParams::default());
                     close();
                 } }
-                HeaderMenuItem { label: "New Tab", shortcut: shortcut("tab.new"), icon: Some(IconName::Add), on_click: move |_| {
+                ContextMenuItem { label: "New Tab", shortcut: shortcut("tab.new"), icon: Some(IconName::Add), on_click: move |_| {
                     state.add_empty_tab(true);
                     close();
                 } }
-                HeaderMenuSeparator {}
-                HeaderMenuItem { label: "Open File...", shortcut: shortcut("file.open"), icon: Some(IconName::File), on_click: move |_| {
+                ContextMenuSeparator {}
+                ContextMenuItem { label: "Open File...", shortcut: shortcut("file.open"), icon: Some(IconName::File), on_click: move |_| {
                     if let Some(file) = rfd::FileDialog::new().add_filter("Markdown", &["md", "markdown"]).pick_file() {
                         state.open_file(file);
                     }
                     close();
                 } }
-                HeaderMenuItem { label: "Open Directory...", shortcut: shortcut("file.open_directory"), icon: Some(IconName::FolderOpen), on_click: move |_| {
+                ContextMenuItem { label: "Open Directory...", shortcut: shortcut("file.open_directory"), icon: Some(IconName::FolderOpen), on_click: move |_| {
                     if let Some(dir) = rfd::FileDialog::new().pick_folder() {
                         state.set_root_directory(dir);
                     }
                     close();
                 } }
-                HeaderMenuSeparator {}
-                HeaderMenuItem { label: "Copy File Path", shortcut: shortcut("clipboard.copy_file_path"), icon: Some(IconName::Copy), disabled: !has_file, on_click: { let f = current_file.clone(); move |_| {
+                ContextMenuSeparator {}
+                ContextMenuItem { label: "Copy File Path", shortcut: shortcut("clipboard.copy_file_path"), icon: Some(IconName::Copy), disabled: !has_file, on_click: { let f = current_file.clone(); move |_| {
                     if let Some(file) = &f { crate::utils::clipboard::copy_text(file.to_string_lossy()); }
                     close();
                 } } }
-                HeaderMenuItem { label: "Reveal in Finder", shortcut: shortcut("file.reveal_in_finder"), icon: Some(IconName::Folder), disabled: !has_file, on_click: { let f = current_file.clone(); move |_| {
+                ContextMenuItem { label: "Reveal in Finder", shortcut: shortcut("file.reveal_in_finder"), icon: Some(IconName::Folder), disabled: !has_file, on_click: { let f = current_file.clone(); move |_| {
                     if let Some(file) = &f { crate::utils::file_operations::reveal_in_finder(file); }
                     close();
                 } } }
-                HeaderMenuSeparator {}
-                HeaderMenuItem { label: "Close Tab", shortcut: shortcut("tab.close"), on_click: move |_| {
+                ContextMenuSeparator {}
+                ContextMenuItem { label: "Close Tab", shortcut: shortcut("tab.close"), on_click: move |_| {
                     let active = *state.active_tab.read();
                     state.close_tab(active);
                     close();
                 } }
-                HeaderMenuItem { label: "Close All Tabs", shortcut: shortcut("tab.close_all"), on_click: move |_| {
+                ContextMenuItem { label: "Close All Tabs", shortcut: shortcut("tab.close_all"), on_click: move |_| {
                     let mut tabs = state.tabs.write();
                     tabs.clear();
                     tabs.push(crate::state::Tab::default());
                     state.active_tab.set(0);
                     close();
                 } }
-                HeaderMenuItem { label: "Close Window", shortcut: shortcut("window.close"), on_click: move |_| {
+                ContextMenuItem { label: "Close Window", shortcut: shortcut("window.close"), on_click: move |_| {
                     dioxus::desktop::window().close();
                 } }
-                HeaderMenuSeparator {}
-                HeaderMenuItem { label: "Print...", shortcut: shortcut("file.print"), on_click: { let f = current_file.clone(); move |_| {
+                ContextMenuSeparator {}
+                ContextMenuItem { label: "Print...", shortcut: shortcut("file.print"), on_click: { let f = current_file.clone(); move |_| {
                     close();
                     crate::utils::print::print_window(f.clone());
                 } } }
             }
 
             // === Edit ===
-            HeaderSubmenu { label: "Edit",
-                HeaderMenuItem { label: "Find...", shortcut: shortcut("search.open"), icon: Some(IconName::Search), on_click: move |_| {
+            ContextMenuSubmenu { label: "Edit",
+                ContextMenuItem { label: "Find...", shortcut: shortcut("search.open"), icon: Some(IconName::Search), on_click: move |_| {
                     state.open_search_with_text(None);
                     close();
                 } }
-                HeaderMenuItem { label: "Find Next", shortcut: shortcut("search.next"), on_click: move |_| {
+                ContextMenuItem { label: "Find Next", shortcut: shortcut("search.next"), on_click: move |_| {
                     spawn(async move { let _ = document::eval("window.Arto.search.navigate('next')").await; });
                     close();
                 } }
-                HeaderMenuItem { label: "Find Previous", shortcut: shortcut("search.prev"), on_click: move |_| {
+                ContextMenuItem { label: "Find Previous", shortcut: shortcut("search.prev"), on_click: move |_| {
                     spawn(async move { let _ = document::eval("window.Arto.search.navigate('prev')").await; });
                     close();
                 } }
             }
 
             // === View ===
-            HeaderSubmenu { label: "View",
-                HeaderMenuItem { label: "Toggle Left Sidebar", shortcut: shortcut("window.toggle_sidebar"), icon: Some(IconName::Sidebar), on_click: move |_| {
+            ContextMenuSubmenu { label: "View",
+                ContextMenuItem { label: "Toggle Left Sidebar", shortcut: shortcut("window.toggle_sidebar"), icon: Some(IconName::Sidebar), on_click: move |_| {
                     state.toggle_sidebar();
                     close();
                 } }
-                HeaderMenuItem { label: "Toggle Right Sidebar", shortcut: shortcut("window.toggle_right_sidebar"), icon: Some(IconName::List), on_click: move |_| {
+                ContextMenuItem { label: "Toggle Right Sidebar", shortcut: shortcut("window.toggle_right_sidebar"), icon: Some(IconName::List), on_click: move |_| {
                     state.toggle_right_sidebar();
                     close();
                 } }
-                HeaderMenuSeparator {}
-                HeaderMenuItem { label: "Actual Size", shortcut: shortcut("zoom.reset"), on_click: move |_| {
-                    state.zoom_level.set(1.0);
+                ContextMenuSeparator {}
+                ContextMenuItem { label: "Actual Size", shortcut: shortcut("zoom.reset"), on_click: move |_| {
+                    state.zoom_reset();
                     close();
                 } }
-                HeaderMenuItem { label: "Zoom In", shortcut: shortcut("zoom.in"), icon: Some(IconName::Add), on_click: move |_| {
-                    let current = crate::window::settings::normalize_zoom_level(*state.zoom_level.read());
-                    state.zoom_level.set(crate::window::settings::normalize_zoom_level(current + 0.1));
+                ContextMenuItem { label: "Zoom In", shortcut: shortcut("zoom.in"), icon: Some(IconName::Add), on_click: move |_| {
+                    state.zoom_in();
                     close();
                 } }
-                HeaderMenuItem { label: "Zoom Out", shortcut: shortcut("zoom.out"), on_click: move |_| {
-                    let current = crate::window::settings::normalize_zoom_level(*state.zoom_level.read());
-                    state.zoom_level.set(crate::window::settings::normalize_zoom_level(current - 0.1));
+                ContextMenuItem { label: "Zoom Out", shortcut: shortcut("zoom.out"), on_click: move |_| {
+                    state.zoom_out();
                     close();
                 } }
             }
 
             // === History ===
-            HeaderSubmenu { label: "History",
-                HeaderMenuItem { label: "Go Back", shortcut: shortcut("history.back"), icon: Some(IconName::ChevronLeft), on_click: move |_| {
+            ContextMenuSubmenu { label: "History",
+                ContextMenuItem { label: "Go Back", shortcut: shortcut("history.back"), icon: Some(IconName::ChevronLeft), on_click: move |_| {
                     state.save_scroll_and_go_back();
                     close();
                 } }
-                HeaderMenuItem { label: "Go Forward", shortcut: shortcut("history.forward"), icon: Some(IconName::ChevronRight), on_click: move |_| {
+                ContextMenuItem { label: "Go Forward", shortcut: shortcut("history.forward"), icon: Some(IconName::ChevronRight), on_click: move |_| {
                     state.save_scroll_and_go_forward();
                     close();
                 } }
             }
 
             // === Window ===
-            HeaderSubmenu { label: "Window",
-                HeaderMenuItem { label: "Close All Child Windows", shortcut: shortcut("window.close_all_child_windows"), on_click: move |_| {
+            ContextMenuSubmenu { label: "Window",
+                ContextMenuItem { label: "Close All Child Windows", shortcut: shortcut("window.close_all_child_windows"), on_click: move |_| {
                     crate::window::close_child_windows_for_last_focused();
                     close();
                 } }
-                HeaderMenuItem { label: "Close All Windows", shortcut: shortcut("window.close_all_windows"), on_click: move |_| {
+                ContextMenuItem { label: "Close All Windows", shortcut: shortcut("window.close_all_windows"), on_click: move |_| {
                     crate::window::close_all_main_windows();
                     close();
                 } }
             }
 
             // === Help ===
-            HeaderSubmenu { label: "Help",
-                HeaderMenuItem { label: "Go to Homepage", shortcut: shortcut("app.go_to_homepage"), icon: Some(IconName::ExternalLink), on_click: move |_| {
+            ContextMenuSubmenu { label: "Help",
+                ContextMenuItem { label: "Go to Homepage", shortcut: shortcut("app.go_to_homepage"), icon: Some(IconName::ExternalLink), on_click: move |_| {
                     let _ = open::that("https://github.com/arto-app/Arto");
                     close();
                 } }
             }
 
-            HeaderMenuSeparator {}
+            ContextMenuSeparator {}
 
             // === Quit ===
-            HeaderMenuItem { label: "Quit", icon: Some(IconName::Close), on_click: move |_| {
+            ContextMenuItem { label: "Quit", icon: Some(IconName::Close), on_click: move |_| {
                 crate::window::shutdown_all_windows();
             } }
         }
-    }
-}
-
-// Component for expanding submenus
-#[component]
-fn HeaderSubmenu(#[props(into)] label: String, children: Element) -> Element {
-    let mut show = use_signal(|| false);
-
-    rsx! {
-        div {
-            class: "context-menu-item has-submenu",
-            onmouseenter: move |_| show.set(true),
-            onmouseleave: move |_| show.set(false),
-
-            span { class: "context-menu-label", "{label}" }
-            span { class: "submenu-arrow", "›" }
-
-            if *show.read() {
-                div {
-                    class: "context-submenu",
-                    {children}
-                }
-            }
-        }
-    }
-}
-
-#[derive(Props, Clone, PartialEq)]
-struct HeaderMenuItemProps {
-    #[props(into)]
-    label: String,
-    #[props(default)]
-    icon: Option<IconName>,
-    #[props(default)]
-    shortcut: Option<String>,
-    #[props(default = false)]
-    disabled: bool,
-    on_click: EventHandler<()>,
-}
-
-#[component]
-fn HeaderMenuItem(props: HeaderMenuItemProps) -> Element {
-    let on_click = props.on_click;
-    let disabled = props.disabled;
-
-    rsx! {
-        div {
-            class: if disabled { "context-menu-item disabled" } else { "context-menu-item" },
-            onclick: move |_| {
-                if !disabled {
-                    on_click.call(());
-                }
-            },
-
-            if let Some(icon) = props.icon {
-                Icon {
-                    name: icon,
-                    size: 14,
-                    class: "context-menu-icon",
-                }
-            }
-            span { class: "context-menu-label", "{props.label}" }
-
-            if let Some(shortcut) = props.shortcut {
-                span { class: "context-menu-shortcut", "{shortcut}" }
-            }
-        }
-    }
-}
-
-#[component]
-fn HeaderMenuSeparator() -> Element {
-    rsx! {
-        div { class: "context-menu-separator" }
     }
 }

--- a/desktop/src/config/app_config.rs
+++ b/desktop/src/config/app_config.rs
@@ -19,14 +19,17 @@ pub use file_open_behavior::FileOpenBehavior;
 pub use keybindings_config::{BindingSet, KeyAction};
 pub use markdown_config::MarkdownConfig;
 pub use right_sidebar_config::{RightSidebarConfig, DEFAULT_RIGHT_SIDEBAR_WIDTH};
-pub use sidebar_config::{normalize_zoom_level, SidebarConfig};
+pub use sidebar_config::SidebarConfig;
 pub use theme_config::ThemeConfig;
 pub use window_dimension::{WindowDimension, WindowDimensionUnit};
 pub use window_position_config::{
     WindowPosition, WindowPositionConfig, WindowPositionMode, WindowPositionOffset,
 };
 pub use window_size_config::{WindowSize, WindowSizeConfig};
-pub use zoom_config::ZoomConfig;
+pub use zoom_config::{
+    normalize_content_zoom, normalize_sidebar_zoom, ZoomConfig, DEFAULT_ZOOM_LEVEL,
+    MAX_SIDEBAR_ZOOM, MIN_SIDEBAR_ZOOM, ZOOM_STEP,
+};
 
 /// Global application configuration
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]

--- a/desktop/src/config/app_config/right_sidebar_config.rs
+++ b/desktop/src/config/app_config/right_sidebar_config.rs
@@ -1,19 +1,17 @@
 use super::behavior::{NewWindowBehavior, StartupBehavior};
+use super::zoom_config::DEFAULT_ZOOM_LEVEL;
 use crate::components::right_sidebar::RightSidebarTab;
 use serde::{Deserialize, Serialize};
 
 /// Default right sidebar panel width in pixels
 pub const DEFAULT_RIGHT_SIDEBAR_WIDTH: f64 = 220.0;
 
-/// Default right sidebar zoom level
-pub const DEFAULT_RIGHT_SIDEBAR_ZOOM_LEVEL: f64 = 1.0;
-
 fn default_right_sidebar_width() -> f64 {
     DEFAULT_RIGHT_SIDEBAR_WIDTH
 }
 
 fn default_right_sidebar_zoom_level() -> f64 {
-    DEFAULT_RIGHT_SIDEBAR_ZOOM_LEVEL
+    DEFAULT_ZOOM_LEVEL
 }
 
 /// Configuration for right sidebar panel settings

--- a/desktop/src/config/app_config/sidebar_config.rs
+++ b/desktop/src/config/app_config/sidebar_config.rs
@@ -1,38 +1,16 @@
 use super::behavior::{NewWindowBehavior, StartupBehavior};
+use super::zoom_config::DEFAULT_ZOOM_LEVEL;
 use serde::{Deserialize, Serialize};
 
 /// Default sidebar width in pixels
 pub const DEFAULT_SIDEBAR_WIDTH: f64 = 280.0;
-
-/// Default sidebar zoom level
-pub const DEFAULT_SIDEBAR_ZOOM_LEVEL: f64 = 1.0;
-
-/// Minimum zoom level for sidebar
-pub const MIN_SIDEBAR_ZOOM: f64 = 0.5;
-
-/// Maximum zoom level for sidebar
-pub const MAX_SIDEBAR_ZOOM: f64 = 2.0;
-
-/// Zoom step for sidebar (0.1 increments)
-pub const ZOOM_STEP: f64 = 0.1;
 
 fn default_sidebar_width() -> f64 {
     DEFAULT_SIDEBAR_WIDTH
 }
 
 fn default_sidebar_zoom_level() -> f64 {
-    DEFAULT_SIDEBAR_ZOOM_LEVEL
-}
-
-/// Normalize and clamp zoom level to valid range with 0.1 step
-pub fn normalize_zoom_level(zoom: f64) -> f64 {
-    if zoom.is_nan() || zoom.is_infinite() {
-        return DEFAULT_SIDEBAR_ZOOM_LEVEL;
-    }
-    // Clamp to valid range
-    let clamped = zoom.clamp(MIN_SIDEBAR_ZOOM, MAX_SIDEBAR_ZOOM);
-    // Snap to 0.1 step
-    (clamped / ZOOM_STEP).round() * ZOOM_STEP
+    DEFAULT_ZOOM_LEVEL
 }
 
 /// Configuration for sidebar-related settings

--- a/desktop/src/config/app_config/zoom_config.rs
+++ b/desktop/src/config/app_config/zoom_config.rs
@@ -2,8 +2,46 @@ use serde::{Deserialize, Serialize};
 
 use super::behavior::{NewWindowBehavior, StartupBehavior};
 
+/// Neutral zoom level (100%), used as the default and as the fallback for
+/// non-finite input.
+pub const DEFAULT_ZOOM_LEVEL: f64 = 1.0;
+
+/// Zoom range for the content area. Content tolerates far more magnification
+/// than the sidebars, whose fixed-width chrome breaks down past 2x.
+pub const MIN_CONTENT_ZOOM: f64 = 0.5;
+pub const MAX_CONTENT_ZOOM: f64 = 5.0;
+
+/// Zoom range for the left and right sidebar panels.
+pub const MIN_SIDEBAR_ZOOM: f64 = 0.5;
+pub const MAX_SIDEBAR_ZOOM: f64 = 2.0;
+
+/// Increment applied by a single zoom in/out action. Normalization snaps to
+/// this same grid.
+pub const ZOOM_STEP: f64 = 0.1;
+
 fn default_zoom_level() -> f64 {
-    1.0
+    DEFAULT_ZOOM_LEVEL
+}
+
+/// Snap to the nearest 0.1 step and clamp into `[min, max]`.
+///
+/// Snapping prevents precision drift from repeated zoom in/out steps, so the
+/// level stays on the same grid the menu and keybinding actions move along.
+fn normalize_zoom(zoom: f64, min: f64, max: f64) -> f64 {
+    if !zoom.is_finite() {
+        return DEFAULT_ZOOM_LEVEL;
+    }
+    ((zoom * 10.0).round() / 10.0).clamp(min, max)
+}
+
+/// Normalize a content-area zoom level.
+pub fn normalize_content_zoom(zoom: f64) -> f64 {
+    normalize_zoom(zoom, MIN_CONTENT_ZOOM, MAX_CONTENT_ZOOM)
+}
+
+/// Normalize a sidebar panel zoom level.
+pub fn normalize_sidebar_zoom(zoom: f64) -> f64 {
+    normalize_zoom(zoom, MIN_SIDEBAR_ZOOM, MAX_SIDEBAR_ZOOM)
 }
 
 /// Configuration for zoom-related settings
@@ -23,9 +61,50 @@ pub struct ZoomConfig {
 impl Default for ZoomConfig {
     fn default() -> Self {
         Self {
-            default_zoom_level: 1.0,
+            default_zoom_level: DEFAULT_ZOOM_LEVEL,
             on_startup: StartupBehavior::default(),
             on_new_window: NewWindowBehavior::default(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn content_zoom_rounds_to_nearest_tenth() {
+        assert_eq!(normalize_content_zoom(1.05), 1.1);
+        assert_eq!(normalize_content_zoom(1.04), 1.0);
+        assert_eq!(normalize_content_zoom(1.95), 2.0);
+        assert_eq!(normalize_content_zoom(0.99), 1.0);
+    }
+
+    #[test]
+    fn content_zoom_clamps_to_range() {
+        assert_eq!(normalize_content_zoom(0.3), MIN_CONTENT_ZOOM);
+        assert_eq!(normalize_content_zoom(10.0), MAX_CONTENT_ZOOM);
+        assert_eq!(normalize_content_zoom(-1.0), MIN_CONTENT_ZOOM);
+    }
+
+    #[test]
+    fn sidebar_zoom_clamps_tighter_than_content() {
+        // 3.0 is a valid content zoom but past the sidebar ceiling.
+        assert_eq!(normalize_content_zoom(3.0), 3.0);
+        assert_eq!(normalize_sidebar_zoom(3.0), MAX_SIDEBAR_ZOOM);
+    }
+
+    #[test]
+    fn non_finite_zoom_falls_back_to_default() {
+        assert_eq!(normalize_content_zoom(f64::NAN), DEFAULT_ZOOM_LEVEL);
+        assert_eq!(normalize_content_zoom(f64::INFINITY), DEFAULT_ZOOM_LEVEL);
+        assert_eq!(normalize_sidebar_zoom(f64::NAN), DEFAULT_ZOOM_LEVEL);
+    }
+
+    #[test]
+    fn aligned_values_are_preserved() {
+        assert_eq!(normalize_content_zoom(1.0), 1.0);
+        assert_eq!(normalize_content_zoom(1.5), 1.5);
+        assert_eq!(normalize_sidebar_zoom(2.0), 2.0);
     }
 }

--- a/desktop/src/keybindings/dispatcher.rs
+++ b/desktop/src/keybindings/dispatcher.rs
@@ -6,7 +6,6 @@ use crate::pinned_search::add_pinned_search;
 use crate::state::sidebar_cursor;
 use crate::state::{AppState, FocusedPanel};
 use crate::theme::Theme;
-use crate::window::settings::normalize_zoom_level;
 
 use super::action::Action;
 
@@ -69,17 +68,9 @@ pub fn dispatch_action(action: &Action, mut state: AppState) {
         Action::SearchPinCurrent => search_pin_current(&mut state),
 
         // --- Zoom ---
-        Action::ZoomIn => {
-            let current = normalize_zoom_level(*state.zoom_level.read());
-            state.zoom_level.set(normalize_zoom_level(current + 0.1));
-        }
-        Action::ZoomOut => {
-            let current = normalize_zoom_level(*state.zoom_level.read());
-            state.zoom_level.set(normalize_zoom_level(current - 0.1));
-        }
-        Action::ZoomReset => {
-            state.zoom_level.set(1.0);
-        }
+        Action::ZoomIn => state.zoom_in(),
+        Action::ZoomOut => state.zoom_out(),
+        Action::ZoomReset => state.zoom_reset(),
 
         // --- Window ---
         Action::WindowNew => {
@@ -110,7 +101,7 @@ pub fn dispatch_action(action: &Action, mut state: AppState) {
             }
         }
         Action::WindowToggleRightSidebar => {
-            let closing = *state.right_sidebar_pinned.read();
+            let closing = state.right_sidebar.read().pinned;
             state.toggle_right_sidebar();
             if closing && *state.focused_panel.read() == FocusedPanel::RightSidebar {
                 state.focused_panel.set(FocusedPanel::Content);
@@ -172,7 +163,7 @@ pub fn dispatch_action(action: &Action, mut state: AppState) {
         }
         Action::FocusRightSidebar => {
             // Show overlay if not pinned, then focus it
-            if !*state.right_sidebar_pinned.read() {
+            if !state.right_sidebar.read().pinned {
                 state.right_hover_active.set(true);
                 state.left_hover_active.set(false);
             }
@@ -277,7 +268,7 @@ pub fn dispatch_action(action: &Action, mut state: AppState) {
 
         // --- Right sidebar ---
         Action::RightSidebarShowContents => {
-            if !*state.right_sidebar_pinned.read() {
+            if !state.right_sidebar.read().pinned {
                 state.right_hover_active.set(true);
                 state.left_hover_active.set(false);
             }
@@ -285,7 +276,7 @@ pub fn dispatch_action(action: &Action, mut state: AppState) {
             state.focused_panel.set(FocusedPanel::RightSidebar);
         }
         Action::RightSidebarShowSearch => {
-            if !*state.right_sidebar_pinned.read() {
+            if !state.right_sidebar.read().pinned {
                 state.right_hover_active.set(true);
                 state.left_hover_active.set(false);
             }
@@ -345,7 +336,7 @@ fn dispatch_tab_cycle(state: &mut AppState, forward: bool) {
 
 /// Cycle the right sidebar between Contents and Search tabs.
 fn toggle_right_sidebar_tab(state: &mut AppState) {
-    let tab = match *state.right_sidebar_tab.read() {
+    let tab = match state.right_sidebar.read().tab {
         RightSidebarTab::Contents => RightSidebarTab::Search,
         RightSidebarTab::Search => RightSidebarTab::Contents,
     };

--- a/desktop/src/state/app_state.rs
+++ b/desktop/src/state/app_state.rs
@@ -3,19 +3,20 @@ use dioxus::prelude::*;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use crate::components::right_sidebar::RightSidebarTab;
 use crate::components::sidebar::context_menu::SidebarContextMenuData;
-use crate::config::DEFAULT_RIGHT_SIDEBAR_WIDTH;
+use crate::config::{normalize_content_zoom, DEFAULT_ZOOM_LEVEL, ZOOM_STEP};
 use crate::markdown::HeadingInfo;
 use crate::pinned_search::PinnedSearchId;
 use crate::theme::Theme;
 
 mod focused_panel;
+mod right_sidebar;
 mod sidebar;
 pub(crate) mod sidebar_cursor;
 mod tabs;
 
 pub use focused_panel::*;
+pub use right_sidebar::RightSidebar;
 pub use sidebar::Sidebar;
 pub use tabs::{Tab, TabContent};
 
@@ -64,10 +65,7 @@ pub struct AppState {
     /// Whether the content area ignores the markdown body's max-width and fills the pane.
     pub content_full_width: Signal<bool>,
     pub sidebar: Signal<Sidebar>,
-    pub right_sidebar_pinned: Signal<bool>,
-    pub right_sidebar_width: Signal<f64>,
-    pub right_sidebar_tab: Signal<RightSidebarTab>,
-    pub right_sidebar_zoom_level: Signal<f64>,
+    pub right_sidebar: Signal<RightSidebar>,
     pub right_sidebar_headings: Signal<Vec<HeadingInfo>>,
     pub position: Signal<LogicalPosition<i32>>,
     pub size: Signal<LogicalSize<u32>>,
@@ -131,13 +129,10 @@ impl AppState {
             tabs: Signal::new(vec![Tab::default()]),
             active_tab: Signal::new(0),
             current_theme: Signal::new(theme),
-            zoom_level: Signal::new(1.0),
+            zoom_level: Signal::new(DEFAULT_ZOOM_LEVEL),
             content_full_width: Signal::new(false),
             sidebar: Signal::new(Sidebar::default()),
-            right_sidebar_pinned: Signal::new(false),
-            right_sidebar_width: Signal::new(DEFAULT_RIGHT_SIDEBAR_WIDTH),
-            right_sidebar_tab: Signal::new(RightSidebarTab::default()),
-            right_sidebar_zoom_level: Signal::new(1.0),
+            right_sidebar: Signal::new(RightSidebar::default()),
             right_sidebar_headings: Signal::new(Vec::new()),
             position: Signal::new(Default::default()),
             size: Signal::new(Default::default()),
@@ -226,23 +221,26 @@ impl AppState {
         self.content_full_width.set(!was_full_width);
     }
 
-    /// Toggle right sidebar between pinned (flex layout) and unpinned (overlay/hover).
-    ///
-    /// - Pinned: visible in flex layout, pushes content aside
-    /// - Unpinned: accessible via hover as an overlay
-    pub fn toggle_right_sidebar(&mut self) {
-        let was_pinned = *self.right_sidebar_pinned.read();
-        self.right_sidebar_pinned.set(!was_pinned);
+    /// Zoom the content area in by one step.
+    pub fn zoom_in(&mut self) {
+        self.step_zoom(ZOOM_STEP);
     }
 
-    /// Set right sidebar width
-    pub fn set_right_sidebar_width(&mut self, width: f64) {
-        self.right_sidebar_width.set(width);
+    /// Zoom the content area out by one step.
+    pub fn zoom_out(&mut self) {
+        self.step_zoom(-ZOOM_STEP);
     }
 
-    /// Set right sidebar active tab
-    pub fn set_right_sidebar_tab(&mut self, tab: RightSidebarTab) {
-        self.right_sidebar_tab.set(tab);
+    /// Restore the content area to its neutral zoom level.
+    pub fn zoom_reset(&mut self) {
+        self.zoom_level.set(DEFAULT_ZOOM_LEVEL);
+    }
+
+    /// Move the content zoom by `delta`, normalizing before and after so the
+    /// level stays on the 0.1 grid even if it drifted.
+    fn step_zoom(&mut self, delta: f64) {
+        let current = normalize_content_zoom(*self.zoom_level.read());
+        self.zoom_level.set(normalize_content_zoom(current + delta));
     }
 
     /// Toggle search bar visibility

--- a/desktop/src/state/app_state/right_sidebar.rs
+++ b/desktop/src/state/app_state/right_sidebar.rs
@@ -1,0 +1,108 @@
+use super::AppState;
+use crate::components::right_sidebar::RightSidebarTab;
+use crate::config::DEFAULT_RIGHT_SIDEBAR_WIDTH;
+use dioxus::prelude::*;
+
+/// Represents the state of the right sidebar panel (table of contents / search).
+///
+/// Mirrors [`super::Sidebar`] so both panels are shaped the same way. The
+/// rendered headings live in `AppState` instead of here because they are
+/// derived from the active document, not a user preference.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RightSidebar {
+    pub pinned: bool,
+    pub width: f64,
+    pub tab: RightSidebarTab,
+    pub zoom_level: f64,
+}
+
+impl Default for RightSidebar {
+    fn default() -> Self {
+        Self {
+            pinned: false,
+            width: DEFAULT_RIGHT_SIDEBAR_WIDTH,
+            tab: RightSidebarTab::default(),
+            zoom_level: 1.0,
+        }
+    }
+}
+
+impl AppState {
+    /// Toggle right sidebar between pinned (flex layout) and unpinned (overlay/hover).
+    ///
+    /// - Pinned: visible in flex layout, pushes content aside
+    /// - Unpinned: accessible via hover as an overlay
+    pub fn toggle_right_sidebar(&mut self) {
+        let mut right_sidebar = self.right_sidebar.write();
+        right_sidebar.pinned = !right_sidebar.pinned;
+    }
+
+    /// Set right sidebar width
+    pub fn set_right_sidebar_width(&mut self, width: f64) {
+        self.right_sidebar.write().width = width;
+    }
+
+    /// Set right sidebar active tab
+    pub fn set_right_sidebar_tab(&mut self, tab: RightSidebarTab) {
+        self.right_sidebar.write().tab = tab;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_right_sidebar_default() {
+        let right_sidebar = RightSidebar::default();
+
+        assert!(!right_sidebar.pinned);
+        assert_eq!(right_sidebar.width, DEFAULT_RIGHT_SIDEBAR_WIDTH);
+        assert_eq!(right_sidebar.tab, RightSidebarTab::default());
+        assert_eq!(right_sidebar.zoom_level, 1.0);
+    }
+
+    /// Simulates the toggle logic from `AppState::toggle_right_sidebar()`.
+    /// The actual method operates on `Signal<RightSidebar>`, but the state
+    /// transition logic is identical.
+    fn apply_toggle(right_sidebar: &mut RightSidebar) {
+        right_sidebar.pinned = !right_sidebar.pinned;
+    }
+
+    #[test]
+    fn test_right_toggle_from_unpinned_to_pinned() {
+        let mut right_sidebar = RightSidebar::default();
+        assert!(!right_sidebar.pinned);
+
+        apply_toggle(&mut right_sidebar);
+        assert!(right_sidebar.pinned);
+    }
+
+    #[test]
+    fn test_right_toggle_from_pinned_to_unpinned() {
+        let mut right_sidebar = RightSidebar {
+            pinned: true,
+            ..Default::default()
+        };
+
+        apply_toggle(&mut right_sidebar);
+        assert!(!right_sidebar.pinned);
+    }
+
+    #[test]
+    fn test_right_toggle_full_cycle() {
+        let mut right_sidebar = RightSidebar::default();
+
+        apply_toggle(&mut right_sidebar);
+        assert!(right_sidebar.pinned);
+
+        apply_toggle(&mut right_sidebar);
+        assert!(!right_sidebar.pinned);
+
+        apply_toggle(&mut right_sidebar);
+        assert!(right_sidebar.pinned);
+
+        apply_toggle(&mut right_sidebar);
+        assert!(!right_sidebar.pinned);
+    }
+}

--- a/desktop/src/state/app_state/sidebar.rs
+++ b/desktop/src/state/app_state/sidebar.rs
@@ -186,44 +186,6 @@ mod tests {
         assert!(!sidebar.pinned);
     }
 
-    /// Simulates the toggle logic from `AppState::toggle_right_sidebar()`.
-    /// The actual method operates on `Signal<bool>`, but the state
-    /// transition logic is identical to the left sidebar.
-    fn apply_right_toggle(pinned: &mut bool) {
-        *pinned = !*pinned;
-    }
-
-    #[test]
-    fn test_right_toggle_from_unpinned_to_pinned() {
-        let mut pinned = false;
-        apply_right_toggle(&mut pinned);
-        assert!(pinned);
-    }
-
-    #[test]
-    fn test_right_toggle_from_pinned_to_unpinned() {
-        let mut pinned = true;
-        apply_right_toggle(&mut pinned);
-        assert!(!pinned);
-    }
-
-    #[test]
-    fn test_right_toggle_full_cycle() {
-        let mut pinned = false;
-
-        apply_right_toggle(&mut pinned);
-        assert!(pinned);
-
-        apply_right_toggle(&mut pinned);
-        assert!(!pinned);
-
-        apply_right_toggle(&mut pinned);
-        assert!(pinned);
-
-        apply_right_toggle(&mut pinned);
-        assert!(!pinned);
-    }
-
     #[test]
     fn test_sidebar_history_initial_state() {
         let sidebar = Sidebar::default();

--- a/desktop/src/state/app_state/tabs/file_ops.rs
+++ b/desktop/src/state/app_state/tabs/file_ops.rs
@@ -40,7 +40,7 @@ impl AppState {
     pub fn open_preferences(&mut self) {
         // Unpin both sidebars and close overlays (preferences is a full-screen settings page)
         self.sidebar.write().pinned = false;
-        self.right_sidebar_pinned.set(false);
+        self.right_sidebar.write().pinned = false;
         self.left_hover_active.set(false);
         self.right_hover_active.set(false);
 

--- a/desktop/src/state/persistence.rs
+++ b/desktop/src/state/persistence.rs
@@ -95,6 +95,7 @@ impl Default for PersistedState {
 impl From<&AppState> for PersistedState {
     fn from(state: &AppState) -> Self {
         let sidebar = state.sidebar.read();
+        let right_sidebar = state.right_sidebar.read();
         Self {
             directory: sidebar.root_directory.clone(),
             theme: *state.current_theme.read(),
@@ -103,10 +104,10 @@ impl From<&AppState> for PersistedState {
             sidebar_width: sidebar.width,
             sidebar_show_all_files: sidebar.show_all_files,
             sidebar_zoom_level: sidebar.zoom_level,
-            right_sidebar_pinned: *state.right_sidebar_pinned.read(),
-            right_sidebar_width: *state.right_sidebar_width.read(),
-            right_sidebar_tab: *state.right_sidebar_tab.read(),
-            right_sidebar_zoom_level: *state.right_sidebar_zoom_level.read(),
+            right_sidebar_pinned: right_sidebar.pinned,
+            right_sidebar_width: right_sidebar.width,
+            right_sidebar_tab: right_sidebar.tab,
+            right_sidebar_zoom_level: right_sidebar.zoom_level,
             window_position: (*state.position.read()).into(),
             window_size: (*state.size.read()).into(),
             zoom_level: *state.zoom_level.read(),

--- a/desktop/src/window/settings.rs
+++ b/desktop/src/window/settings.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 
 use crate::components::right_sidebar::RightSidebarTab;
 use crate::config::{
-    normalize_zoom_level as normalize_sidebar_zoom_level, NewWindowBehavior, StartupBehavior,
+    normalize_content_zoom, normalize_sidebar_zoom, NewWindowBehavior, StartupBehavior,
     WindowDimension, WindowDimensionUnit, WindowPosition, WindowPositionMode, WindowSize, CONFIG,
 };
 use crate::state::{PersistedState, Position, Size};
@@ -17,16 +17,6 @@ use crate::utils::screen::{
 use crate::window::main::get_last_focused_window_state;
 
 const MIN_WINDOW_DIMENSION: f64 = 100.0;
-
-// ============================================================================
-// Zoom Helpers
-// ============================================================================
-
-/// Normalize zoom level to the nearest 0.1 step to prevent precision drift
-/// and ensure consistent behavior with menu zoom in/out actions.
-pub fn normalize_zoom_level(zoom: f64) -> f64 {
-    ((zoom * 10.0).round() / 10.0).clamp(0.5, 5.0)
-}
 
 // ============================================================================
 // Preference Types
@@ -329,7 +319,7 @@ pub fn get_sidebar_preference(is_first_window: bool) -> SidebarPreference {
     );
     // Normalize zoom level to valid range with 0.1 step
     SidebarPreference {
-        zoom_level: normalize_sidebar_zoom_level(pref.zoom_level),
+        zoom_level: normalize_sidebar_zoom(pref.zoom_level),
         ..pref
     }
 }
@@ -348,11 +338,14 @@ pub fn get_right_sidebar_preference(is_first_window: bool) -> RightSidebarPrefer
         },
         || {
             resolve_from_state_or_persisted(
-                |state| RightSidebarPreference {
-                    pinned: *state.right_sidebar_pinned.read(),
-                    width: *state.right_sidebar_width.read(),
-                    tab: *state.right_sidebar_tab.read(),
-                    zoom_level: *state.right_sidebar_zoom_level.read(),
+                |state| {
+                    let right_sidebar = state.right_sidebar.read();
+                    RightSidebarPreference {
+                        pinned: right_sidebar.pinned,
+                        width: right_sidebar.width,
+                        tab: right_sidebar.tab,
+                        zoom_level: right_sidebar.zoom_level,
+                    }
                 },
                 |persisted| RightSidebarPreference {
                     pinned: persisted.right_sidebar_pinned,
@@ -365,7 +358,7 @@ pub fn get_right_sidebar_preference(is_first_window: bool) -> RightSidebarPrefer
     );
     // Normalize zoom level to valid range with 0.1 step
     RightSidebarPreference {
-        zoom_level: normalize_sidebar_zoom_level(pref.zoom_level),
+        zoom_level: normalize_sidebar_zoom(pref.zoom_level),
         ..pref
     }
 }
@@ -398,7 +391,7 @@ pub fn get_zoom_preference(is_first_window: bool) -> ZoomPreference {
     );
     // Normalize to 0.1 step grid and clamp to safe range
     ZoomPreference {
-        zoom_level: normalize_zoom_level(zoom_level),
+        zoom_level: normalize_content_zoom(zoom_level),
     }
 }
 
@@ -667,27 +660,5 @@ mod tests {
         let resolved = resolve_window_size(size, LogicalSize::new(1200, 900));
         assert_eq!(resolved.width, 1200);
         assert_eq!(resolved.height, 900);
-    }
-
-    #[test]
-    fn test_normalize_zoom_level_rounds_to_nearest_tenth() {
-        assert_eq!(normalize_zoom_level(1.05), 1.1);
-        assert_eq!(normalize_zoom_level(1.04), 1.0);
-        assert_eq!(normalize_zoom_level(1.95), 2.0);
-        assert_eq!(normalize_zoom_level(0.99), 1.0);
-    }
-
-    #[test]
-    fn test_normalize_zoom_level_clamps_to_range() {
-        assert_eq!(normalize_zoom_level(0.3), 0.5);
-        assert_eq!(normalize_zoom_level(10.0), 5.0);
-        assert_eq!(normalize_zoom_level(-1.0), 0.5);
-    }
-
-    #[test]
-    fn test_normalize_zoom_level_preserves_aligned_values() {
-        assert_eq!(normalize_zoom_level(1.0), 1.0);
-        assert_eq!(normalize_zoom_level(1.5), 1.5);
-        assert_eq!(normalize_zoom_level(2.0), 2.0);
     }
 }


### PR DESCRIPTION
## Why

Three pieces of duplication that had drifted apart, found while looking for refactoring targets.

1. **The right sidebar had a different shape from the left one.** `AppState` spelled it out as four flat signals (`right_sidebar_pinned/width/tab/zoom_level`) while the left sidebar was a single `Signal<Sidebar>`. Every right-sidebar setting had to be threaded separately through `AppState`, `PersistedState`, the preference resolver and the preferences tab.
2. **Three byte-identical copies of the context-menu components** lived under `content/`, `tab/` and `sidebar/`, and the viewport clamping helpers existed only in `sidebar/` — so only the sidebar menu stayed on screen near a viewport edge.
3. **Two different functions named `normalize_zoom_level`** with different clamp ranges (0.5–2.0 for sidebars, 0.5–5.0 for content), distinguished only by which module a caller imported from. Picking the wrong one was invisible to the type system.

## What changed

- `RightSidebar` mirrors `Sidebar`; the right-sidebar methods move next to it the way `sidebar.rs` already holds `toggle_sidebar`.
- `components/context_menu/` holds one item/separator/submenu implementation plus the clamping helpers. Four call sites now share it — including the Windows hamburger menu, which is `cfg`-gated and was a fourth copy.
- `zoom_config.rs` owns `normalize_sidebar_zoom` and `normalize_content_zoom` next to the range constants the preferences sliders now share. `AppState` gains `zoom_in`/`zoom_out`/`zoom_reset` so the step arithmetic is not duplicated between the keybinding dispatcher and the Windows menu.

## Compatibility

On-disk formats are deliberately unchanged. `state.json` keeps its `rightSidebar*` keys and `config.json` keeps `RightSidebarConfig`, so files already on users' disks keep loading; `From<&AppState> for PersistedState` absorbs the mapping.

## Behavior changes

Two follow from unifying the two zoom normalizers:

- Non-finite input now falls back to `1.0` instead of propagating `NaN` through a `clamp`.
- Sidebar zoom snaps via `(x * 10.0).round() / 10.0` rather than `(x / 0.1).round() * 0.1`. The new form is closer to the intended 0.1 grid but moves values such as `1.05` from `1.0` to `1.1`, so a persisted sidebar zoom can normalize differently on load.

Collapsing four signals into one also coarsens reactivity: a component reading only `pinned` now re-renders when `width` changes during a resize drag. This is exactly what the left sidebar already does (`DirectoryNavigation` reads the whole `Sidebar` just for `pinned`), and matching it is the point of the change. If the resize jitter turns out to matter in practice it should be addressed for both sidebars together, not for the right one alone.

## Commit split

The two commits are the only split where every intermediate state compiles on every platform. The right-sidebar and zoom work edit the same regions of `app_state.rs`, `window/settings.rs` and `dispatcher.rs` — in the import block, the same hunk — so they cannot be separated at file or hunk granularity. Ordering the context-menu commit first keeps `win_hamburger.rs` untouched and valid at that point; the reverse order breaks the Windows build at the intermediate commit.

## Testing

- `just fmt check test` — Rust 399 + 6 + 142 + 5 tests, vitest 69, clippy `-D warnings` clean.
- The first commit was checked out into a separate worktree and verified standalone.
- `win_hamburger.rs` is `#![cfg(target_os = "windows")]`, so `just check` on macOS never compiles it. It was verified by temporarily retargeting the `cfg` to `macos` and running `cargo clippy --all-targets --all-features -- -D warnings`, then restoring (SHA-verified).

## Manual QA still needed

Tests cannot reach signal-guard lifetimes or render behavior:

- Drag-resize the right sidebar; pin/unpin it; toggle TOC ↔ Search.
- Open Preferences (unpins both sidebars in one go).
- Zoom content past 2.0 (must reach 5.0); sidebar zoom must cap at 2.0.
- Right-click in the tab bar, the sidebar file tree and the content area — the sidebar one near the bottom-right corner, to exercise the moved clamp/flip path.

## Deliberately not in scope

- `set_right_sidebar_width` / `set_right_sidebar_tab` have no counterpart on `Sidebar`; removing them touches five call sites and belongs in its own change.
- The shared `ContextMenuSubmenu` does not yet support the flip-left/offset positioning the sidebar and tab menus need, so those two still hand-roll their submenu markup — unchanged from before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
