### PR TITLE
docs(arto-markdown): pin the HTML contract with docs and TOC snapshots

### DIFF
--- a/crates/arto-markdown/src/lib.rs
+++ b/crates/arto-markdown/src/lib.rs
@@ -1,3 +1,113 @@
+//! Arto's Markdown to HTML pipeline.
+//!
+//! One rendering path serves the desktop app, `arto page` and the Quick
+//! Look extension, so the HTML this crate produces is a contract: the
+//! frontend scripts, the app and the stylesheets read the attributes and
+//! class names listed below by name. Changing any of them means changing
+//! every reader in the same step, and the sample documents under
+//! `samples/` are snapshot-tested (`tests/samples.rs`) so that an unintended
+//! change shows up as a diff.
+//!
+//! # Pipeline
+//!
+//! 1. **Frontmatter.** A leading YAML block is cut off and rendered to a
+//!    `<details class="frontmatter">` table that is prepended to the
+//!    output at the very end. The lines it occupied are added to every
+//!    source line below it.
+//! 2. **Text pre-processing.** Bare URLs become `<URL>` autolinks (when
+//!    [`RenderOptions::auto_link_urls`] is set) and GitHub alerts
+//!    (`> [!NOTE]`) are rendered to HTML before the parser sees them. The
+//!    first keeps the line count; the second records which original line
+//!    each processed line came from, so source lines stay correct.
+//! 3. **Parsing and rendering.** pulldown-cmark with every extension.
+//!    Fenced `mermaid` and `math` blocks and `$…$` expressions are replaced
+//!    by the `preprocessed-*` containers described below, and block
+//!    elements receive their `data-source-line` attributes.
+//! 4. **Post-processing** with lol_html: local images are inlined as data
+//!    URLs, local Markdown links become `<span class="md-link">`, tables get
+//!    their source lines, and headings get their ids when a table of
+//!    contents was requested.
+//!
+//! # HTML contract
+//!
+//! ## Source lines
+//!
+//! Block elements carry `data-source-line="N"`, the 1-based line of the
+//! file where the block starts: `p`, `h1`–`h6`, `blockquote`, `hr`, `tr`
+//! and `div.markdown-alert`. Blocks that span several lines also carry
+//! `data-source-line-end="N"`: `ul`, `ol`, `li`, `table`, `pre` and
+//! `div.preprocessed-math-display`. Code blocks additionally carry
+//! `data-source-line-start="N"`, the line their content starts on (the
+//! line after the fence, or the same line for an indented block), so the
+//! frontend can count newlines inside `<code>` down to the exact line.
+//!
+//! Readers: `frontend/src/context-menu-handler.ts` (copy path with line)
+//! and `frontend/src/content-cursor.ts` (keyboard cursor) resolve line
+//! ranges from these; the app receives the range through
+//! `crates/arto/src/components/content/context_menu/data.rs` and turns it
+//! back into text in `crates/arto/src/utils/source_lines.rs`.
+//!
+//! ## Mermaid and math
+//!
+//! The frontend renders diagrams and formulas client-side, so the pipeline
+//! emits containers that hold the source text twice: escaped as the
+//! visible fallback, and in `data-original-content` for the renderer.
+//!
+//! - ` ```mermaid ` → `<pre class="preprocessed-mermaid" data-original-content="…">`
+//! - ` ```math ` → `<pre class="preprocessed-math" data-original-content="…">`
+//! - `$$…$$` → `<div class="preprocessed-math-display" data-original-content="…">`
+//! - `$…$` → `<span class="preprocessed-math-inline" data-original-content="…">`
+//!
+//! Readers: `frontend/src/mermaid-renderer.ts`, `frontend/src/math-renderer.ts`,
+//! `frontend/src/code-copy.ts` (copy as image), `frontend/src/content-cursor.ts`,
+//! `frontend/src/context-menu-handler.ts`, `frontend/src/render-coordinator.ts`
+//! and `crates/arto/src/keybindings/dispatcher.rs` (open in a window);
+//! styled by `frontend/style/components/content/markdown-viewer.css`,
+//! `frontend/style/components/mermaid-window.css`,
+//! `frontend/style/components/math-window.css` and `frontend/style/print.css`.
+//!
+//! ## GitHub alerts
+//!
+//! `> [!NOTE]` and the other kinds become
+//! `<div class="markdown-alert markdown-alert-<kind>" dir="auto">` with a
+//! `<p class="markdown-alert-title">` holding
+//! `<span class="alert-icon" data-alert-type="<kind>">` and the kind name.
+//! The class names are GitHub's, so `github-markdown-css` styles them; the
+//! icon span is filled in by the frontend.
+//!
+//! ## Frontmatter
+//!
+//! `<details class="frontmatter">` wraps `<summary class="frontmatter-summary">`
+//! and `<table class="frontmatter-table">`. Values are typed with
+//! `yaml-null`, `yaml-bool`, `yaml-number`, `yaml-empty`, `yaml-list` and
+//! `yaml-nested`; styled by `frontend/style/components/content/frontmatter.css`.
+//!
+//! ## Links and images
+//!
+//! A link to a local file becomes `<span class="md-link" data-md-link="…">`
+//! with an inline `onmousedown` that calls
+//! `window.handleMarkdownLinkClick(path, button)`, which the app installs
+//! in `crates/arto/src/components/content/file_viewer.rs`. Links to files
+//! that are not Markdown add `md-link-invalid`. `http(s)` links stay
+//! anchors. Local images are inlined as `data:` URLs so the page works
+//! offline and in Quick Look; readers of `data-md-link` and `.md-link` are
+//! the app and `frontend/style/components/content/markdown-viewer.css`.
+//!
+//! ## Headings
+//!
+//! [`render_to_html_with_toc`] returns [`HeadingInfo`] for every heading
+//! and sets the same `id` on the rendered `h1`–`h6`, so the table of
+//! contents (`crates/arto/src/components/right_sidebar/contents_tab.rs`)
+//! can scroll to it with `getElementById`. The id is derived from the
+//! heading text and replaces an explicit `{#id}` attribute.
+//! [`render_to_html`] adds no ids; only an explicit `{#id}` survives.
+//!
+//! ## Code blocks
+//!
+//! `<pre><code class="language-<lang>">` as pulldown-cmark writes it; the
+//! frontend highlights by that class and `frontend/src/code-copy.ts` adds
+//! the copy button to every `pre`.
+
 mod alerts;
 mod autolinks;
 mod event_processors;

--- a/crates/arto-markdown/tests/samples.rs
+++ b/crates/arto-markdown/tests/samples.rs
@@ -5,8 +5,11 @@
 //! change in output fails here with a diff, so a parser upgrade or an engine
 //! swap shows exactly which constructs moved. Review and accept intended
 //! changes with `cargo insta review` (the devShell ships `cargo-insta`).
+//!
+//! The HTML contract those snapshots pin down is documented in the crate
+//! docs of `arto-markdown`.
 
-use arto_markdown::{render_to_html, RenderOptions};
+use arto_markdown::{render_to_html, render_to_html_with_toc, HeadingInfo, RenderOptions};
 
 #[test]
 fn samples_render_as_before() {
@@ -17,4 +20,59 @@ fn samples_render_as_before() {
             .unwrap_or_else(|err| panic!("{}: {err:#}", path.display()));
         insta::assert_snapshot!(html);
     });
+}
+
+/// The table of contents: heading levels, texts and the ids that the
+/// rendered headings carry. Rendering with a TOC differs from plain
+/// rendering only by `id` attributes, which is asserted here rather than
+/// stored as a second copy of the HTML.
+#[test]
+fn samples_headings_as_before() {
+    insta::glob!("../../../samples", "[0-9]*.md", |path| {
+        let markdown = std::fs::read_to_string(path).expect("sample is readable");
+        let options = RenderOptions::default();
+        let plain = render_to_html(&markdown, path, &options)
+            .unwrap_or_else(|err| panic!("{}: {err:#}", path.display()));
+        let (with_toc, headings) = render_to_html_with_toc(&markdown, path, &options)
+            .unwrap_or_else(|err| panic!("{}: {err:#}", path.display()));
+
+        assert_eq!(
+            strip_ids(&with_toc),
+            strip_ids(&plain),
+            "{}: TOC rendering must differ only by id attributes",
+            path.display()
+        );
+        for heading in &headings {
+            assert!(
+                heading.id.is_empty() || with_toc.contains(&format!(r#" id="{}""#, heading.id)),
+                "{}: heading id {:?} is missing from the rendered HTML",
+                path.display(),
+                heading.id
+            );
+        }
+
+        insta::assert_snapshot!(outline(&headings));
+    });
+}
+
+fn outline(headings: &[HeadingInfo]) -> String {
+    headings
+        .iter()
+        .map(|h| format!("{} {:?} #{}", h.level, h.text, h.id))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Remove every ` id="…"` attribute.
+fn strip_ids(html: &str) -> String {
+    let mut rest = html;
+    let mut out = String::with_capacity(html.len());
+    while let Some(pos) = rest.find(" id=\"") {
+        out.push_str(&rest[..pos]);
+        let after = &rest[pos + 5..];
+        let end = after.find('"').expect("id attribute is closed");
+        rest = &after[end + 1..];
+    }
+    out.push_str(rest);
+    out
 }

--- a/crates/arto-markdown/tests/snapshots/samples__samples_headings_as_before@01-inline.md.snap
+++ b/crates/arto-markdown/tests/snapshots/samples__samples_headings_as_before@01-inline.md.snap
@@ -1,0 +1,16 @@
+---
+source: crates/arto-markdown/tests/samples.rs
+expression: outline(&headings)
+input_file: samples/01-inline.md
+---
+1 "Inline Syntax" #inline-syntax
+2 "Emphasis" #emphasis
+2 "Strikethrough" #strikethrough
+2 "Inline code" #inline-code
+2 "Links" #links
+3 "Bare URLs next to other syntax" #bare-urls-next-to-other-syntax
+2 "Images" #images
+2 "Line breaks" #line-breaks
+2 "Escapes and entities" #escapes-and-entities
+2 "Raw inline HTML" #raw-inline-html
+2 "Emoji and Unicode" #emoji-and-unicode

--- a/crates/arto-markdown/tests/snapshots/samples__samples_headings_as_before@02-blocks.md.snap
+++ b/crates/arto-markdown/tests/snapshots/samples__samples_headings_as_before@02-blocks.md.snap
@@ -1,0 +1,39 @@
+---
+source: crates/arto-markdown/tests/samples.rs
+expression: outline(&headings)
+input_file: samples/02-blocks.md
+---
+1 "Block Syntax" #block-syntax
+2 "Headings" #headings
+1 "Level 1" #level-1
+2 "Level 2" #level-2
+3 "Level 3" #level-3
+4 "Level 4" #level-4
+5 "Level 5" #level-5
+6 "Level 6" #level-6
+1 "Setext heading level 1" #setext-heading-level-1
+2 "Setext heading level 2" #setext-heading-level-2
+3 "Heading with code, bold, and a link" #heading-with-code-bold-and-a-link
+3 "日本語の見出し" #
+3 "Repeated Title" #repeated-title
+3 "Repeated Title" #repeated-title-1
+2 "Paragraphs" #paragraphs
+2 "Block quotes" #block-quotes
+2 "Lists" #lists
+3 "Unordered" #unordered
+3 "Ordered" #ordered
+3 "Loose and tight" #loose-and-tight
+3 "Items containing blocks" #items-containing-blocks
+3 "Task lists" #task-lists
+2 "Horizontal rules" #horizontal-rules
+2 "Code blocks" #code-blocks
+3 "Fenced with a language" #fenced-with-a-language
+3 "Fenced without a language" #fenced-without-a-language
+3 "Unknown language and info string" #unknown-language-and-info-string
+3 "Tilde fence and fence inside a fence" #tilde-fence-and-fence-inside-a-fence
+3 "Indented code block" #indented-code-block
+3 "Long lines" #long-lines
+2 "Tables" #tables
+2 "Footnotes" #footnotes
+2 "GitHub alerts" #github-alerts
+2 "HTML blocks" #html-blocks

--- a/crates/arto-markdown/tests/snapshots/samples__samples_headings_as_before@03-math-and-diagrams.md.snap
+++ b/crates/arto-markdown/tests/snapshots/samples__samples_headings_as_before@03-math-and-diagrams.md.snap
@@ -1,0 +1,24 @@
+---
+source: crates/arto-markdown/tests/samples.rs
+expression: outline(&headings)
+input_file: samples/03-math-and-diagrams.md
+---
+1 "Math and Diagrams" #math-and-diagrams
+2 "Inline math" #inline-math
+3 "Math that contains Markdown punctuation" #math-that-contains-markdown-punctuation
+3 "Math inside other inline syntax" #math-inside-other-inline-syntax
+3 "Not math" #not-math
+3 "Math in table cells" #math-in-table-cells
+2 "Display math" #display-math
+3 "Display math edge cases" #display-math-edge-cases
+2 "Mermaid" #mermaid
+3 "Flowchart" #flowchart
+3 "Sequence" #sequence
+3 "Class" #class
+3 "State" #state
+3 "Entity relationship" #entity-relationship
+3 "Gantt" #gantt
+3 "Git graph" #git-graph
+3 "Pie and mindmap" #pie-and-mindmap
+3 "Wide diagram" #wide-diagram
+3 "Invalid diagram" #invalid-diagram

--- a/crates/arto-markdown/tests/snapshots/samples__samples_headings_as_before@04-frontmatter.md.snap
+++ b/crates/arto-markdown/tests/snapshots/samples__samples_headings_as_before@04-frontmatter.md.snap
@@ -1,0 +1,8 @@
+---
+source: crates/arto-markdown/tests/samples.rs
+expression: outline(&headings)
+input_file: samples/04-frontmatter.md
+---
+1 "Frontmatter" #frontmatter
+2 "Source lines after frontmatter" #source-lines-after-frontmatter
+2 "Body content is unaffected" #body-content-is-unaffected

--- a/crates/arto-markdown/tests/snapshots/samples__samples_headings_as_before@05-beyond-gfm.md.snap
+++ b/crates/arto-markdown/tests/snapshots/samples__samples_headings_as_before@05-beyond-gfm.md.snap
@@ -1,0 +1,16 @@
+---
+source: crates/arto-markdown/tests/samples.rs
+expression: outline(&headings)
+input_file: samples/05-beyond-gfm.md
+---
+1 "Beyond GitHub Flavored Markdown" #beyond-github-flavored-markdown
+2 "Smart punctuation" #smart-punctuation
+2 "Superscript" #superscript
+2 "Subscript and single tildes" #subscript-and-single-tildes
+2 "Definition lists" #definition-lists
+2 "Wiki links" #wiki-links
+2 "Heading attributes" #heading-attributes
+3 "Custom identifier" #custom-identifier
+2 "Math in table cells" #math-in-table-cells
+2 "Emoji shortcodes" #emoji-shortcodes
+2 "Autolinks without a scheme" #autolinks-without-a-scheme

--- a/crates/arto-markdown/tests/snapshots/samples__samples_render_as_before@01-inline.md.snap
+++ b/crates/arto-markdown/tests/snapshots/samples__samples_render_as_before@01-inline.md.snap
@@ -67,56 +67,80 @@ behavior there depends on the engine.</p>
 <p data-source-line="92"><strong>Expected:</strong> the first one navigates inside Arto; the missing file looks like
 a normal document link but clicking it does nothing; the last two are dimmed.
 Anchors on document links are not followed.</p>
-<h2 data-source-line="96">Images</h2>
-<p data-source-line="98">Remote image:</p>
-<p data-source-line="100"><img src="https://www.rust-lang.org/static/images/rust-logo-blk.svg" alt="Rust logo" /></p>
-<p data-source-line="102">Local image, relative path:</p>
-<p data-source-line="104"><img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMDAiIGhlaWdodD0iMTAwIiB2aWV3Qm94PSIwIDAgMjAwIDEwMCI+CiAgPHJlY3Qgd2lkdGg9IjIwMCIgaGVpZ2h0PSIxMDAiIGZpbGw9IiM0QTkwRTIiLz4KICA8dGV4dCB4PSIxMDAiIHk9IjUwIiBmb250LWZhbWlseT0iQXJpYWwiIGZvbnQtc2l6ZT0iMjAiIGZpbGw9IndoaXRlIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBkb21pbmFudC1iYXNlbGluZT0ibWlkZGxlIj4KICAgIFNhbXBsZSBJbWFnZQogIDwvdGV4dD4KPC9zdmc+Cg==" alt="Local sample" /></p>
-<p data-source-line="106">Local image with a title and reference-style syntax:</p>
-<p data-source-line="108"><img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMDAiIGhlaWdodD0iMTAwIiB2aWV3Qm94PSIwIDAgMjAwIDEwMCI+CiAgPHJlY3Qgd2lkdGg9IjIwMCIgaGVpZ2h0PSIxMDAiIGZpbGw9IiM0QTkwRTIiLz4KICA8dGV4dCB4PSIxMDAiIHk9IjUwIiBmb250LWZhbWlseT0iQXJpYWwiIGZvbnQtc2l6ZT0iMjAiIGZpbGw9IndoaXRlIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBkb21pbmFudC1iYXNlbGluZT0ibWlkZGxlIj4KICAgIFNhbXBsZSBJbWFnZQogIDwvdGV4dD4KPC9zdmc+Cg==" alt="Local sample again" title="Sample title" /></p>
-<p data-source-line="112">Missing local image:</p>
-<p data-source-line="114"><img src="./assets/missing.png" alt="This file does not exist" /></p>
-<p data-source-line="116">Image inside a link: <span data-md-link="./README.md" class="md-link" onmousedown="if(event.button===0||event.button===1){event.preventDefault();window.handleMarkdownLinkClick(this.dataset.mdLink,event.button)}"><img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMDAiIGhlaWdodD0iMTAwIiB2aWV3Qm94PSIwIDAgMjAwIDEwMCI+CiAgPHJlY3Qgd2lkdGg9IjIwMCIgaGVpZ2h0PSIxMDAiIGZpbGw9IiM0QTkwRTIiLz4KICA8dGV4dCB4PSIxMDAiIHk9IjUwIiBmb250LWZhbWlseT0iQXJpYWwiIGZvbnQtc2l6ZT0iMjAiIGZpbGw9IndoaXRlIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBkb21pbmFudC1iYXNlbGluZT0ibWlkZGxlIj4KICAgIFNhbXBsZSBJbWFnZQogIDwvdGV4dD4KPC9zdmc+Cg==" alt="Local sample" /></span></p>
-<p data-source-line="118"><strong>Expected:</strong> the first three images render (the local one is inlined as a data
+<h3 data-source-line="96">Bare URLs next to other syntax</h3>
+<p data-source-line="98">Where a bare URL meets emphasis, link syntax, quotes or an indented code
+block, engines disagree. Each case below is written so that its correct
+rendering is unambiguous.</p>
+<ul data-source-line="102" data-source-line-end="108">
+<li data-source-line="102" data-source-line-end="102">Emphasized: <em>https://example.com/emphasized</em></li>
+<li data-source-line="103" data-source-line-end="103">Inside link text: [see <a href="https://example.com/inner%5D(https://example.com/outer)">https://example.com/inner](https://example.com/outer)</a></li>
+<li data-source-line="104" data-source-line-end="104">In double quotes: “https://example.com/quoted”</li>
+<li data-source-line="105" data-source-line-end="105">In single quotes: ‘https://example.com/single’</li>
+<li data-source-line="106" data-source-line-end="106">Followed by an ellipsis: <a href="https://example.com/ellipsis">https://example.com/ellipsis</a>…</li>
+<li data-source-line="107" data-source-line-end="108">Followed by a full-width comma: <a href="https://example.com/fullwidth%E3%80%81%E7%B6%9A%E3%81%8D">https://example.com/fullwidth、続き</a></li>
+</ul>
+<p data-source-line="109">An indented code block containing a URL:</p>
+<pre data-source-line="111" data-source-line-end="111" data-source-line-start="111"><code>&lt;https://example.com/indented&gt;
+</code></pre>
+<p data-source-line="113"><strong>Expected:</strong> the emphasized URL is an italic link, the link text is
+plain text inside a single link to <code>example.com/outer</code>, the quoted URLs
+link without the closing quote, the ellipsis and the comma stay outside the
+link, and the indented block shows the URL as plain code.
+<strong>Arto:</strong> the emphasized and quoted forms may render as text or as a link
+with the closing punctuation inside it, the link-in-link-text form may break
+the outer link, and the indented block may show <code>&lt;…&gt;</code> around the URL; all
+of these depend on the engine and are fixed in the snapshot so a change is
+visible.</p>
+<h2 data-source-line="123">Images</h2>
+<p data-source-line="125">Remote image:</p>
+<p data-source-line="127"><img src="https://www.rust-lang.org/static/images/rust-logo-blk.svg" alt="Rust logo" /></p>
+<p data-source-line="129">Local image, relative path:</p>
+<p data-source-line="131"><img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMDAiIGhlaWdodD0iMTAwIiB2aWV3Qm94PSIwIDAgMjAwIDEwMCI+CiAgPHJlY3Qgd2lkdGg9IjIwMCIgaGVpZ2h0PSIxMDAiIGZpbGw9IiM0QTkwRTIiLz4KICA8dGV4dCB4PSIxMDAiIHk9IjUwIiBmb250LWZhbWlseT0iQXJpYWwiIGZvbnQtc2l6ZT0iMjAiIGZpbGw9IndoaXRlIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBkb21pbmFudC1iYXNlbGluZT0ibWlkZGxlIj4KICAgIFNhbXBsZSBJbWFnZQogIDwvdGV4dD4KPC9zdmc+Cg==" alt="Local sample" /></p>
+<p data-source-line="133">Local image with a title and reference-style syntax:</p>
+<p data-source-line="135"><img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMDAiIGhlaWdodD0iMTAwIiB2aWV3Qm94PSIwIDAgMjAwIDEwMCI+CiAgPHJlY3Qgd2lkdGg9IjIwMCIgaGVpZ2h0PSIxMDAiIGZpbGw9IiM0QTkwRTIiLz4KICA8dGV4dCB4PSIxMDAiIHk9IjUwIiBmb250LWZhbWlseT0iQXJpYWwiIGZvbnQtc2l6ZT0iMjAiIGZpbGw9IndoaXRlIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBkb21pbmFudC1iYXNlbGluZT0ibWlkZGxlIj4KICAgIFNhbXBsZSBJbWFnZQogIDwvdGV4dD4KPC9zdmc+Cg==" alt="Local sample again" title="Sample title" /></p>
+<p data-source-line="139">Missing local image:</p>
+<p data-source-line="141"><img src="./assets/missing.png" alt="This file does not exist" /></p>
+<p data-source-line="143">Image inside a link: <span data-md-link="./README.md" class="md-link" onmousedown="if(event.button===0||event.button===1){event.preventDefault();window.handleMarkdownLinkClick(this.dataset.mdLink,event.button)}"><img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMDAiIGhlaWdodD0iMTAwIiB2aWV3Qm94PSIwIDAgMjAwIDEwMCI+CiAgPHJlY3Qgd2lkdGg9IjIwMCIgaGVpZ2h0PSIxMDAiIGZpbGw9IiM0QTkwRTIiLz4KICA8dGV4dCB4PSIxMDAiIHk9IjUwIiBmb250LWZhbWlseT0iQXJpYWwiIGZvbnQtc2l6ZT0iMjAiIGZpbGw9IndoaXRlIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBkb21pbmFudC1iYXNlbGluZT0ibWlkZGxlIj4KICAgIFNhbXBsZSBJbWFnZQogIDwvdGV4dD4KPC9zdmc+Cg==" alt="Local sample" /></span></p>
+<p data-source-line="145"><strong>Expected:</strong> the first three images render (the local one is inlined as a data
 URL, so it also shows offline); the missing one shows its alt text; the last
 one is clickable and opens the index.</p>
-<h2 data-source-line="122">Line breaks</h2>
-<p data-source-line="124">Two trailing spaces<br />
+<h2 data-source-line="149">Line breaks</h2>
+<p data-source-line="151">Two trailing spaces<br />
 force a hard break. So does a backslash<br />
 at the end of the line.
 A plain newline is a soft break and stays on the same line.</p>
-<p data-source-line="129"><strong>Expected:</strong> the first three lines are three visual lines; the fourth
+<p data-source-line="156"><strong>Expected:</strong> the first three lines are three visual lines; the fourth
 continues the third on the same line.</p>
-<h2 data-source-line="132">Escapes and entities</h2>
-<p data-source-line="134">Escaped punctuation: *not italic*, _not italic_, `not code`, # not a
+<h2 data-source-line="159">Escapes and entities</h2>
+<p data-source-line="161">Escaped punctuation: *not italic*, _not italic_, `not code`, # not a
 heading, [not a link](x), 1. not a list.</p>
-<p data-source-line="137"><strong>Expected:</strong> the characters are visible and nothing is formatted.</p>
-<p data-source-line="139">Entities: © &amp; &lt;tag&gt; "quoted"  non-breaking —
+<p data-source-line="164"><strong>Expected:</strong> the characters are visible and nothing is formatted.</p>
+<p data-source-line="166">Entities: © &amp; &lt;tag&gt; "quoted"  non-breaking —
 numeric — and hex 😀.</p>
-<p data-source-line="142"><strong>Expected:</strong> ©, &amp;, <tag>, “quoted”, a dash, another dash, and an emoji.</p>
-<p data-source-line="144">Backslash before a non-punctuation character stays: C:\Users\name and 3\4.</p>
-<h2 data-source-line="146">Raw inline HTML</h2>
-<p data-source-line="148">Tags Markdown has no syntax for: H<sub>2</sub>O, x<sup>2</sup>, press
+<p data-source-line="169"><strong>Expected:</strong> ©, &amp;, <tag>, “quoted”, a dash, another dash, and an emoji.</p>
+<p data-source-line="171">Backslash before a non-punctuation character stays: C:\Users\name and 3\4.</p>
+<h2 data-source-line="173">Raw inline HTML</h2>
+<p data-source-line="175">Tags Markdown has no syntax for: H<sub>2</sub>O, x<sup>2</sup>, press
 <kbd>Cmd</kbd> + <kbd>F</kbd>, <mark>highlighted</mark>, <abbr title="GitHub
 Flavored Markdown">GFM</abbr>, <ins>inserted</ins>, <del>deleted</del>,
 <small>small print</small>, and <span style="color: tomato">inline style</span>.</p>
-<p data-source-line="153"><strong>Expected:</strong> subscript, superscript, key caps, highlight, dotted abbreviation,
+<p data-source-line="180"><strong>Expected:</strong> subscript, superscript, key caps, highlight, dotted abbreviation,
 underline, strikethrough, smaller text, and a colored word.</p>
-<p data-source-line="156">Disallowed raw HTML: <script>alert(“x”)</script></p>
+<p data-source-line="183">Disallowed raw HTML: <script>alert(“x”)</script></p>
 <style>.tagfilter-probe { color: red }</style>
-<p data-source-line="158"><span class="tagfilter-probe">this sentence turns red if style tags are applied</span>.</p>
-<p data-source-line="160"><strong>Expected:</strong> no dialog appears. Whether the sentence turns red depends on
+<p data-source-line="185"><span class="tagfilter-probe">this sentence turns red if style tags are applied</span>.</p>
+<p data-source-line="187"><strong>Expected:</strong> no dialog appears. Whether the sentence turns red depends on
 the engine: GitHub’s tag filter escapes <code>&lt;script&gt;</code> and <code>&lt;style&gt;</code> so they show
 as text; an engine that passes raw HTML through applies the style.</p>
-<p data-source-line="164">An HTML comment follows this sentence and must be invisible. <!-- hidden --></p>
-<h2 data-source-line="166">Emoji and Unicode</h2>
-<p data-source-line="168">Emoji: 🎉 🚀 ✨ 👩‍💻 🇯🇵. Shortcodes are <strong>not</strong> expanded: :tada: :rocket:</p>
-<p data-source-line="170"><strong>Expected:</strong> the first row shows emoji including the multi-codepoint ones; the
+<p data-source-line="191">An HTML comment follows this sentence and must be invisible. <!-- hidden --></p>
+<h2 data-source-line="193">Emoji and Unicode</h2>
+<p data-source-line="195">Emoji: 🎉 🚀 ✨ 👩‍💻 🇯🇵. Shortcodes are <strong>not</strong> expanded: :tada: :rocket:</p>
+<p data-source-line="197"><strong>Expected:</strong> the first row shows emoji including the multi-codepoint ones; the
 shortcodes stay as text.
 <strong>GitHub:</strong> expands the shortcodes.</p>
-<p data-source-line="174">Mixed scripts in one paragraph: English, 日本語、한국어, العربية, עברית, and
+<p data-source-line="201">Mixed scripts in one paragraph: English, 日本語、한국어, العربية, עברית, and
 combining marks: é (e + ◌́), ﬁ ligature.</p>
-<p data-source-line="177"><strong>Expected:</strong> every script displays with its own font; right-to-left runs are
+<p data-source-line="204"><strong>Expected:</strong> every script displays with its own font; right-to-left runs are
 shaped correctly inside the left-to-right paragraph.</p>
-<hr data-source-line="180" />
-<p data-source-line="182">Next: <span data-md-link="./02-blocks.md" class="md-link" onmousedown="if(event.button===0||event.button===1){event.preventDefault();window.handleMarkdownLinkClick(this.dataset.mdLink,event.button)}">Block syntax</span></p>
+<hr data-source-line="207" />
+<p data-source-line="209">Next: <span data-md-link="./02-blocks.md" class="md-link" onmousedown="if(event.button===0||event.button===1){event.preventDefault();window.handleMarkdownLinkClick(this.dataset.mdLink,event.button)}">Block syntax</span></p>

--- a/samples/01-inline.md
+++ b/samples/01-inline.md
@@ -93,6 +93,33 @@ Links to other documents:
 a normal document link but clicking it does nothing; the last two are dimmed.
 Anchors on document links are not followed.
 
+### Bare URLs next to other syntax
+
+Where a bare URL meets emphasis, link syntax, quotes or an indented code
+block, engines disagree. Each case below is written so that its correct
+rendering is unambiguous.
+
+- Emphasized: *https://example.com/emphasized*
+- Inside link text: [see https://example.com/inner](https://example.com/outer)
+- In double quotes: "https://example.com/quoted"
+- In single quotes: 'https://example.com/single'
+- Followed by an ellipsis: https://example.com/ellipsis...
+- Followed by a full-width comma: https://example.com/fullwidth、続き
+
+An indented code block containing a URL:
+
+    https://example.com/indented
+
+**Expected:** the emphasized URL is an italic link, the link text is
+plain text inside a single link to `example.com/outer`, the quoted URLs
+link without the closing quote, the ellipsis and the comma stay outside the
+link, and the indented block shows the URL as plain code.
+**Arto:** the emphasized and quoted forms may render as text or as a link
+with the closing punctuation inside it, the link-in-link-text form may break
+the outer link, and the indented block may show `<…>` around the URL; all
+of these depend on the engine and are fixed in the snapshot so a change is
+visible.
+
 ## Images
 
 Remote image:


### PR DESCRIPTION
## Summary

- Document in the `arto-markdown` crate docs the pipeline order and the HTML contract: every attribute and class name the frontend scripts, the app and the stylesheets read, and which file reads it.
- Add a second snapshot per sample that records the table of contents (level, text, id of every heading) and asserts that rendering with a TOC differs from plain rendering only by `id` attributes.
- Extend `samples/01-inline.md` with the bare-URL cases where engines disagree (emphasis, link text, quotes, trailing punctuation, indented code) and pin Arto's current output for them.

## Why

This is the first of the refactoring steps that prepare `arto-markdown` for swapping pulldown-cmark for ox-content. Before any internals move, "unchanged output" needs a definition: the contract was spread over its readers (`frontend/src/*.ts`, `crates/arto/src/keybindings/dispatcher.rs`, the CSS) and nowhere near the code that emits it, and heading ids had no snapshot at all. With the contract written down and both renderings snapshotted, every later step (and the engine swap itself) can be judged by "snapshot diff is empty" or by a reviewed diff.

The bare-URL cases are the ones where the current line-based autolink pre-processing and a GFM autolink-literal engine differ; pinning them now means the swap shows those differences as a reviewed diff instead of a silent change.

No rendering behaviour changes in this PR; the only snapshot diff is the new sample section.

## Test Plan

- [x] `just fmt check test`
- [x] `cargo insta test -p arto-markdown` reviewed: only `01-inline.md` changed, by the added section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HuXHcuVqExcZXRjWRRaR5t
