### PR TITLE
feat(desktop): open files dragged from editors like VS Code

### DIFF
--- a/desktop/src/components/app/drop_handlers.rs
+++ b/desktop/src/components/app/drop_handlers.rs
@@ -49,6 +49,13 @@ fn open_dropped_path(path: PathBuf, state: &mut AppState) {
 fn drag_pasteboard_paths() -> Vec<PathBuf> {
     use objc2_app_kit::NSPasteboard;
 
+    // NSPasteboard is not bound as MainThreadOnly, but AppKit is only
+    // documented safe from the main thread
+    if objc2::MainThreadMarker::new().is_none() {
+        tracing::warn!("Drag pasteboard must be read on the main thread");
+        return Vec::new();
+    }
+
     let pasteboard =
         NSPasteboard::pasteboardWithName(unsafe { objc2_app_kit::NSPasteboardNameDrag });
     let Some(items) = pasteboard.pasteboardItems() else {

--- a/desktop/src/components/app/drop_handlers.rs
+++ b/desktop/src/components/app/drop_handlers.rs
@@ -1,46 +1,127 @@
 use dioxus::html::HasFileData;
 use dioxus::prelude::*;
+use std::path::PathBuf;
 
 use crate::state::AppState;
 
-/// Handle dropped files/directories - opens markdown files or sets directory as root
 pub(super) async fn handle_dropped_files(evt: Event<DragData>, mut state: AppState) {
-    let files = evt.files();
-    if files.is_empty() {
-        return;
+    let paths: Vec<PathBuf> = evt.files().into_iter().map(|f| f.path()).collect();
+
+    // wry only reads the legacy NSFilenamesPboardType, so drags from apps that
+    // publish modern pasteboard types only (e.g. VS Code) arrive with no files
+    #[cfg(target_os = "macos")]
+    let paths = if paths.is_empty() {
+        drag_pasteboard_paths()
+    } else {
+        paths
+    };
+
+    for path in paths {
+        open_dropped_path(path, &mut state);
+    }
+}
+
+fn open_dropped_path(path: PathBuf, state: &mut AppState) {
+    // Finder sidebar items arrive as symlinks
+    let resolved_path = match std::fs::canonicalize(&path) {
+        Ok(p) => {
+            tracing::info!("Resolved path: {:?} -> {:?}", path, p);
+            p
+        }
+        Err(e) => {
+            tracing::warn!("Failed to canonicalize path {:?}: {}", path, e);
+            path
+        }
+    };
+
+    if resolved_path.is_dir() {
+        tracing::info!("Setting dropped directory as root: {:?}", resolved_path);
+        state.set_root_directory(resolved_path);
+        // Pin so the tree the drop just opened is actually visible
+        state.sidebar.write().pinned = true;
+    } else {
+        tracing::info!("Opening dropped file: {:?}", resolved_path);
+        state.open_file(resolved_path);
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn drag_pasteboard_paths() -> Vec<PathBuf> {
+    use objc2_app_kit::NSPasteboard;
+
+    let pasteboard =
+        NSPasteboard::pasteboardWithName(unsafe { objc2_app_kit::NSPasteboardNameDrag });
+    let Some(items) = pasteboard.pasteboardItems() else {
+        return Vec::new();
+    };
+
+    items
+        .iter()
+        .filter_map(|item| {
+            // Chromium-based apps (e.g. VS Code) publish public.url instead of
+            // public.file-url; path_from_file_url keeps non-file URLs out
+            item.stringForType(unsafe { objc2_app_kit::NSPasteboardTypeFileURL })
+                .or_else(|| item.stringForType(unsafe { objc2_app_kit::NSPasteboardTypeURL }))
+        })
+        .filter_map(|url| path_from_file_url(&url.to_string()))
+        .filter(|path| path.exists())
+        .collect()
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn path_from_file_url(url: &str) -> Option<PathBuf> {
+    let rest = url.strip_prefix("file://")?;
+
+    // A remote authority (file://server/...) must not resolve to a local path
+    let path_part = match rest.find('/') {
+        Some(idx) if matches!(&rest[..idx], "" | "localhost") => &rest[idx..],
+        _ => return None,
+    };
+
+    let decoded = percent_encoding::percent_decode_str(path_part)
+        .decode_utf8()
+        .ok()?;
+
+    Some(PathBuf::from(decoded.into_owned()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_file_url_is_percent_decoded() {
+        assert_eq!(
+            path_from_file_url("file:///Users/alice/My%20Notes/todo.md"),
+            Some(PathBuf::from("/Users/alice/My Notes/todo.md"))
+        );
     }
 
-    for file_data in files {
-        let path = file_data.path();
-
-        // Resolve symlinks and canonicalize the path to handle Finder sidebar items
-        let resolved_path = match std::fs::canonicalize(&path) {
-            Ok(p) => {
-                tracing::info!("Resolved path: {:?} -> {:?}", path, p);
-                p
-            }
-            Err(e) => {
-                tracing::warn!("Failed to canonicalize path {:?}: {}", path, e);
-                path.clone()
-            }
-        };
-
-        tracing::info!(
-            "Processing dropped path: {:?}, is_dir: {}",
-            resolved_path,
-            resolved_path.is_dir()
+    #[test]
+    fn test_file_url_with_localhost_authority() {
+        assert_eq!(
+            path_from_file_url("file://localhost/Users/alice/todo.md"),
+            Some(PathBuf::from("/Users/alice/todo.md"))
         );
+    }
 
-        if resolved_path.is_dir() {
-            // If it's a directory, set it as root and show the sidebar
-            tracing::info!("Setting dropped directory as root: {:?}", resolved_path);
-            state.set_root_directory(resolved_path);
-            // Pin the sidebar so users can see the directory tree
-            state.sidebar.write().pinned = true;
-        } else {
-            // Open any file (not just markdown)
-            tracing::info!("Opening dropped file: {:?}", resolved_path);
-            state.open_file(resolved_path);
-        }
+    #[test]
+    fn test_file_url_with_remote_authority_is_rejected() {
+        assert_eq!(
+            path_from_file_url("file://example.com/Users/alice/todo.md"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_file_url_without_path_is_rejected() {
+        assert_eq!(path_from_file_url("file://"), None);
+        assert_eq!(path_from_file_url("file://localhost"), None);
+    }
+
+    #[test]
+    fn test_non_file_url_is_rejected() {
+        assert_eq!(path_from_file_url("https://example.com/a.md"), None);
+        assert_eq!(path_from_file_url("/Users/alice/todo.md"), None);
     }
 }


### PR DESCRIPTION
## Summary

Implements #210: dragging a file from VS Code's explorer onto Arto previously did nothing — now it opens the file (or sets the directory as sidebar root), the same as a native Finder drop.

## Root cause

Logging the drop's dataTransfer showed the drag arrives in the WebView as a real file drop, but with an empty file list on the Rust side: **wry's macOS drop handler only reads the legacy `NSFilenamesPboardType`**, while Chromium-based apps such as VS Code publish modern pasteboard types only (`public.url`, plus promise types — notably not even `public.file-url`). The drop therefore reached Arto with no paths and was silently ignored.

## How it works

- `handle_dropped_files` keeps its existing path: paths surfaced by Dioxus/wry (`evt.files()`) are opened as before, so native Finder drops are untouched.
- When a drop delivers **no** files, a macOS-only fallback reads the drag pasteboard (`NSPasteboardNameDrag`) directly via the already-present `objc2-app-kit` dependency, taking each item's `public.file-url` or, failing that, `public.url`.
- URLs are accepted only with the `file://` scheme, an empty or `localhost` authority (a remote-host URI must not resolve to a local path), and an existing target after percent-decoding — so dropping a browser tab or an http(s) link is ignored as before.
- Opening reuses the same logic as native drops (extracted into a shared `open_dropped_path`): directories become the sidebar root with the sidebar pinned, files open in a tab.

**This change is macOS-specific** (the fallback is gated behind `#[cfg(target_os = "macos")]`), because the bug most likely does not occur on other platforms: on Windows and Linux, wry reads `CF_HDROP` / `text/uri-list` respectively, which Chromium-based apps do publish. Behavior there is completely unchanged.

## Changes

- `desktop/src/components/app/drop_handlers.rs` — the only file touched: `drag_pasteboard_paths` fallback, `path_from_file_url` with 5 unit tests, and the shared `open_dropped_path` extraction

## Testing

- `just fmt check test` passes locally on macOS: cargo fmt, clippy `-D warnings`, desktop / markdown / ql-generator / renderer test suites
- Manually verified on macOS: a file dragged from VS Code's explorer opens; Finder file/directory drops behave as before

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)
