### PR TITLE
refactor(arto): follow Dioxus 0.7 idioms where 0.6 habits remained

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -170,11 +170,11 @@ use_drop(move || {
 **Key patterns (see TIPS.md for details):**
 
 - `spawn()` - Event handlers, one-time async
-- `use_effect()` - React to state changes
-- `spawn_forever()` - Infinite loops (broadcast listeners)
+- `use_effect()` - React to state changes (reads inside the closure subscribe it; take changing props as `ReadSignal<T>` instead of `use_reactive!`)
+- `use_future()` - Long-running listeners tied to the component (broadcast subscriptions); cancelled when the component drops
 - `use_drop()` - Cleanup (synchronous only!)
 
-**Critical:** `spawn_forever()` never returns. `use_drop()` is synchronous - use `persisted.save()` for blocking operations.
+**Critical:** avoid `spawn_forever()` in components: the task outlives the window and keeps writing to dropped signals. `use_drop()` is synchronous - use `persisted.save()` for blocking operations.
 
 ### Markdown Rendering Pipeline
 
@@ -340,26 +340,39 @@ pub fn handle_menu_event_global(event: MenuEvent) {
 }
 ```
 
-**2. State-Dependent Handler** (in App component):
+**2. State-Dependent Handler** (in App component, one per window):
 ```rust
 // In app.rs
-use_effect(move || {
-    spawn_forever(async move {
-        while let Ok(event) = rx.recv().await {
-            match event.id.as_ref().parse::<MenuId>() {
-                MenuId::CloseTab => {
-                    state.close_current_tab();
-                }
-                MenuId::Preferences => {
-                    state.open_preferences();
-                }
-                // Other state actions...
-                _ => {}
-            }
-        }
-    });
+#[cfg(not(target_os = "windows"))]
+use_muda_event_handler(move |event| {
+    menu::handle_menu_event_with_state(&event, &mut state);
 });
+
+// In menu.rs
+pub fn handle_menu_event_with_state(event: &MenuEvent, state: &mut AppState) -> bool {
+    // Every window registers this handler; only the focused one acts.
+    if !window().is_focused() {
+        return false;
+    }
+    match event.id.as_ref().parse::<MenuId>() {
+        MenuId::CloseTab => {
+            state.close_current_tab();
+            true
+        }
+        MenuId::Preferences => {
+            state.open_preferences();
+            true
+        }
+        // Other state actions...
+        _ => false,
+    }
+}
 ```
+
+Both handlers are plain `use_muda_event_handler` callbacks; there is no
+channel between them. Every window registers the state-dependent one, muda
+delivers each event to every registered handler, and the focus check keeps
+only the focused window from acting on it.
 
 **Why split:** Some actions don't need state (new window), others do (close tab, preferences).
 

--- a/.claude/TIPS.md
+++ b/.claude/TIPS.md
@@ -225,14 +225,12 @@ use_effect(move || {
     });
 });
 
-// ✓ spawn_forever() - Infinite event loop (NEVER returns)
-use_effect(move || {
+// ✓ use_future() - Listener that lives as long as the component
+use_future(move || async move {
     let mut rx = BROADCAST.subscribe();
-    spawn_forever(async move {
-        while let Ok(event) = rx.recv().await {
-            handle(event);
-        }
-    });
+    while let Ok(event) = rx.recv().await {
+        handle(event);
+    }
 });
 
 // ✓ use_drop() - Cleanup (synchronous only!)
@@ -242,7 +240,7 @@ use_drop(move || {
 });
 ```
 
-**Critical:** `spawn_forever()` is for infinite loops that should never block. Use for broadcast channel listeners.
+**Critical:** `use_future()` is cancelled when the component drops, so a broadcast listener stops with its window. `spawn_forever()` would keep running and write to dropped signals; do not use it in components.
 
 ### Dynamic Text in RSX
 
@@ -1007,9 +1005,9 @@ div {
 ### Dioxus Signal Lifetime Issues
 
 - **spawn_forever Warning**: Using `spawn_forever` with component-scoped signals causes lifetime warnings because task outlives component
-- **Solution**: Use `use_hook` + `spawn` instead - task is automatically cancelled when component drops
-- **When spawn_forever IS correct**: Only for app-lifetime components like MainApp that live until app quits
-- **Pattern**: `use_effect` + `spawn` for reactive listeners, `use_hook` + `spawn` for one-time infinite loops
+- **Solution**: Use `use_future` (or `use_hook` + `spawn`) instead - task is automatically cancelled when component drops
+- **Pattern**: `use_effect` + `spawn` for reactive work, `use_future` for listeners that run for the component's lifetime
+- **Changing props in effects**: take the prop as `ReadSignal<T>` and read it inside the effect; that subscribes the effect without `use_reactive!`
 
 ### JavaScript Initialization
 

--- a/crates/arto/src/assets.rs
+++ b/crates/arto/src/assets.rs
@@ -4,6 +4,17 @@ use dioxus::prelude::*;
 pub static MAIN_SCRIPT: Asset = asset!("/assets/frontend/main.js");
 pub static MAIN_STYLE: Asset = asset!("/assets/frontend/main.css");
 
+/// The `<head>` markup that loads the main stylesheet, for
+/// `Config::with_custom_head` on every window.
+///
+/// Kept as static head markup on purpose. `document::Stylesheet {}` would be
+/// the idiomatic rsx form, but it is inserted by the runtime after the first
+/// render, so the window would paint unstyled for a moment on every open.
+/// Head markup is parsed with the page and applies before anything shows.
+pub fn main_stylesheet_head() -> String {
+    format!(r#"<link rel="stylesheet" href="{MAIN_STYLE}">"#)
+}
+
 static ARTO_HEADER_IMAGE: Asset = asset!("/assets/arto-header-welcome.png");
 static WELCOME_TEMPLATE: Asset = asset!("/assets/welcome.md");
 

--- a/crates/arto/src/components/app/keybinding_engine.rs
+++ b/crates/arto/src/components/app/keybinding_engine.rs
@@ -112,7 +112,7 @@ pub(super) fn setup_keybinding_engine(
     let initial_config = CONFIG.read().keybindings.clone();
     let engine = use_signal(|| RefCell::new(crate::keybindings::engine_for(&initial_config)));
 
-    // spawn/spawn_forever wrapped in use_hook to run only once
+    // The keyboard loop is spawned from use_hook so it starts exactly once
     use_hook(move || {
         // Keyboard event processing loop
         spawn(async move {
@@ -220,19 +220,21 @@ pub(super) fn setup_keybinding_engine(
                 tracing::warn!("Keybinding engine: JS keyboard interceptor failed to initialize");
             }
         });
-
-        // Config change listener: rebuild engine when keybindings are saved
-        dioxus_core::spawn_forever(async move {
-            let mut rx = CONFIG_CHANGED_BROADCAST.subscribe();
-            while rx.recv().await.is_ok() {
-                let new_config = CONFIG.read().keybindings.clone();
-                *engine.read().borrow_mut() = crate::keybindings::engine_for(&new_config);
-                push_menu_accelerators_to_js();
-                push_reserved_key_overrides_to_js();
-                tracing::debug!("Keybinding engine rebuilt after config change");
-            }
-        });
     }); // use_hook
+
+    // Config change listener: rebuild engine when keybindings are saved.
+    // `use_future` ties the task to this component, so it stops when the
+    // window closes instead of outliving the `engine` signal it writes to.
+    use_future(move || async move {
+        let mut rx = CONFIG_CHANGED_BROADCAST.subscribe();
+        while rx.recv().await.is_ok() {
+            let new_config = CONFIG.read().keybindings.clone();
+            *engine.read().borrow_mut() = crate::keybindings::engine_for(&new_config);
+            push_menu_accelerators_to_js();
+            push_reserved_key_overrides_to_js();
+            tracing::debug!("Keybinding engine rebuilt after config change");
+        }
+    });
 }
 
 #[cfg(test)]

--- a/crates/arto/src/components/content/context_menu.rs
+++ b/crates/arto/src/components/content/context_menu.rs
@@ -10,6 +10,7 @@ pub use data::*;
 
 use dioxus::document;
 use dioxus::prelude::*;
+use std::path::PathBuf;
 
 use crate::components::context_menu::{ContextMenuItem, ContextMenuSeparator};
 use crate::components::icon::IconName;
@@ -23,12 +24,27 @@ use image_ops::{CopyImageAsSubmenu, CopySpecialBlockAsSubmenu};
 use source_ops::LinkContextItems;
 
 #[component]
-pub fn ContentContextMenu(props: ContentContextMenuProps) -> Element {
+pub fn ContentContextMenu(
+    position: (i32, i32),
+    context: ContentContext,
+    has_selection: bool,
+    selected_text: String,
+    current_file: Option<PathBuf>,
+    base_dir: PathBuf,
+    source_line: Option<u32>,
+    source_line_end: Option<u32>,
+    table_csv: Option<String>,
+    table_tsv: Option<String>,
+    table_markdown: Option<String>,
+    table_source_line: Option<u32>,
+    table_source_line_end: Option<u32>,
+    on_close: EventHandler<()>,
+) -> Element {
     let shortcut = |action| shortcut_hint_for_context_action(KeyContext::Content, action);
     let state = use_context::<crate::state::AppState>();
 
     // Extract copyable source from context (code blocks, mermaid, math)
-    let (copy_code_source, code_block_line, code_block_line_end) = match &props.context {
+    let (copy_code_source, code_block_line, code_block_line_end) = match &context {
         ContentContext::CodeBlock {
             content,
             source_line,
@@ -36,26 +52,22 @@ pub fn ContentContextMenu(props: ContentContextMenuProps) -> Element {
             ..
         } => (Some(content.clone()), *source_line, *source_line_end),
         ContentContext::Mermaid { source } | ContentContext::MathBlock { source } => {
-            // The renderer sets props.source_line/source_line_end to the block's
+            // The renderer sets source_line/source_line_end to the block's
             // line range for mermaid/math (via detectContext's block-level override)
-            (
-                Some(source.clone()),
-                props.source_line,
-                props.source_line_end,
-            )
+            (Some(source.clone()), source_line, source_line_end)
         }
         _ => (None, None, None),
     };
 
     // Extract image info for smart default and submenu
-    let image_info = match &props.context {
+    let image_info = match &context {
         ContentContext::Image { src, alt } => Some((src.clone(), alt.clone())),
         _ => None,
     };
     let is_image = image_info.is_some();
 
     // Detect special blocks (Mermaid/Math) for image operations
-    let (is_mermaid, is_math) = match &props.context {
+    let (is_mermaid, is_math) = match &context {
         ContentContext::Mermaid { .. } => (true, false),
         ContentContext::MathBlock { .. } => (false, true),
         _ => (false, false),
@@ -63,16 +75,16 @@ pub fn ContentContextMenu(props: ContentContextMenuProps) -> Element {
     let is_special_block = is_mermaid || is_math;
 
     let has_context_specific = matches!(
-        props.context,
+        context,
         ContentContext::Link { .. }
             | ContentContext::Image { .. }
             | ContentContext::Mermaid { .. }
             | ContentContext::MathBlock { .. }
     );
 
-    let has_table = props.table_csv.is_some();
-    let has_file = props.current_file.is_some();
-    let has_any_submenu = props.has_selection
+    let has_table = table_csv.is_some();
+    let has_file = current_file.is_some();
+    let has_any_submenu = has_selection
         || has_file
         || copy_code_source.is_some()
         || has_table
@@ -80,31 +92,28 @@ pub fn ContentContextMenu(props: ContentContextMenuProps) -> Element {
         || is_special_block;
 
     // Determine smart default for Copy Path label and value
-    let (copy_path_label, copy_path_value) = match (
-        props.current_file.as_ref(),
-        props.source_line,
-        props.source_line_end,
-    ) {
-        (Some(f), Some(start), Some(end)) if start != end => {
-            let path_str = f.display().to_string();
-            (
-                format!("Copy Path with Range ({start}-{end})"),
-                Some(format!("{path_str}:{start}-{end}")),
-            )
-        }
-        (Some(f), Some(line), _) => {
-            let path_str = f.display().to_string();
-            (
-                format!("Copy Path with Line ({line})"),
-                Some(format!("{path_str}:{line}")),
-            )
-        }
-        (Some(f), None, _) => {
-            let path_str = f.display().to_string();
-            ("Copy Path".to_string(), Some(path_str))
-        }
-        (None, _, _) => ("Copy Path".to_string(), None),
-    };
+    let (copy_path_label, copy_path_value) =
+        match (current_file.as_ref(), source_line, source_line_end) {
+            (Some(f), Some(start), Some(end)) if start != end => {
+                let path_str = f.display().to_string();
+                (
+                    format!("Copy Path with Range ({start}-{end})"),
+                    Some(format!("{path_str}:{start}-{end}")),
+                )
+            }
+            (Some(f), Some(line), _) => {
+                let path_str = f.display().to_string();
+                (
+                    format!("Copy Path with Line ({line})"),
+                    Some(format!("{path_str}:{line}")),
+                )
+            }
+            (Some(f), None, _) => {
+                let path_str = f.display().to_string();
+                ("Copy Path".to_string(), Some(path_str))
+            }
+            (None, _, _) => ("Copy Path".to_string(), None),
+        };
 
     rsx! {
         // Backdrop to close menu on outside click
@@ -113,26 +122,26 @@ pub fn ContentContextMenu(props: ContentContextMenuProps) -> Element {
             // Prevent mousedown from clearing text selection
             onmousedown: move |evt| evt.prevent_default(),
             onclick: move |_| {
-                props.on_close.call(());
+                on_close.call(());
             },
         }
 
         // Context menu
         div {
             class: "context-menu content-context-menu",
-            style: "left: {props.position.0}px; top: {props.position.1}px;",
+            style: "left: {position.0}px; top: {position.1}px;",
             // Prevent mousedown from clearing text selection
             onmousedown: move |evt| evt.prevent_default(),
             onclick: move |evt| evt.stop_propagation(),
 
             // === Section 1: Smart default copy operations ===
-            if props.has_selection {
+            if has_selection {
                 ContextMenuItem {
                     label: "Copy",
                     icon: Some(IconName::Copy),
                     on_click: {
-                        let on_close = props.on_close;
-                        let text = props.selected_text.clone();
+                        let on_close = on_close;
+                        let text = selected_text.clone();
                         move |_| {
                             crate::utils::clipboard::copy_text(&text);
                             on_close.call(());
@@ -147,7 +156,7 @@ pub fn ContentContextMenu(props: ContentContextMenuProps) -> Element {
                     shortcut: shortcut("clipboard.copy_code"),
                     icon: Some(IconName::Copy),
                     on_click: {
-                        let on_close = props.on_close;
+                        let on_close = on_close;
                         move |_| {
                             crate::utils::clipboard::copy_text(&code_content);
                             crate::keybindings::dispatcher::show_action_feedback("Copied");
@@ -158,13 +167,13 @@ pub fn ContentContextMenu(props: ContentContextMenuProps) -> Element {
             }
 
             // Copy Table (smart default: TSV)
-            if let Some(tsv) = props.table_tsv.clone() {
+            if let Some(tsv) = table_tsv.clone() {
                 ContextMenuItem {
                     label: "Copy Table",
                     shortcut: shortcut("clipboard.copy_table_as_tsv"),
                     icon: Some(IconName::Copy),
                     on_click: {
-                        let on_close = props.on_close;
+                        let on_close = on_close;
                         move |_| {
                             crate::utils::clipboard::copy_text(&tsv);
                             crate::keybindings::dispatcher::show_action_feedback("Copied");
@@ -181,7 +190,7 @@ pub fn ContentContextMenu(props: ContentContextMenuProps) -> Element {
                     shortcut: shortcut("clipboard.copy_image"),
                     icon: Some(IconName::Photo),
                     on_click: {
-                        let on_close = props.on_close;
+                        let on_close = on_close;
                         let src = src.clone();
                         move |_| {
                             let src = src.clone();
@@ -201,7 +210,7 @@ pub fn ContentContextMenu(props: ContentContextMenuProps) -> Element {
                     shortcut: shortcut("clipboard.copy_image"),
                     icon: Some(IconName::Photo),
                     on_click: {
-                        let on_close = props.on_close;
+                        let on_close = on_close;
                         move |_| {
                             copy_special_block_image(is_mermaid, false);
                             on_close.call(());
@@ -214,10 +223,10 @@ pub fn ContentContextMenu(props: ContentContextMenuProps) -> Element {
             if let Some(value) = copy_path_value.clone() {
                 ContextMenuItem {
                     label: copy_path_label.clone(),
-                    shortcut: shortcut(copy_path_shortcut_action_str(props.source_line, props.source_line_end)),
+                    shortcut: shortcut(copy_path_shortcut_action_str(source_line, source_line_end)),
                     icon: Some(IconName::Copy),
                     on_click: {
-                        let on_close = props.on_close;
+                        let on_close = on_close;
                         move |_| {
                             crate::utils::clipboard::copy_text(&value);
                             crate::keybindings::dispatcher::show_action_feedback("Copied");
@@ -234,7 +243,7 @@ pub fn ContentContextMenu(props: ContentContextMenuProps) -> Element {
                 label: "Select All",
                 icon: Some(IconName::SelectAll),
                 on_click: {
-                    let on_close = props.on_close;
+                    let on_close = on_close;
                     move |_| {
                         exec_edit_command("selectAll");
                         on_close.call(());
@@ -247,7 +256,7 @@ pub fn ContentContextMenu(props: ContentContextMenuProps) -> Element {
                 shortcut: shortcut("search.open"),
                 icon: Some(IconName::Search),
                 on_click: {
-                    let on_close = props.on_close;
+                    let on_close = on_close;
                     move |_| {
                         dispatch_action(&Action::SearchOpen, state);
                         on_close.call(());
@@ -261,23 +270,23 @@ pub fn ContentContextMenu(props: ContentContextMenuProps) -> Element {
             }
 
             // Copy As... (Text / Markdown)
-            if props.has_selection {
+            if has_selection {
                 CopyAsSubmenu {
-                    selected_text: props.selected_text.clone(),
-                    current_file: props.current_file.clone(),
-                    source_line: props.source_line,
-                    source_line_end: props.source_line_end,
-                    on_close: props.on_close,
+                    selected_text: selected_text.clone(),
+                    current_file: current_file.clone(),
+                    source_line: source_line,
+                    source_line_end: source_line_end,
+                    on_close: on_close,
                 }
             }
 
             // Copy Path As... (Path / Path with Line / Path with Range)
             if has_file {
                 CopyPathAsSubmenu {
-                    current_file: props.current_file.clone().unwrap(),
-                    source_line: props.source_line,
-                    source_line_end: props.source_line_end,
-                    on_close: props.on_close,
+                    current_file: current_file.clone().unwrap(),
+                    source_line: source_line,
+                    source_line_end: source_line_end,
+                    on_close: on_close,
                 }
             }
 
@@ -285,23 +294,23 @@ pub fn ContentContextMenu(props: ContentContextMenuProps) -> Element {
             if let Some(code_content) = copy_code_source.clone() {
                 CopyCodeAsSubmenu {
                     code_content,
-                    current_file: props.current_file.clone(),
+                    current_file: current_file.clone(),
                     block_source_line: code_block_line,
                     block_source_line_end: code_block_line_end,
-                    on_close: props.on_close,
+                    on_close: on_close,
                 }
             }
 
             // Copy Table As... (TSV / CSV / Markdown)
             if has_table {
                 CopyTableAsSubmenu {
-                    table_tsv: props.table_tsv.clone(),
-                    table_csv: props.table_csv.clone(),
-                    table_markdown: props.table_markdown.clone(),
-                    current_file: props.current_file.clone(),
-                    table_source_line: props.table_source_line,
-                    table_source_line_end: props.table_source_line_end,
-                    on_close: props.on_close,
+                    table_tsv: table_tsv.clone(),
+                    table_csv: table_csv.clone(),
+                    table_markdown: table_markdown.clone(),
+                    current_file: current_file.clone(),
+                    table_source_line: table_source_line,
+                    table_source_line_end: table_source_line_end,
+                    on_close: on_close,
                 }
             }
 
@@ -310,7 +319,7 @@ pub fn ContentContextMenu(props: ContentContextMenuProps) -> Element {
                 CopyImageAsSubmenu {
                     src: src.clone(),
                     alt: alt.clone(),
-                    on_close: props.on_close,
+                    on_close: on_close,
                 }
             }
 
@@ -318,7 +327,7 @@ pub fn ContentContextMenu(props: ContentContextMenuProps) -> Element {
             if is_special_block {
                 CopySpecialBlockAsSubmenu {
                     is_mermaid,
-                    on_close: props.on_close,
+                    on_close: on_close,
                 }
             }
 
@@ -327,11 +336,11 @@ pub fn ContentContextMenu(props: ContentContextMenuProps) -> Element {
                 ContextMenuSeparator {}
             }
 
-            match &props.context {
+            match &context {
                 ContentContext::Link { href } => rsx! {
                     LinkContextItems {
                         href: href.clone(),
-                        on_close: props.on_close,
+                        on_close: on_close,
                     }
                 },
                 ContentContext::Image { .. } => rsx! {
@@ -340,7 +349,7 @@ pub fn ContentContextMenu(props: ContentContextMenuProps) -> Element {
                         shortcut: shortcut("file.save_image_as"),
                         icon: Some(IconName::Download),
                         on_click: {
-                            let on_close = props.on_close;
+                            let on_close = on_close;
                             move |_| {
                                 dispatch_action(&Action::FileSaveImageAs, state);
                                 on_close.call(());
@@ -354,7 +363,7 @@ pub fn ContentContextMenu(props: ContentContextMenuProps) -> Element {
                         shortcut: shortcut("file.save_image_as"),
                         icon: Some(IconName::Download),
                         on_click: {
-                            let on_close = props.on_close;
+                            let on_close = on_close;
                             move |_| {
                                 dispatch_action(&Action::FileSaveImageAs, state);
                                 on_close.call(());

--- a/crates/arto/src/components/content/context_menu/data.rs
+++ b/crates/arto/src/components/content/context_menu/data.rs
@@ -1,6 +1,4 @@
-use dioxus::prelude::*;
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
 
 /// Context type for right-click detection
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -61,22 +59,4 @@ pub struct ContextMenuData {
     /// Table source line end (1-based)
     #[serde(default)]
     pub table_source_line_end: Option<u32>,
-}
-
-#[derive(Props, Clone, PartialEq)]
-pub struct ContentContextMenuProps {
-    pub position: (i32, i32),
-    pub context: ContentContext,
-    pub has_selection: bool,
-    pub selected_text: String,
-    pub current_file: Option<PathBuf>,
-    pub base_dir: PathBuf,
-    pub source_line: Option<u32>,
-    pub source_line_end: Option<u32>,
-    pub table_csv: Option<String>,
-    pub table_tsv: Option<String>,
-    pub table_markdown: Option<String>,
-    pub table_source_line: Option<u32>,
-    pub table_source_line_end: Option<u32>,
-    pub on_close: EventHandler<()>,
 }

--- a/crates/arto/src/components/content/file_viewer.rs
+++ b/crates/arto/src/components/content/file_viewer.rs
@@ -22,26 +22,30 @@ struct LinkClickData {
 const LEFT_CLICK: u32 = 0;
 const MIDDLE_CLICK: u32 = 1;
 
+/// The directory relative links in `file` resolve against.
+fn base_dir_of(file: &Path) -> PathBuf {
+    file.parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
+/// `file` is a `ReadSignal` so the hooks below re-run when the parent passes
+/// a different path: reading it inside an effect subscribes the effect, which
+/// is what `use_reactive!` used to emulate for a plain value.
 #[component]
-pub fn FileViewer(file: PathBuf) -> Element {
+pub fn FileViewer(file: ReadSignal<PathBuf>) -> Element {
     let state = use_context::<AppState>();
     let html = use_signal(String::new);
 
-    // Get base directory for link resolution
-    let base_dir = file
-        .parent()
-        .map(|p| p.to_path_buf())
-        .unwrap_or_else(|| PathBuf::from("."));
-
     // Setup component hooks
-    use_file_loader(file.clone(), html, state);
-    use_file_watcher(file.clone(), state);
-    use_link_click_handler(file.clone(), state);
+    use_file_loader(file, html, state);
+    use_file_watcher(file, state);
+    use_link_click_handler(file, state);
     use_mermaid_window_handler();
     use_math_window_handler();
     use_image_window_handler();
     use_clipboard_handlers();
-    use_context_menu_handler(file.clone(), base_dir);
+    use_context_menu_handler(file);
 
     rsx! {
         div {
@@ -57,17 +61,13 @@ pub fn FileViewer(file: PathBuf) -> Element {
 }
 
 /// Hook to load and render file content
-fn use_file_loader(file: PathBuf, html: Signal<String>, mut state: AppState) {
-    use_effect(use_reactive!(|file| {
+fn use_file_loader(file: ReadSignal<PathBuf>, html: Signal<String>, mut state: AppState) {
+    use_effect(move || {
+        let file = file();
         let mut html = html;
-        // Subscribe to reload_trigger via Dioxus auto-subscription so this
-        // effect re-runs when the counter changes (manual reload or file watcher).
-        // NOTE: We intentionally read() here instead of adding reload_trigger to the
-        // use_reactive!(|...|) argument list, because use_reactive! compares Signal
-        // by pointer identity — the same Signal object is always "equal" to itself,
-        // so value changes would never be detected.
+        // Reading reload_trigger subscribes this effect to it, so a manual
+        // reload or a file-watcher event re-runs the load as well.
         let _ = state.reload_trigger.read();
-        let file = file.clone();
 
         // Handle scroll position SYNCHRONOUSLY before spawning async task.
         // This ensures the onRenderComplete callback is registered before
@@ -135,7 +135,7 @@ fn use_file_loader(file: PathBuf, html: Signal<String>, mut state: AppState) {
                 }
             }
         });
-    }));
+    });
 }
 
 /// Handle scroll position when navigating to a file.
@@ -270,9 +270,9 @@ async fn reapply_search() {
 }
 
 /// Hook to watch file for changes and trigger reload
-fn use_file_watcher(file: PathBuf, mut state: AppState) {
-    use_effect(use_reactive!(|file| {
-        let file = file.clone();
+fn use_file_watcher(file: ReadSignal<PathBuf>, mut state: AppState) {
+    use_effect(move || {
+        let file = file();
 
         spawn(async move {
             let file_path = file.clone();
@@ -301,24 +301,19 @@ fn use_file_watcher(file: PathBuf, mut state: AppState) {
                 );
             }
         });
-    }));
+    });
 }
 
 /// Hook to setup JavaScript handler for markdown link clicks
-fn use_link_click_handler(file: PathBuf, state: AppState) {
-    use_effect(use_reactive!(|file| {
-        let file = file.clone();
+fn use_link_click_handler(file: ReadSignal<PathBuf>, state: AppState) {
+    use_effect(move || {
+        let base_dir = base_dir_of(&file());
         let mut eval_provider = document::eval(indoc::indoc! {r#"
             window.handleMarkdownLinkClick = (path, button) => {
                 const scrollPosition = document.querySelector('.content')?.scrollTop || 0;
                 dioxus.send({ path, button, scroll_position: scrollPosition });
             };
         "#});
-
-        let base_dir = file
-            .parent()
-            .map(|p| p.to_path_buf())
-            .unwrap_or_else(|| PathBuf::from("."));
 
         let mut state_clone = state;
 
@@ -327,7 +322,7 @@ fn use_link_click_handler(file: PathBuf, state: AppState) {
                 handle_link_click(click_data, &base_dir, &mut state_clone);
             }
         });
-    }));
+    });
 }
 
 /// Handle a markdown link click event
@@ -496,10 +491,10 @@ fn use_clipboard_handlers() {
 ///
 /// Uses global state to avoid re-rendering FileViewer when menu state changes.
 /// This preserves text selection in the content.
-fn use_context_menu_handler(file: PathBuf, base_dir: PathBuf) {
-    use_effect(use_reactive!(|file, base_dir| {
-        let file = file.clone();
-        let base_dir = base_dir.clone();
+fn use_context_menu_handler(file: ReadSignal<PathBuf>) {
+    use_effect(move || {
+        let file = file();
+        let base_dir = base_dir_of(&file);
 
         // Setup JS context menu handler using the exported function
         // Wait for window.Arto to be available (init() is async)
@@ -525,5 +520,5 @@ fn use_context_menu_handler(file: PathBuf, base_dir: PathBuf) {
                 });
             }
         });
-    }));
+    });
 }

--- a/crates/arto/src/components/content/inline_viewer.rs
+++ b/crates/arto/src/components/content/inline_viewer.rs
@@ -4,8 +4,11 @@ use std::path::Path;
 use crate::markdown::render_to_html;
 use crate::state::AppState;
 
+/// `markdown` is a `ReadSignal` for the same reason as `FileViewer`'s path:
+/// the loader effect reads it and so re-renders when the parent passes new
+/// text to the same mounted instance.
 #[component]
-pub fn InlineViewer(markdown: String) -> Element {
+pub fn InlineViewer(markdown: ReadSignal<String>) -> Element {
     let state = use_context::<AppState>();
     let html = use_signal(String::new);
 
@@ -25,10 +28,10 @@ pub fn InlineViewer(markdown: String) -> Element {
 }
 
 /// Hook to render inline markdown content
-fn use_inline_markdown_loader(markdown: String, html: Signal<String>) {
+fn use_inline_markdown_loader(markdown: ReadSignal<String>, html: Signal<String>) {
     use_effect(move || {
         let mut html = html;
-        let markdown = markdown.clone();
+        let markdown = markdown();
 
         spawn(async move {
             // Render inline markdown (use a dummy path since images are already embedded)

--- a/crates/arto/src/components/context_menu/menu_item.rs
+++ b/crates/arto/src/components/context_menu/menu_item.rs
@@ -2,31 +2,24 @@ use dioxus::prelude::*;
 
 use crate::components::icon::{Icon, IconName};
 
-#[derive(Props, Clone, PartialEq)]
-pub struct ContextMenuItemProps {
-    #[props(into)]
-    label: String,
-    #[props(default)]
-    shortcut: Option<String>,
-    #[props(default)]
-    icon: Option<IconName>,
-    #[props(default = false)]
-    disabled: bool,
-    on_click: EventHandler<()>,
-}
-
 #[component]
-pub fn ContextMenuItem(props: ContextMenuItemProps) -> Element {
+pub fn ContextMenuItem(
+    #[props(into)] label: String,
+    #[props(default)] shortcut: Option<String>,
+    #[props(default)] icon: Option<IconName>,
+    #[props(default = false)] disabled: bool,
+    on_click: EventHandler<()>,
+) -> Element {
     rsx! {
         div {
-            class: if props.disabled { "context-menu-item disabled" } else { "context-menu-item" },
+            class: if disabled { "context-menu-item disabled" } else { "context-menu-item" },
             onclick: move |_| {
-                if !props.disabled {
-                    props.on_click.call(());
+                if !disabled {
+                    on_click.call(());
                 }
             },
 
-            if let Some(icon) = props.icon {
+            if let Some(icon) = icon {
                 Icon {
                     name: icon,
                     size: 14,
@@ -34,9 +27,9 @@ pub fn ContextMenuItem(props: ContextMenuItemProps) -> Element {
                 }
             }
 
-            span { class: "context-menu-label", "{props.label}" }
+            span { class: "context-menu-label", "{label}" }
 
-            if let Some(shortcut) = props.shortcut {
+            if let Some(shortcut) = shortcut {
                 span { class: "context-menu-shortcut", "{shortcut}" }
             }
         }

--- a/crates/arto/src/components/icon.rs
+++ b/crates/arto/src/components/icon.rs
@@ -105,25 +105,20 @@ impl fmt::Display for IconName {
     }
 }
 
-#[derive(Props, Clone, PartialEq)]
-pub struct IconProps {
-    pub name: IconName,
-    #[props(default = 20)]
-    pub size: u32,
-    #[props(default = "")]
-    pub class: &'static str,
-}
-
 #[component]
-pub fn Icon(props: IconProps) -> Element {
+pub fn Icon(
+    name: IconName,
+    #[props(default = 20)] size: u32,
+    #[props(default = "")] class: &'static str,
+) -> Element {
     let sprite_url = TABLER_SPRITE.to_string();
-    let icon_id = format!("tabler-{}", props.name);
+    let icon_id = format!("tabler-{}", name);
 
     rsx! {
         svg {
-            class: "icon {props.class}",
-            width: "{props.size}",
-            height: "{props.size}",
+            class: "icon {class}",
+            width: "{size}",
+            height: "{size}",
             "aria-hidden": "true",
             r#use {
                 href: "{sprite_url}#{icon_id}"

--- a/crates/arto/src/components/right_sidebar.rs
+++ b/crates/arto/src/components/right_sidebar.rs
@@ -15,15 +15,12 @@ use crate::state::{AppState, FocusedPanel};
 // it is re-exported here so the sidebar keeps a local name for it.
 pub use crate::config::RightSidebarTab;
 
-#[derive(Props, Clone, PartialEq)]
-pub struct RightSidebarProps {
-    pub headings: Vec<HeadingInfo>,
-    pub on_pin_toggle: Option<EventHandler<()>>,
-    pub on_resize_change: Option<EventHandler<bool>>,
-}
-
 #[component]
-pub fn RightSidebar(props: RightSidebarProps) -> Element {
+pub fn RightSidebar(
+    headings: Vec<HeadingInfo>,
+    on_pin_toggle: Option<EventHandler<()>>,
+    on_resize_change: Option<EventHandler<bool>>,
+) -> Element {
     let mut state = use_context::<AppState>();
     let (width, active_tab, zoom_level) = {
         let right_sidebar = state.right_sidebar.read();
@@ -37,9 +34,6 @@ pub fn RightSidebar(props: RightSidebarProps) -> Element {
     let toc_cursor = *state.toc_cursor.read();
     let is_resizing = use_signal(|| false);
 
-    // Get data for each tab
-    let headings = props.headings.clone();
-
     let outer_style = format!("width: {}px;", width);
     let inner_style = format!("zoom: {};", zoom_level);
 
@@ -51,7 +45,7 @@ pub fn RightSidebar(props: RightSidebarProps) -> Element {
             style: "{outer_style}",
 
             // Resize handle
-            RightSidebarResizeHandle { is_resizing, on_resize_change: props.on_resize_change }
+            RightSidebarResizeHandle { is_resizing, on_resize_change }
 
             // Inner wrapper with zoom applied
             div {
@@ -62,7 +56,7 @@ pub fn RightSidebar(props: RightSidebarProps) -> Element {
                 TabBar {
                     active_tab,
                     on_change: move |tab| state.set_right_sidebar_tab(tab),
-                    on_pin_toggle: props.on_pin_toggle,
+                    on_pin_toggle,
                 }
 
                 // Tab content

--- a/crates/arto/src/components/search_bar.rs
+++ b/crates/arto/src/components/search_bar.rs
@@ -90,10 +90,6 @@ pub fn SearchBar() -> Element {
     let is_open = *state.search_open.read();
     let match_count = *state.search_match_count.read();
     let current_index = *state.search_current_index.read();
-    let initial_text = state.search_initial_text.read().clone();
-    // Bumped on every open-search request so re-pressing the shortcut refocuses
-    // the input even when the bar is already open.
-    let focus_request = *state.search_focus_request.read();
     let mut has_input = use_signal(|| false);
 
     // Local signal for pinned searches (updated via broadcast)
@@ -119,11 +115,14 @@ pub fn SearchBar() -> Element {
         }
     });
 
-    // Handle focus and initial text when search bar opens.
-    // `focus_request` is a reactive trigger: it re-runs this effect on every
-    // open-search request, even when `is_open`/`initial_text` are unchanged.
-    use_effect(use_reactive!(|is_open, initial_text, focus_request| {
-        let _ = focus_request;
+    // Handle focus and initial text when search bar opens. The effect
+    // subscribes to the signals it reads; `search_focus_request` is bumped on
+    // every open-search request so re-pressing the shortcut refocuses the
+    // input even when the bar is already open with the same text.
+    use_effect(move || {
+        let is_open = *state.search_open.read();
+        let initial_text = state.search_initial_text.read().clone();
+        let _ = state.search_focus_request.read();
         if is_open {
             if let Some(ref text) = initial_text {
                 if !text.is_empty() {
@@ -160,18 +159,18 @@ pub fn SearchBar() -> Element {
                 });
             }
         }
-    }));
+    });
 
     // Move focus away from search input after closing the search bar.
     // Without explicit body focus, keyboard shortcuts stop working because
     // keydown events may not reach the document-level interceptor.
-    use_effect(use_reactive!(|is_open| {
-        if !is_open {
+    use_effect(move || {
+        if !*state.search_open.read() {
             spawn(async move {
                 let _ = document::eval(JS_BLUR_TO_BODY).await;
             });
         }
-    }));
+    });
 
     rsx! {
         div {

--- a/crates/arto/src/components/sidebar/file_explorer.rs
+++ b/crates/arto/src/components/sidebar/file_explorer.rs
@@ -79,7 +79,9 @@ fn read_sorted_entries(path: &PathBuf) -> Vec<FileEntry> {
 #[component]
 pub fn FileExplorer(on_pin_toggle: Option<EventHandler<()>>) -> Element {
     let state = use_context::<AppState>();
-    let root_directory = state.sidebar.read().root_directory.clone();
+    // A memo rather than a plain read: the watcher below must restart only
+    // when the root changes, not on every other sidebar field update.
+    let root_directory = use_memo(move || state.sidebar.read().root_directory.clone());
 
     // Refresh counter to force DirectoryTree re-render. Sourced from AppState
     // (not a local signal) so the hoisted context menu's "Reload" action can
@@ -87,14 +89,14 @@ pub fn FileExplorer(on_pin_toggle: Option<EventHandler<()>>) -> Element {
     let refresh_counter = state.sidebar_refresh_counter;
 
     // Watch directory for file system changes
-    use_directory_watcher(root_directory.clone(), refresh_counter);
+    use_directory_watcher(root_directory.into(), refresh_counter);
 
     rsx! {
         div {
             class: "left-sidebar-explorer",
             key: "{refresh_counter}",
 
-            if let Some(root) = root_directory {
+            if let Some(root) = root_directory() {
                 DirectoryNavigation { current_dir: root.clone(), on_pin_toggle }
                 DirectoryTree { path: root, refresh_counter }
             } else {
@@ -380,13 +382,19 @@ fn DirectoryTree(path: PathBuf, refresh_counter: Signal<u32>) -> Element {
 /// - `path` changes (user navigates to a different directory)
 /// - `refresh_counter` increments (file watcher detects filesystem changes)
 #[component]
-fn DirectoryChildren(path: PathBuf, depth: usize, refresh_counter: Signal<u32>) -> Element {
+fn DirectoryChildren(
+    path: ReadSignal<PathBuf>,
+    depth: usize,
+    refresh_counter: Signal<u32>,
+) -> Element {
     // Watch expanded directories only (non-recursive) to avoid broad permission access.
-    use_directory_watcher(Some(path.clone()), refresh_counter);
+    let watched = use_memo(move || Some(path()));
+    use_directory_watcher(watched.into(), refresh_counter);
 
     // Subscribe to the signal so Dioxus re-runs this component when the
     // counter increments (file watcher detected filesystem changes).
     let _ = refresh_counter.read();
+    let path = path();
     let children = read_sorted_entries(&path);
     rsx! {
         for child in children {
@@ -784,11 +792,12 @@ pub fn SidebarContextMenuHost() -> Element {
 }
 
 /// Hook to watch a directory for file system changes and trigger refresh
-fn use_directory_watcher(directory: Option<PathBuf>, mut refresh_counter: Signal<u32>) {
+fn use_directory_watcher(directory: ReadSignal<Option<PathBuf>>, mut refresh_counter: Signal<u32>) {
     // Cancellation signal for the currently active watcher task.
     let mut stop_tx = use_signal(|| None::<oneshot::Sender<()>>);
 
-    use_effect(use_reactive!(|directory| {
+    use_effect(move || {
+        let directory = directory();
         // Cancel previous watcher when target directory changes.
         if let Some(tx) = stop_tx.write().take() {
             let _ = tx.send(());
@@ -829,7 +838,7 @@ fn use_directory_watcher(directory: Option<PathBuf>, mut refresh_counter: Signal
 
             let _ = FILE_WATCHER.unwatch_directory_non_recursive(dir).await;
         });
-    }));
+    });
 
     // Ensure watcher task gets cancelled when component unmounts.
     use_drop(move || {

--- a/crates/arto/src/hooks/viewer_window.rs
+++ b/crates/arto/src/hooks/viewer_window.rs
@@ -133,20 +133,13 @@ pub enum CopyStatus {
     Error,
 }
 
-/// Props for the CopyImageButton component.
-#[derive(Props, Clone, PartialEq)]
-pub struct CopyImageButtonProps {
-    /// JavaScript function to call for copy (e.g., "copyImageToClipboard", "copyMathAsImage")
-    pub js_function: String,
-    /// Aria label for accessibility
-    pub label: String,
-}
-
 /// Reusable copy image button that calls a JS function and shows feedback.
+///
+/// `js_function` names the frontend export to call (e.g.
+/// "copyImageToClipboard", "copyMathAsImage"); `label` is the aria label.
 #[component]
-pub fn CopyImageButton(props: CopyImageButtonProps) -> Element {
+pub fn CopyImageButton(js_function: String, label: String) -> Element {
     let mut copy_status = use_signal(|| CopyStatus::Idle);
-    let js_function = props.js_function.clone();
 
     let handle_click = move |_| {
         let js_function = js_function.clone();
@@ -197,8 +190,8 @@ pub fn CopyImageButton(props: CopyImageButtonProps) -> Element {
     rsx! {
         button {
             class: "viewer-control-btn {extra_class}",
-            "aria-label": "{props.label}",
-            title: "{props.label}",
+            "aria-label": "{label}",
+            title: "{label}",
             disabled: is_copying,
             onclick: handle_click,
             Icon { name: icon, size: 18 }

--- a/crates/arto/src/lib.rs
+++ b/crates/arto/src/lib.rs
@@ -138,12 +138,6 @@ pub fn run(invocation: cli::CliInvocation) -> RunResult {
 }
 
 fn init_tracing() {
-    let silence_filter = tracing_subscriber::filter::filter_fn(|metadata| {
-        // Filter out specific error from dioxus_core::properties:136
-        // Known issue: https://github.com/DioxusLabs/dioxus/issues/3872
-        metadata.target() != "dioxus_core::properties::__component_called_as_function"
-    });
-
     let env_filter_layer =
         EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(DEFAULT_LOGLEVEL));
 
@@ -153,8 +147,7 @@ fn init_tracing() {
         .with_target(false)
         .with_thread_ids(false)
         .with_file(true)
-        .with_line_number(true)
-        .with_filter(silence_filter.clone());
+        .with_line_number(true);
 
     let registry = tracing_subscriber::registry()
         .with(env_filter_layer)
@@ -162,9 +155,10 @@ fn init_tracing() {
 
     // On macOS, log to Console.app via oslog
     #[cfg(target_os = "macos")]
-    let registry = registry.with(
-        tracing_oslog::OsLogger::new("com.lambdalisue.Arto", "default").with_filter(silence_filter),
-    );
+    let registry = registry.with(tracing_oslog::OsLogger::new(
+        "com.lambdalisue.Arto",
+        "default",
+    ));
 
     registry.init();
 }

--- a/crates/arto/src/window/child.rs
+++ b/crates/arto/src/window/child.rs
@@ -5,7 +5,7 @@ use dioxus::prelude::*;
 use std::cell::RefCell;
 use std::collections::HashMap;
 
-use crate::assets::MAIN_STYLE;
+use crate::assets::main_stylesheet_head;
 use crate::components::image_window::{generate_image_id, ImageWindow, ImageWindowProps};
 use crate::components::math_window::{generate_math_id, MathWindow, MathWindowProps};
 use crate::components::mermaid_window::{generate_diagram_id, MermaidWindow, MermaidWindowProps};
@@ -183,7 +183,7 @@ pub fn open_or_focus_mermaid_window(source: String, theme: Theme) {
             .with_window(super::icon::apply_app_icon(
                 WindowBuilder::new().with_title("Mermaid Viewer"),
             ))
-            .with_custom_head(indoc::formatdoc! {r#"<link rel="stylesheet" href="{MAIN_STYLE}">"#})
+            .with_custom_head(main_stylesheet_head())
             .with_custom_index(build_mermaid_window_index(theme));
 
         dioxus_core::spawn(create_and_register_child_window(
@@ -210,7 +210,7 @@ pub fn open_or_focus_math_window(source: String, theme: Theme) {
             .with_window(super::icon::apply_app_icon(
                 WindowBuilder::new().with_title("Math Viewer"),
             ))
-            .with_custom_head(indoc::formatdoc! {r#"<link rel="stylesheet" href="{MAIN_STYLE}">"#})
+            .with_custom_head(main_stylesheet_head())
             .with_custom_index(build_math_window_index(theme));
 
         dioxus_core::spawn(create_and_register_child_window(
@@ -238,7 +238,7 @@ pub fn open_or_focus_image_window(src: String, alt: Option<String>, theme: Theme
             .with_window(super::icon::apply_app_icon(
                 WindowBuilder::new().with_title("Image Viewer"),
             ))
-            .with_custom_head(indoc::formatdoc! {r#"<link rel="stylesheet" href="{MAIN_STYLE}">"#})
+            .with_custom_head(main_stylesheet_head())
             .with_custom_index(build_image_window_index(theme));
 
         dioxus_core::spawn(create_and_register_child_window(

--- a/crates/arto/src/window/main.rs
+++ b/crates/arto/src/window/main.rs
@@ -12,7 +12,7 @@ use std::rc::Rc;
 
 use crate::state::AppState;
 
-use crate::assets::MAIN_STYLE;
+use crate::assets::main_stylesheet_head;
 use crate::components::app::{App, AppProps};
 use crate::components::right_sidebar::RightSidebarTab;
 use crate::config::{WindowPositionOffset, CONFIG};
@@ -46,7 +46,7 @@ pub fn create_main_window_config(params: &CreateMainWindowConfigParams) -> Confi
         })
         // Add main style in config. Otherwise the style takes time to load and
         // the window appears unstyled for a brief moment.
-        .with_custom_head(indoc::formatdoc! {r#"<link rel="stylesheet" href="{MAIN_STYLE}">"#})
+        .with_custom_head(main_stylesheet_head())
         // Use a custom index to set the initial theme correctly
         .with_custom_index(build_custom_index(params.theme))
 }


### PR DESCRIPTION
## Summary

Stacked on #232 (`refactor/page-config`). Dioxus 0.7 idioms pass of the repository layout refactor: removes the 0.6-era habits that can be changed safely without on-device verification.

- **Workaround removal:** the tracing filter for `dioxus_core::properties::__component_called_as_function` (DioxusLabs/dioxus#3872). dioxus-core 0.7.10 no longer logs under that target (verified by grepping the vendored source), so the filter was dead.
- **`use_reactive!` gone (8 sites):** `FileViewer` takes `file: ReadSignal<PathBuf>` and its hooks read the signal inside their effects (same for `InlineViewer` and its markdown); `SearchBar` effects read the open/initial-text/focus-request signals directly; `FileExplorer` derives the root via `use_memo` so the directory watcher only restarts when the root changes (a plain `state.sidebar.read()` inside the effect would restart it on every sidebar width/pin change).
- **`spawn_forever` → `use_future`** for the keybinding config listener, so it is cancelled with the window instead of outliving the `engine` signal.
- **Props audit:** five standalone `Props` structs folded into `#[component]` parameters (Icon, ContextMenuItem, CopyImageButton, RightSidebar, ContentContextMenu). Mermaid/Math/Image window props stay as structs (`VirtualDom::new_with_props`).
- **Stylesheet:** kept in `with_custom_head`, now through one `main_stylesheet_head()` helper. `document::Stylesheet {}` was evaluated and rejected: it is inserted by the runtime after the first render (`create_head_component`), which would bring back the unstyled flash on every new window. The helper's doc comment records this.
- Docs: `.claude/CLAUDE.md` async patterns and `.claude/TIPS.md` updated accordingly; the "State-Dependent Handler" example in CLAUDE.md showed a broadcast receiver loop that never existed in the code and now shows the real second `use_muda_event_handler` with its focus check.

Not done in this PR (separate follow-ups): consolidating the `document::eval` call sites into a typed bridge, and the `dx serve --hot-patch` check, which needs the app running.

## Test plan

- [x] `just fmt check test`
- [ ] CI: Build workflow on all three OSes
- [ ] Manual on macOS: open a file, switch tabs, edit the file on disk (reload), open the search bar twice with different text, change the sidebar root and confirm the tree refreshes on file changes, save keybindings in Preferences and confirm they apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VhuHhy2xFFF9UHEd9Pg4mx
