### PR TITLE
feat(arto-page): render pages with the user's configuration

### DIFF
--- a/.claude/rules/config-module.md
+++ b/.claude/rules/config-module.md
@@ -64,8 +64,9 @@ mod tests { ... }
 ### Library and App Split
 
 The crate owns everything that is true for every consumer of the
-configuration: the types, the file locations, and `Config::load()` /
-`Config::save()` returning a `ConfigError`. It never logs above debug and
+configuration: the types, the file locations, and `Config::load()` (with keybindings),
+`Config::load_preferences()` (config.json alone, for consumers that only
+render) and `Config::save()`, all returning a `ConfigError`. It never logs above debug and
 never holds a global. The desktop app wraps it in `crates/arto/src/config.rs`,
 where the loaded instance lives behind a lock (`CONFIG`) and changes are
 broadcast to windows (`CONFIG_CHANGED_BROADCAST`). Other consumers, such as

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,6 +263,7 @@ name = "arto-page"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "arto-config",
  "arto-markdown",
  "base64 0.23.1",
  "clap",

--- a/README.md
+++ b/README.md
@@ -193,7 +193,10 @@ Arto runs as a **single instance** — if Arto is already running, the command s
 ```
 arto page README.md > README.html
 arto page --output out.html docs/guide.md
+arto page --theme dark notes.md
 ```
+
+The page follows your `config.json` (rendering options and default theme), so it looks the way the app shows the file; `--theme`, `--no-auto-link-urls` and friends override individual settings, `--config FILE` reads another file, and `--no-config` starts from the built-in defaults. The Quick Look preview on macOS reads the same configuration when its sandbox allows.
 
 The page ships with a Content-Security-Policy that blocks any script embedded in the Markdown; pass `--no-csp` only for input you trust. The same command is available as the standalone `arto-page` binary (the `arto-page` crate) for machines without the app.
 

--- a/crates/arto-config/src/persistence.rs
+++ b/crates/arto-config/src/persistence.rs
@@ -37,6 +37,20 @@ pub enum ConfigError {
     Serialize(#[source] serde_json::Error),
 }
 
+impl ConfigError {
+    /// Whether the file simply does not exist.
+    ///
+    /// Loaders fall back to defaults only in this case; a file that exists
+    /// but cannot be read (permissions, a directory in its place) is an
+    /// error the caller must see.
+    pub fn is_not_found(&self) -> bool {
+        matches!(
+            self,
+            ConfigError::Read { source, .. } if source.kind() == std::io::ErrorKind::NotFound
+        )
+    }
+}
+
 impl Config {
     /// Get the configuration file path based on the platform
     pub fn path() -> PathBuf {
@@ -65,23 +79,37 @@ impl Config {
     /// A missing `mappings.json` yields the default preset, so a fresh
     /// install has working shortcuts without writing anything first.
     pub fn load() -> Result<Self, ConfigError> {
-        let config_path = Self::path();
+        let mut config = Self::load_preferences()?;
         let mappings_path = Self::mappings_path();
-
-        let mut config = if config_path.exists() {
-            read_json(&config_path)?
-        } else {
-            Config::default()
-        };
-
         config.keybindings = resolve_keybindings(load_mappings(&mappings_path)?);
+        tracing::debug!(mappings_path = %mappings_path.display(), "Keybindings loaded");
+        Ok(config)
+    }
 
-        tracing::debug!(
-            config_path = %config_path.display(),
-            mappings_path = %mappings_path.display(),
-            "Configuration loaded"
-        );
+    /// Load `config.json` alone, or the defaults when it does not exist.
+    ///
+    /// Keybindings are the default preset; `mappings.json` is not read. For
+    /// consumers that only render (`arto page`, Quick Look) this keeps a
+    /// broken `mappings.json` from getting in the way of settings that have
+    /// nothing to do with it.
+    pub fn load_preferences() -> Result<Self, ConfigError> {
+        // Try the read rather than testing existence first: `Path::exists`
+        // answers false for a permission error too, which would silently
+        // turn an unreadable config.json into the defaults.
+        match Self::load_preferences_from(Self::path()) {
+            Err(error) if error.is_not_found() => Ok(Self::default_with_keybindings()),
+            result => result,
+        }
+    }
 
+    /// Load `config.json` from a specific file, which must exist.
+    ///
+    /// Like [`Config::load_preferences`], keybindings are the default preset.
+    pub fn load_preferences_from(config_path: impl AsRef<Path>) -> Result<Self, ConfigError> {
+        let config_path = config_path.as_ref();
+        let mut config: Config = read_json(config_path)?;
+        config.keybindings = resolve_keybindings(None);
+        tracing::debug!(config_path = %config_path.display(), "Configuration loaded");
         Ok(config)
     }
 
@@ -144,10 +172,11 @@ fn write_json<T: serde::Serialize>(path: &Path, value: &T) -> Result<(), ConfigE
 }
 
 fn load_mappings(path: &Path) -> Result<Option<BindingSet>, ConfigError> {
-    if !path.exists() {
-        return Ok(None);
+    match read_json(path) {
+        Ok(mappings) => Ok(Some(mappings)),
+        Err(error) if error.is_not_found() => Ok(None),
+        Err(error) => Err(error),
     }
-    read_json(path).map(Some)
 }
 
 fn resolve_keybindings(mappings: Option<BindingSet>) -> BindingSet {
@@ -190,6 +219,33 @@ mod tests {
     }
 
     #[test]
+    fn only_a_missing_file_counts_as_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let missing = read_json::<Config>(&dir.path().join("missing.json")).unwrap_err();
+        assert!(missing.is_not_found());
+
+        let malformed_path = dir.path().join("config.json");
+        fs::write(&malformed_path, "{ not json").unwrap();
+        let malformed = read_json::<Config>(&malformed_path).unwrap_err();
+        assert!(!malformed.is_not_found());
+
+        // A directory where the file should be exists but cannot be read.
+        let in_the_way = read_json::<Config>(dir.path()).unwrap_err();
+        assert!(!in_the_way.is_not_found());
+    }
+
+    #[test]
+    fn load_mappings_distinguishes_missing_from_unreadable() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(
+            load_mappings(&dir.path().join("mappings.json")).unwrap(),
+            None
+        );
+        assert!(load_mappings(dir.path()).is_err());
+    }
+
+    #[test]
     fn read_json_reports_the_offending_file() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("config.json");
@@ -198,6 +254,34 @@ mod tests {
         let err = read_json::<Config>(&path).unwrap_err();
         assert!(matches!(err, ConfigError::Parse { .. }));
         assert!(err.to_string().contains("config.json"));
+    }
+
+    #[test]
+    fn load_preferences_from_reads_the_file_and_ignores_sibling_mappings() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config.json");
+        fs::write(
+            &config_path,
+            r#"{"theme":{"defaultTheme":"dark","onStartup":"default","onNewWindow":"default"}}"#,
+        )
+        .unwrap();
+        // A broken mappings.json next to it must not matter to a consumer
+        // that only wants preferences.
+        fs::write(dir.path().join("mappings.json"), "{ not json").unwrap();
+
+        let config = Config::load_preferences_from(&config_path).unwrap();
+        assert_eq!(config.theme.default_theme, crate::Theme::Dark);
+        assert_eq!(
+            config.keybindings,
+            arto_keybindings::presets::default_bindings()
+        );
+    }
+
+    #[test]
+    fn load_preferences_from_requires_the_file_to_exist() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = Config::load_preferences_from(dir.path().join("missing.json")).unwrap_err();
+        assert!(matches!(err, ConfigError::Read { .. }));
     }
 
     #[test]

--- a/crates/arto-page/Cargo.toml
+++ b/crates/arto-page/Cargo.toml
@@ -34,6 +34,9 @@ ffi = []
 [dependencies]
 # Only for `PageError::Render`, which carries arto-markdown's error as-is.
 anyhow.workspace = true
+# The page honours the user's config.json (rendering options, default theme)
+# so `arto page` and Quick Look look like the app does.
+arto-config = { path = "../arto-config" }
 arto-markdown = { path = "../arto-markdown" }
 base64.workspace = true
 clap = { workspace = true, optional = true }

--- a/crates/arto-page/src/cli.rs
+++ b/crates/arto-page/src/cli.rs
@@ -3,11 +3,34 @@
 //! The arguments are defined once here so both entry points accept exactly
 //! the same flags. Errors are reported as [`PageError`]; the binaries decide
 //! how to print them.
+//!
+//! Options are layered: built-in defaults, then the user's `config.json`
+//! (the same file the app reads), then the flags. So a page looks like the
+//! app would show it unless a flag says otherwise.
 
-use crate::{render_file, PageError, PageOptions, RenderOptions};
-use clap::Args;
+use crate::{render_file, Config, PageError, PageOptions, Theme};
+use clap::{Args, ValueEnum};
 use std::io::Write;
 use std::path::PathBuf;
+
+/// The `--theme` values; a clap-side mirror of [`Theme`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum ThemeArg {
+    /// Follow the viewer's system setting
+    Auto,
+    Light,
+    Dark,
+}
+
+impl From<ThemeArg> for Theme {
+    fn from(theme: ThemeArg) -> Self {
+        match theme {
+            ThemeArg::Auto => Theme::Auto,
+            ThemeArg::Light => Theme::Light,
+            ThemeArg::Dark => Theme::Dark,
+        }
+    }
+}
 
 /// Render a Markdown file into a self-contained HTML page.
 #[derive(Debug, Clone, Args)]
@@ -17,6 +40,15 @@ pub struct PageArgs {
     /// Write the page to this file instead of standard output
     #[arg(short, long, value_name = "FILE")]
     pub output: Option<PathBuf>,
+    /// Read settings from this file instead of the app's config.json
+    #[arg(long, value_name = "FILE", conflicts_with = "no_config")]
+    pub config: Option<PathBuf>,
+    /// Ignore config.json and start from the built-in defaults
+    #[arg(long)]
+    pub no_config: bool,
+    /// Colour theme of the page
+    #[arg(long, value_enum, value_name = "THEME")]
+    pub theme: Option<ThemeArg>,
     /// Omit the Content-Security-Policy that blocks scripts embedded in the
     /// Markdown; only for input you trust
     #[arg(long)]
@@ -27,20 +59,35 @@ pub struct PageArgs {
 }
 
 impl PageArgs {
-    /// The rendering options these arguments describe.
-    pub fn options(&self) -> PageOptions {
-        PageOptions {
-            render: RenderOptions {
-                auto_link_urls: !self.no_auto_link_urls,
-            },
-            content_security_policy: !self.no_csp,
+    /// The rendering options these arguments describe, on top of the user's
+    /// configuration unless `--no-config` was given.
+    ///
+    /// A missing config.json is not an error; an unreadable or malformed one
+    /// is, because silently rendering with other settings than the app uses
+    /// would be confusing. `--no-config` is the escape hatch.
+    pub fn options(&self) -> Result<PageOptions, PageError> {
+        let mut options = match (&self.config, self.no_config) {
+            (_, true) => PageOptions::default(),
+            (Some(path), false) => PageOptions::from_config(&Config::load_preferences_from(path)?),
+            (None, false) => PageOptions::from_config(&Config::load_preferences()?),
+        };
+
+        if let Some(theme) = self.theme {
+            options.theme = Theme::from(theme);
         }
+        if self.no_auto_link_urls {
+            options.render.auto_link_urls = false;
+        }
+        if self.no_csp {
+            options.content_security_policy = false;
+        }
+        Ok(options)
     }
 }
 
 /// Render `args.input` and write the page to `args.output` or standard output.
 pub fn run(args: &PageArgs) -> Result<(), PageError> {
-    let html = render_file(&args.input, &args.options())?;
+    let html = render_file(&args.input, &args.options()?)?;
     match &args.output {
         Some(output) => std::fs::write(output, html).map_err(|source| PageError::Write {
             path: output.clone(),
@@ -53,5 +100,77 @@ pub fn run(args: &PageArgs) -> Result<(), PageError> {
                 .and_then(|()| stdout.flush())
                 .map_err(PageError::WriteStdout)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(input: &str) -> PageArgs {
+        PageArgs {
+            input: PathBuf::from(input),
+            output: None,
+            config: None,
+            no_config: true,
+            theme: None,
+            no_csp: false,
+            no_auto_link_urls: false,
+        }
+    }
+
+    #[test]
+    fn no_config_uses_the_built_in_defaults() {
+        let options = args("doc.md").options().unwrap();
+        assert!(options.render.auto_link_urls);
+        assert_eq!(options.theme, Theme::Auto);
+        assert!(options.content_security_policy);
+    }
+
+    #[test]
+    fn flags_override_the_configuration_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config.json");
+        std::fs::write(
+            &config_path,
+            r#"{"theme":{"defaultTheme":"dark","onStartup":"default","onNewWindow":"default"},"markdown":{"autoLinkUrls":true}}"#,
+        )
+        .unwrap();
+
+        let from_config = PageArgs {
+            config: Some(config_path.clone()),
+            no_config: false,
+            ..args("doc.md")
+        };
+        let options = from_config.options().unwrap();
+        assert_eq!(options.theme, Theme::Dark);
+        assert!(options.render.auto_link_urls);
+
+        let overridden = PageArgs {
+            theme: Some(ThemeArg::Light),
+            no_auto_link_urls: true,
+            no_csp: true,
+            ..from_config
+        };
+        let options = overridden.options().unwrap();
+        assert_eq!(options.theme, Theme::Light);
+        assert!(!options.render.auto_link_urls);
+        assert!(!options.content_security_policy);
+    }
+
+    #[test]
+    fn a_malformed_configuration_file_is_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config.json");
+        std::fs::write(&config_path, "{ not json").unwrap();
+
+        let err = PageArgs {
+            config: Some(config_path),
+            no_config: false,
+            ..args("doc.md")
+        }
+        .options()
+        .unwrap_err();
+        assert!(matches!(err, PageError::Config(_)));
     }
 }

--- a/crates/arto-page/src/ffi.rs
+++ b/crates/arto-page/src/ffi.rs
@@ -4,12 +4,17 @@
 //! shim under platform/macos/quicklook links. The extension passes a file
 //! path in and receives the finished page as a C string.
 
-use crate::PageOptions;
+use crate::{Config, PageOptions};
 use std::ffi::{c_char, CStr, CString};
 use std::path::PathBuf;
 use std::ptr;
 
 /// Render the Markdown file at `path_utf8` to a full self-contained HTML page.
+///
+/// The page follows the user's `config.json` when it can be read; the
+/// extension's sandbox may hide the app's configuration directory, in which
+/// case the built-in defaults apply. A preview must never fail because of a
+/// configuration problem, so those errors are swallowed here.
 ///
 /// Returns a Rust-allocated C string that the caller must release only with
 /// [`arto_page_free_string`] (never libc `free`). Returns null on any error
@@ -30,7 +35,10 @@ pub unsafe extern "C" fn arto_page_render_markdown_file(path_utf8: *const c_char
     // guaranteed to be valid UTF-8, so build the path from bytes directly.
     let path = path_from_ffi_bytes(CStr::from_ptr(path_utf8).to_bytes());
 
-    let Ok(document) = crate::render_file(&path, &PageOptions::default()) else {
+    let options = Config::load_preferences()
+        .map(|config| PageOptions::from_config(&config))
+        .unwrap_or_default();
+    let Ok(document) = crate::render_file(&path, &options) else {
         return ptr::null_mut();
     };
 

--- a/crates/arto-page/src/lib.rs
+++ b/crates/arto-page/src/lib.rs
@@ -23,6 +23,7 @@
 //! first-party inline scripts embedded here. [`PageOptions`] can switch the
 //! policy off for callers that render trusted input.
 
+pub use arto_config::{Config, ConfigError, Theme};
 pub use arto_markdown::RenderOptions;
 
 use base64::Engine;
@@ -51,9 +52,14 @@ const FRONTEND_JS: &str = include_str!("../assets/frontend/main.iife.js");
 /// page unscrollable. Restore natural document scrolling.
 const STANDALONE_OVERRIDE_CSS: &str = "html,body{overflow:auto!important;height:auto!important;}";
 
-/// The inline bootstrap script. Picks the initial theme from
-/// `prefers-color-scheme` (the frontend reads `document.body`'s `data-theme`
-/// during initialization) and then starts the frontend.
+/// The inline bootstrap script. Settles the theme (the frontend reads
+/// `document.body`'s `data-theme` during initialization) and then starts the
+/// frontend.
+///
+/// The theme preference travels in `data-theme-preference` on `<body>` rather
+/// than in this script, so the script stays byte-identical across pages and
+/// its CSP hash can be a constant. `light` and `dark` are taken as-is;
+/// anything else follows `prefers-color-scheme`.
 const BOOTSTRAP_JS: &str = r#"(function(){
   // Quick Look loads this page from an opaque origin, which is not a secure
   // context, so crypto.randomUUID (used by Mermaid) is undefined. Polyfill it
@@ -69,8 +75,12 @@ const BOOTSTRAP_JS: &str = r#"(function(){
     }
   } catch (e) {}
   try {
-    var m = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-    document.body.setAttribute('data-theme', m ? 'dark' : 'light');
+    var theme = document.body.getAttribute('data-theme-preference');
+    if (theme !== 'light' && theme !== 'dark') {
+      var m = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+      theme = m ? 'dark' : 'light';
+    }
+    document.body.setAttribute('data-theme', theme);
   } catch (e) {}
   if (window.ArtoRenderer && typeof window.ArtoRenderer.init === 'function') { window.ArtoRenderer.init(); }
 })();"#;
@@ -86,6 +96,9 @@ pub struct PageOptions {
     /// Markdown rendering choices, shared with every other consumer of
     /// arto-markdown (the app reads the same struct from `config.json`).
     pub render: RenderOptions,
+    /// The colour theme the page opens in. `Auto` follows the viewer's
+    /// `prefers-color-scheme`.
+    pub theme: Theme,
     /// Emit the `Content-Security-Policy` that restricts script execution to
     /// the embedded frontend. Leave it on for untrusted input.
     pub content_security_policy: bool,
@@ -95,6 +108,20 @@ impl Default for PageOptions {
     fn default() -> Self {
         Self {
             render: RenderOptions::default(),
+            theme: Theme::default(),
+            content_security_policy: true,
+        }
+    }
+}
+
+impl PageOptions {
+    /// The options the user's configuration asks for: the app's rendering
+    /// options and its default theme. The policy stays on; a configuration
+    /// file must not be able to switch off the protection for untrusted input.
+    pub fn from_config(config: &Config) -> Self {
+        Self {
+            render: config.markdown.clone(),
+            theme: config.theme.default_theme,
             content_security_policy: true,
         }
     }
@@ -124,6 +151,9 @@ pub enum PageError {
     /// The page could not be written to standard output.
     #[error("cannot write to standard output: {0}")]
     WriteStdout(#[source] std::io::Error),
+    /// The user's configuration could not be read or parsed.
+    #[error("cannot load the configuration: {0}")]
+    Config(#[from] ConfigError),
 }
 
 /// Render the Markdown file at `path` into a self-contained HTML page.
@@ -223,12 +253,21 @@ fn build_document(body_html: &str, options: &PageOptions) -> String {
         String::new()
     };
 
+    // `data-theme` is what the stylesheet reads, so a fixed theme applies
+    // before any script runs (and with scripts blocked). `Auto` starts light
+    // and lets the bootstrap consult `prefers-color-scheme`.
+    let (initial_theme, theme_preference) = match options.theme {
+        Theme::Auto => ("light", "auto"),
+        Theme::Light => ("light", "light"),
+        Theme::Dark => ("dark", "dark"),
+    };
+
     format!(
         r#"<!DOCTYPE html><html><head><meta charset="utf-8">
 {csp_meta}<meta name="viewport" content="width=device-width, initial-scale=1">
 <style>{css}</style>
 <style>{standalone_override}</style></head>
-<body data-theme="light">
+<body data-theme="{initial_theme}" data-theme-preference="{theme_preference}">
 <div class="markdown-viewer"><article class="markdown-body">{body}</article></div>
 <script>{bundle}</script>
 <script>{bootstrap}</script>
@@ -236,6 +275,8 @@ fn build_document(body_html: &str, options: &PageOptions) -> String {
         csp_meta = csp_meta,
         css = FRONTEND_CSS,
         standalone_override = STANDALONE_OVERRIDE_CSS,
+        initial_theme = initial_theme,
+        theme_preference = theme_preference,
         body = body_html,
         bundle = bundle,
         bootstrap = BOOTSTRAP_JS,
@@ -267,8 +308,9 @@ mod tests {
         assert!(html.contains("overflow:auto"));
         assert!(html.contains("<script>"));
         assert!(html.contains("</script>"));
-        // Theme defaults are present.
-        assert!(html.contains(r#"<body data-theme="light">"#));
+        // Theme defaults are present: start light, let the bootstrap follow
+        // the system.
+        assert!(html.contains(r#"<body data-theme="light" data-theme-preference="auto">"#));
         assert!(html.contains("prefers-color-scheme"));
         // Mermaid needs crypto.randomUUID, which an opaque origin lacks, so
         // the bootstrap must polyfill it.
@@ -313,6 +355,81 @@ mod tests {
         // The rest of the document is unchanged.
         assert!(html.contains("ArtoRenderer.init"));
         assert!(html.contains(r#"<meta name="viewport""#));
+    }
+
+    #[test]
+    fn test_build_document_applies_a_fixed_theme_before_scripts_run() {
+        let dark = build_document(
+            "<p>hi</p>",
+            &PageOptions {
+                theme: Theme::Dark,
+                ..PageOptions::default()
+            },
+        );
+        assert!(dark.contains(r#"<body data-theme="dark" data-theme-preference="dark">"#));
+
+        let light = build_document(
+            "<p>hi</p>",
+            &PageOptions {
+                theme: Theme::Light,
+                ..PageOptions::default()
+            },
+        );
+        assert!(light.contains(r#"<body data-theme="light" data-theme-preference="light">"#));
+
+        // The bootstrap is byte-identical whatever the theme, so its CSP hash
+        // stays valid.
+        let hash = format!("'sha256-{}'", sha256_base64(BOOTSTRAP_JS));
+        assert!(dark.contains(&hash));
+        assert!(light.contains(&hash));
+    }
+
+    #[test]
+    fn test_options_from_config_take_render_options_and_theme_but_keep_csp() {
+        let config = Config {
+            markdown: RenderOptions {
+                auto_link_urls: false,
+            },
+            theme: arto_config::ThemeConfig {
+                default_theme: Theme::Dark,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let options = PageOptions::from_config(&config);
+        assert!(!options.render.auto_link_urls);
+        assert_eq!(options.theme, Theme::Dark);
+        assert!(options.content_security_policy);
+    }
+
+    #[test]
+    fn test_every_sample_renders_to_a_well_formed_page() {
+        let samples = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../samples");
+        let mut rendered = 0;
+        for entry in fs::read_dir(&samples).unwrap() {
+            let path = entry.unwrap().path();
+            if path.extension().is_none_or(|ext| ext != "md") {
+                continue;
+            }
+            let html = render_file(&path, &PageOptions::default())
+                .unwrap_or_else(|err| panic!("{}: {err}", path.display()));
+            assert!(
+                html.contains(r#"<article class="markdown-body">"#),
+                "{} lacks the article wrapper",
+                path.display()
+            );
+            // The body may legitimately mention `</script>` (a sample about
+            // raw HTML does), so only the tail is checked: both first-party
+            // scripts must still close the document.
+            assert!(
+                html.ends_with("</script>\n</body></html>"),
+                "{} does not end with the bootstrap script",
+                path.display()
+            );
+            rendered += 1;
+        }
+        assert!(rendered > 0, "no samples found under {}", samples.display());
     }
 
     #[test]

--- a/crates/arto-page/src/main.rs
+++ b/crates/arto-page/src/main.rs
@@ -7,10 +7,13 @@ use clap::Parser;
     about,
     long_about = "Render a Markdown file into a single HTML page that carries Arto's \
         stylesheet and frontend bundle inline, so it can be opened anywhere without \
-        the app: in a browser, in a Quick Look preview, or attached to a message.",
+        the app: in a browser, in a Quick Look preview, or attached to a message. \
+        Rendering options and the theme come from the app's config.json unless \
+        overridden by flags or disabled with --no-config.",
     after_long_help = "Examples:\n\
         \x20 arto-page README.md > README.html\n\
         \x20 arto-page --output out.html docs/guide.md\n\
+        \x20 arto-page --theme dark --no-config notes.md\n\
         \x20 arto-page --no-csp trusted.md"
 )]
 struct Cli {


### PR DESCRIPTION
## Summary

Stacked on #231 (`refactor/ipc-crate`). Ninth step of the repository layout refactor, and the payoff of extracting `arto-config`: `arto page` and the Quick Look preview now follow the user's `config.json`.

- `PageOptions` gains `theme` and `PageOptions::from_config(&Config)` (rendering options + default theme). The Content-Security-Policy is deliberately not configurable from a file.
- CLI precedence: built-in defaults → `config.json` → flags. New flags: `--config FILE`, `--no-config`, `--theme auto|light|dark`. Missing `config.json` is fine; a malformed one is an error (`PageError::Config`), with `--no-config` as the escape hatch.
- Quick Look (`ffi` feature) loads the config and silently falls back to defaults when the extension sandbox hides the app's config directory. A preview never fails because of config.
- Theme plumbing: `<body data-theme="…" data-theme-preference="auto|light|dark">`; the constant bootstrap script resolves `auto` via `prefers-color-scheme`, so its CSP hash stays constant. Fixed light/dark is applied before any script runs.
- `arto-config`: `Config::load_preferences()` / `load_preferences_from(path)` read `config.json` alone (default keybinding preset), so a broken `mappings.json` cannot stop a page from rendering; `Config::load()` builds on them.
- Tests: every `samples/*.md` renders through `render_file`; CLI precedence and malformed-config tests; theme attribute tests.
- README: `arto page` section describes the config behaviour and the new flags.

## Review notes

One design-review objection was not adopted: making `arto-config` an optional dependency of `arto-page` so a `render_file`-only consumer avoids the configuration crate. Sharing one `Config` definition between the app and every page renderer is the reason `arto-config` exists; the crate is small and a renderer that wants to look like the app needs it.

## Test plan

- [x] `just fmt check test` (workspace, all targets, all features; includes `ffi` and `cli` features of `arto-page`)
- [ ] CI: Build workflow on all three OSes (macOS job builds the Quick Look static library with `--features ffi`)
- [ ] Manual: `arto page --theme dark samples/01-inline.md > /tmp/a.html` opens dark; without `--theme` it follows `config.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VhuHhy2xFFF9UHEd9Pg4mx
