### PR TITLE
refactor(arto-markdown): parse each document once with one parser configuration

### DIFF
--- a/crates/arto-markdown/src/alerts.rs
+++ b/crates/arto-markdown/src/alerts.rs
@@ -1,5 +1,6 @@
-use pulldown_cmark::{html, Options, Parser};
+use pulldown_cmark::{html, Parser};
 
+use super::parser_options;
 use super::source_lines::{byte_offset_to_line, inject_source_lines_impl};
 
 /// Get SVG icon placeholder for alert type (actual SVG injected by JavaScript)
@@ -78,16 +79,19 @@ fn process_alert_block(
     // Render the collected content as markdown with source line annotations
     if !content_lines.is_empty() {
         let content_markdown = content_lines.join("\n");
-        let options = Options::all();
-        let parser = Parser::new_ext(&content_markdown, options).into_offset_iter();
-        let parser = inject_source_lines_impl(parser, |byte_offset| {
-            let content_line = byte_offset_to_line(&content_markdown, byte_offset) - 1; // 0-based
-            let original_line = content_origins
-                .get(content_line)
-                .copied()
-                .unwrap_or(content_line);
-            original_line + 1 + frontmatter_lines // 1-based
-        });
+        let parser = Parser::new_ext(&content_markdown, parser_options()).into_offset_iter();
+        let parser = inject_source_lines_impl(
+            parser,
+            |byte_offset| {
+                let content_line = byte_offset_to_line(&content_markdown, byte_offset) - 1; // 0-based
+                let original_line = content_origins
+                    .get(content_line)
+                    .copied()
+                    .unwrap_or(content_line);
+                original_line + 1 + frontmatter_lines // 1-based
+            },
+            Vec::new(),
+        );
         let mut content_html = String::new();
         html::push_html(&mut content_html, parser);
         html_lines.push(content_html);

--- a/crates/arto-markdown/src/headings.rs
+++ b/crates/arto-markdown/src/headings.rs
@@ -1,7 +1,5 @@
-use pulldown_cmark::{Event, HeadingLevel, Options, Parser, Tag, TagEnd};
-
-use super::alerts::process_github_alerts;
-use super::frontmatter::extract_and_render_frontmatter;
+use pulldown_cmark::{Event, HeadingLevel, Tag, TagEnd};
+use std::ops::Range;
 
 /// Information about a heading extracted from markdown
 #[derive(Debug, Clone, PartialEq)]
@@ -36,33 +34,18 @@ fn generate_slug(text: &str) -> String {
         .join("-")
 }
 
-/// Extract headings from markdown content
-pub(super) fn extract_headings(markdown: &str, auto_link_urls: bool) -> Vec<HeadingInfo> {
-    let options = Options::all();
-
-    // Reuse the renderer's frontmatter detection to stay in sync:
-    // invalid YAML frontmatter is NOT stripped (same as render pipeline).
-    let (_, content, _) = extract_and_render_frontmatter(markdown);
-
-    // Convert bare URLs to <URL> autolinks (consistent with render pipeline, if enabled)
-    let content = if auto_link_urls {
-        super::autolinks::preprocess_autolinks(&content)
-    } else {
-        content
-    };
-
-    // Process GitHub alerts (they contain their own parsing)
-    // frontmatter_lines=0 since extract_headings doesn't need source line tracking
-    let (processed, _) = process_github_alerts(&content, 0);
-    let parser = Parser::new_ext(&processed, options);
-
+/// Collect the headings of a parsed document in order, with unique ids.
+///
+/// Headings inside pre-rendered HTML (alert bodies) are not events and so
+/// are not listed, which matches the rendered output: they get no id.
+pub(super) fn collect_headings(events: &[(Event<'_>, Range<usize>)]) -> Vec<HeadingInfo> {
     let mut headings = Vec::new();
     let mut current_level: Option<u8> = None;
     let mut current_text = String::new();
     let mut slug_counts: std::collections::HashMap<String, usize> =
         std::collections::HashMap::new();
 
-    for event in parser {
+    for (event, _) in events {
         match event {
             Event::Start(Tag::Heading { level, .. }) => {
                 current_level = Some(match level {
@@ -76,10 +59,10 @@ pub(super) fn extract_headings(markdown: &str, auto_link_urls: bool) -> Vec<Head
                 current_text.clear();
             }
             Event::Text(text) if current_level.is_some() => {
-                current_text.push_str(&text);
+                current_text.push_str(text);
             }
             Event::Code(code) if current_level.is_some() => {
-                current_text.push_str(&code);
+                current_text.push_str(code);
             }
             Event::SoftBreak | Event::HardBreak if current_level.is_some() => {
                 current_text.push(' ');

--- a/crates/arto-markdown/src/lib.rs
+++ b/crates/arto-markdown/src/lib.rs
@@ -126,55 +126,65 @@ use alerts::process_github_alerts;
 use anyhow::Result;
 use event_processors::{extend_table_ranges, process_code_blocks, process_math_expressions};
 use frontmatter::extract_and_render_frontmatter;
-use headings::extract_headings;
-use post_process::{post_process_html_tags, post_process_html_with_headings};
+use headings::collect_headings;
+use post_process::post_process_html_tags;
 use pulldown_cmark::{html, Options, Parser};
 use source_lines::{extract_table_source_lines, inject_source_lines};
 use std::path::{Path, PathBuf};
 
-/// Intermediate result from the common markdown parsing pipeline.
+/// The parser configuration every parse in this crate uses.
 ///
-/// Contains all data needed for post-processing, allowing the two public
-/// render functions to share the parsing logic while differing only in
-/// how they post-process the raw HTML output.
+/// Rendering, alert bodies and the selection source map must parse the
+/// same way, or a selection in the rendered view maps onto a differently
+/// shaped document.
+pub(crate) fn parser_options() -> Options {
+    Options::all()
+}
+
+/// Everything the render functions need after the document was parsed.
 struct PipelineResult {
     raw_html: String,
     frontmatter_html: String,
     base_dir: PathBuf,
     table_source_lines: Vec<(usize, usize)>,
+    headings: Vec<HeadingInfo>,
 }
 
-/// Run the common markdown parsing pipeline: frontmatter extraction,
-/// GitHub alert preprocessing, pulldown-cmark parsing, source line
-/// injection, and HTML generation.
-fn run_pipeline(markdown: &str, base_path: &Path, auto_link_urls: bool) -> PipelineResult {
+/// Run the pipeline up to the raw HTML: frontmatter extraction, text
+/// pre-processing, one parse, source line injection and HTML generation.
+///
+/// With `with_toc`, the headings are collected from the same parse and
+/// their ids are written onto the rendered headings; without it, no
+/// heading work is done and `headings` comes back empty.
+fn run_pipeline(
+    markdown: &str,
+    base_path: &Path,
+    auto_link_urls: bool,
+    with_toc: bool,
+) -> PipelineResult {
     let base_dir = base_path
         .parent()
         .map(|p| p.to_path_buf())
         .unwrap_or_else(|| PathBuf::from("."));
 
-    // Extract frontmatter if present
     let (frontmatter_html, content, frontmatter_lines) = extract_and_render_frontmatter(markdown);
 
-    // Convert bare URLs to <URL> autolinks before any parsing (if enabled)
     let content = if auto_link_urls {
         autolinks::preprocess_autolinks(&content)
     } else {
         content
     };
 
-    // Process GitHub alerts (returns line origin mapping for correct source line tracking)
     let (processed_markdown, line_origins) = process_github_alerts(&content, frontmatter_lines);
 
-    // Parse Markdown with offset tracking and process blocks
-    let options = Options::all();
-    let parser = Parser::new_ext(&processed_markdown, options).into_offset_iter();
+    let parser = Parser::new_ext(&processed_markdown, parser_options()).into_offset_iter();
     let parser = extend_table_ranges(parser);
     let parser = process_code_blocks(parser, "mermaid");
     let parser = process_code_blocks(parser, "math");
     let parser = process_math_expressions(parser);
 
-    // Collect events to extract table source lines before inject_source_lines consumes ranges
+    // The events are needed twice: once to read positions and headings,
+    // once to render. Injection consumes the ranges.
     let events: Vec<_> = parser.collect();
     let table_source_lines = extract_table_source_lines(
         &events,
@@ -182,15 +192,22 @@ fn run_pipeline(markdown: &str, base_path: &Path, auto_link_urls: bool) -> Pipel
         &line_origins,
         frontmatter_lines,
     );
+    let (headings, heading_ids) = if with_toc {
+        let headings = collect_headings(&events);
+        let ids = headings.iter().map(|h| h.id.clone()).collect();
+        (headings, ids)
+    } else {
+        (Vec::new(), Vec::new())
+    };
 
     let parser = inject_source_lines(
         events.into_iter(),
         &processed_markdown,
         &line_origins,
         frontmatter_lines,
+        heading_ids,
     );
 
-    // Convert to HTML
     let mut raw_html = String::new();
     html::push_html(&mut raw_html, parser);
 
@@ -199,6 +216,7 @@ fn run_pipeline(markdown: &str, base_path: &Path, auto_link_urls: bool) -> Pipel
         frontmatter_html,
         base_dir,
         table_source_lines,
+        headings,
     }
 }
 
@@ -223,6 +241,7 @@ pub fn render_to_html(
         markdown.as_ref(),
         base_path.as_ref(),
         options.auto_link_urls,
+        false,
     );
 
     let html_output = post_process_html_tags(
@@ -242,20 +261,22 @@ pub fn render_to_html_with_toc(
     base_path: impl AsRef<Path>,
     options: &RenderOptions,
 ) -> Result<(String, Vec<HeadingInfo>)> {
-    let markdown = markdown.as_ref();
-    let headings = extract_headings(markdown, options.auto_link_urls);
-    let pipeline = run_pipeline(markdown, base_path.as_ref(), options.auto_link_urls);
+    let pipeline = run_pipeline(
+        markdown.as_ref(),
+        base_path.as_ref(),
+        options.auto_link_urls,
+        true,
+    );
 
-    let html_output = post_process_html_with_headings(
+    let html_output = post_process_html_tags(
         &pipeline.raw_html,
         &pipeline.base_dir,
-        &headings,
         &pipeline.table_source_lines,
     );
 
     Ok((
         prepend_frontmatter(&pipeline.frontmatter_html, html_output),
-        headings,
+        pipeline.headings,
     ))
 }
 

--- a/crates/arto-markdown/src/post_process.rs
+++ b/crates/arto-markdown/src/post_process.rs
@@ -3,8 +3,6 @@ use lol_html::{element, HtmlRewriter, Settings};
 use std::io::Read;
 use std::path::Path;
 
-use super::headings::HeadingInfo;
-
 /// Maximum byte size of a local image that will be inlined as a data URL.
 ///
 /// Prevents accidental misreferences (e.g. log files, device files like `/dev/zero`)
@@ -58,30 +56,10 @@ pub(super) fn get_mime_type(path: &Path) -> &'static str {
     }
 }
 
-/// Post-process HTML to handle img, anchor, and table tags using lol_html
-pub(super) fn post_process_html_tags(
-    html_str: &str,
-    base_dir: &Path,
-    table_source_lines: &[(usize, usize)],
-) -> String {
-    post_process_html_impl(html_str, base_dir, table_source_lines, None)
-}
-
-/// Post-process HTML to handle img, anchor, table tags, and add heading IDs using lol_html
-pub(super) fn post_process_html_with_headings(
-    html_str: &str,
-    base_dir: &Path,
-    headings: &[HeadingInfo],
-    table_source_lines: &[(usize, usize)],
-) -> String {
-    post_process_html_impl(html_str, base_dir, table_source_lines, Some(headings))
-}
-
-/// Common HTML post-processing implementation.
+/// Post-process HTML with lol_html.
 ///
 /// Handles:
 /// - `<table>`: inject `data-source-line` attributes for source mapping
-/// - `<h1>`–`<h6>`: inject `id` attributes for TOC navigation (when `headings` is Some)
 /// - `<img src="…">`: inline local images as data URLs. Supports `file:` URLs
 ///   (parsed via `url::Url`, handles percent-encoding and platform differences)
 ///   as well as absolute and relative filesystem paths. Relative paths resolve
@@ -90,11 +68,10 @@ pub(super) fn post_process_html_with_headings(
 ///   Reads are bounded by `MAX_INLINE_IMAGE_SIZE` to prevent misreferenced huge
 ///   files or device files from freezing the UI.
 /// - `<a href="…">`: convert local links to `<span data-md-link="…">` for in-app navigation
-fn post_process_html_impl(
+pub(super) fn post_process_html_tags(
     html_str: &str,
     base_dir: &Path,
     table_source_lines: &[(usize, usize)],
-    headings: Option<&[HeadingInfo]>,
 ) -> String {
     let canonical_base = base_dir
         .canonicalize()
@@ -102,8 +79,6 @@ fn post_process_html_impl(
     let mut output = Vec::new();
     let table_index = std::cell::RefCell::new(0usize);
     let table_source_lines = table_source_lines.to_vec();
-    let heading_index = std::cell::RefCell::new(0usize);
-    let headings = headings.map(|h| h.to_vec()).unwrap_or_default();
 
     let mut rewriter = HtmlRewriter::new(
         Settings::new()
@@ -113,19 +88,6 @@ fn post_process_html_impl(
                 if let Some(&(start, end)) = table_source_lines.get(*idx) {
                     el.set_attribute("data-source-line", &start.to_string())?;
                     el.set_attribute("data-source-line-end", &end.to_string())?;
-                }
-                *idx += 1;
-                Ok(())
-            }))
-            // Process heading tags: add IDs for TOC navigation
-            // No-op when headings is empty (called from post_process_html_tags)
-            .append_element_content_handler(element!("h1, h2, h3, h4, h5, h6", |el| {
-                if headings.is_empty() {
-                    return Ok(());
-                }
-                let mut idx = heading_index.borrow_mut();
-                if let Some(heading) = headings.get(*idx) {
-                    el.set_attribute("id", &heading.id)?;
                 }
                 *idx += 1;
                 Ok(())
@@ -471,71 +433,6 @@ mod tests {
         assert_eq!(
             click_handler_count, 2,
             "Should have click handlers for both links"
-        );
-    }
-
-    #[test]
-    fn test_post_process_html_with_headings_injects_ids() {
-        let html = r#"<h1 data-source-line="1">Title</h1><h2 data-source-line="3">Section</h2>"#;
-        let headings = vec![
-            HeadingInfo {
-                level: 1,
-                text: "Title".to_string(),
-                id: "title".to_string(),
-            },
-            HeadingInfo {
-                level: 2,
-                text: "Section".to_string(),
-                id: "section".to_string(),
-            },
-        ];
-
-        let result = post_process_html_with_headings(html, Path::new("."), &headings, &[]);
-
-        assert!(
-            result.contains(r#"id="title""#),
-            "H1 should get id from headings: {result}"
-        );
-        assert!(
-            result.contains(r#"id="section""#),
-            "H2 should get id from headings: {result}"
-        );
-    }
-
-    #[test]
-    fn test_post_process_html_with_headings_more_html_headings_than_info() {
-        // When HTML has more headings than HeadingInfo entries, extra headings are skipped
-        let html = r#"<h1>A</h1><h2>B</h2><h3>C</h3>"#;
-        let headings = vec![HeadingInfo {
-            level: 1,
-            text: "A".to_string(),
-            id: "a".to_string(),
-        }];
-
-        let result = post_process_html_with_headings(html, Path::new("."), &headings, &[]);
-
-        assert!(
-            result.contains(r#"id="a""#),
-            "First heading should get id: {result}"
-        );
-        // Remaining headings should still render without error
-        assert!(
-            result.contains("<h2>B</h2>") || result.contains("<h2 >B</h2>"),
-            "Extra headings should render without id: {result}"
-        );
-    }
-
-    #[test]
-    fn test_post_process_html_with_headings_empty_headings() {
-        let html = r#"<h1>Title</h1>"#;
-        let headings: Vec<HeadingInfo> = vec![];
-
-        let result = post_process_html_with_headings(html, Path::new("."), &headings, &[]);
-
-        // Should not crash, heading renders without id
-        assert!(
-            result.contains("Title"),
-            "Should still render heading text: {result}"
         );
     }
 

--- a/crates/arto-markdown/src/source_extract.rs
+++ b/crates/arto-markdown/src/source_extract.rs
@@ -8,7 +8,9 @@
 
 use std::ops::Range;
 
-use pulldown_cmark::{Event, Options, Parser, TagEnd};
+use pulldown_cmark::{Event, Parser, TagEnd};
+
+use super::parser_options;
 
 /// A segment mapping between rendered plain text and markdown source byte positions.
 struct TextSegment {
@@ -22,7 +24,7 @@ struct TextSegment {
 /// "rendered" string while recording which source byte range each rendered
 /// segment came from.
 fn build_source_map(source: &str) -> (String, Vec<TextSegment>) {
-    let parser = Parser::new_ext(source, Options::all());
+    let parser = Parser::new_ext(source, parser_options());
     let mut rendered = String::new();
     let mut segments = Vec::new();
 

--- a/crates/arto-markdown/src/source_lines.rs
+++ b/crates/arto-markdown/src/source_lines.rs
@@ -30,13 +30,19 @@ fn clamp_to_char_boundary(text: &str, offset: usize) -> usize {
 ///
 /// For code blocks, `<pre>` receives `data-source-line-start="N"` indicating where
 /// the code content begins.  The frontend counts newlines from there for per-line tracking.
+///
+/// `heading_ids` are written onto the headings in document order and take
+/// precedence over an explicit `{#id}` attribute; pass an empty list to
+/// leave headings without generated ids.
 pub(super) fn inject_source_lines_impl<'a, F>(
     parser: impl Iterator<Item = (Event<'a>, Range<usize>)> + 'a,
     line_fn: F,
+    heading_ids: Vec<String>,
 ) -> impl Iterator<Item = Event<'a>> + 'a
 where
     F: Fn(usize) -> usize + 'a,
 {
+    let mut heading_ids = heading_ids.into_iter();
     parser.map(move |(event, range)| {
         let line = || line_fn(range.start);
         let line_end = || line_fn(range.end.saturating_sub(1).max(range.start));
@@ -52,6 +58,9 @@ where
                 attrs,
             }) => {
                 let mut html = format!("<{} data-source-line=\"{}\"", level, line());
+                let id = heading_ids
+                    .next()
+                    .or_else(|| id.map(|explicit| explicit.to_string()));
                 if let Some(id) = id {
                     html.push_str(&format!(
                         " id=\"{}\"",
@@ -207,15 +216,20 @@ pub(super) fn inject_source_lines<'a>(
     processed_markdown: &'a str,
     line_origins: &'a [usize],
     frontmatter_lines: usize,
+    heading_ids: Vec<String>,
 ) -> impl Iterator<Item = Event<'a>> + 'a {
-    inject_source_lines_impl(parser, move |byte_offset| {
-        let processed_line = byte_offset_to_line(processed_markdown, byte_offset) - 1; // 0-based
-        let original_line = line_origins
-            .get(processed_line)
-            .copied()
-            .unwrap_or(processed_line);
-        original_line + 1 + frontmatter_lines // 1-based
-    })
+    inject_source_lines_impl(
+        parser,
+        move |byte_offset| {
+            let processed_line = byte_offset_to_line(processed_markdown, byte_offset) - 1; // 0-based
+            let original_line = line_origins
+                .get(processed_line)
+                .copied()
+                .unwrap_or(processed_line);
+            original_line + 1 + frontmatter_lines // 1-based
+        },
+        heading_ids,
+    )
 }
 
 /// Extract source-line ranges for table elements before `inject_source_lines` consumes

--- a/crates/arto-markdown/tests/pipeline.rs
+++ b/crates/arto-markdown/tests/pipeline.rs
@@ -366,6 +366,69 @@ fn duplicate_headings_get_numbered_ids() {
 }
 
 #[test]
+fn heading_ids_are_written_only_when_a_toc_is_requested() {
+    let markdown = "# Title\n\n## Section {#custom}\n";
+    let (with_toc, headings) = render_to_html_with_toc(
+        markdown,
+        Path::new("/nonexistent/test.md"),
+        &RenderOptions::default(),
+    )
+    .expect("renders");
+    let plain = render(markdown);
+
+    assert_eq!(headings.len(), 2);
+    assert!(
+        with_toc.contains(r#"<h1 data-source-line="1" id="title">"#),
+        "{with_toc}"
+    );
+    // The generated id replaces an explicit one, so the TOC always finds its target.
+    assert!(
+        with_toc.contains(r#"<h2 data-source-line="3" id="section">"#),
+        "{with_toc}"
+    );
+    assert!(plain.contains(r#"<h1 data-source-line="1">"#), "{plain}");
+    assert!(
+        plain.contains(r#"<h2 data-source-line="3" id="custom">"#),
+        "{plain}"
+    );
+}
+
+#[test]
+fn headings_inside_raw_html_do_not_shift_ids() {
+    // A heading written as HTML is not a Markdown heading: it gets no id
+    // and must not consume the id of the Markdown heading after it.
+    let markdown = "<h2>Raw</h2>\n\n## Real\n";
+    let (with_toc, headings) = render_to_html_with_toc(
+        markdown,
+        Path::new("/nonexistent/test.md"),
+        &RenderOptions::default(),
+    )
+    .expect("renders");
+
+    let texts: Vec<&str> = headings.iter().map(|h| h.text.as_str()).collect();
+    assert_eq!(texts, ["Real"]);
+    assert!(with_toc.contains("<h2>Raw</h2>"), "{with_toc}");
+    assert!(
+        with_toc.contains(r#"<h2 data-source-line="3" id="real">"#),
+        "{with_toc}"
+    );
+}
+
+#[test]
+fn a_document_without_headings_has_an_empty_toc() {
+    let (html, headings) = render_to_html_with_toc(
+        "Just text.",
+        Path::new("/nonexistent/test.md"),
+        &RenderOptions::default(),
+    )
+    .expect("renders");
+
+    assert!(headings.is_empty());
+    assert!(html.contains("Just text."));
+    assert!(!html.contains(" id="), "{html}");
+}
+
+#[test]
 fn frontmatter_is_not_a_heading() {
     let headings = headings(indoc! {"
         ---


### PR DESCRIPTION
Stacked on #241.

## Summary

- One `parser_options()` replaces the four independent `Options::all()` call sites (rendering, alert bodies, heading extraction, selection source map).
- `render_to_html_with_toc` no longer parses the document twice: headings are collected from the same event stream the renderer consumes, and `run_pipeline` returns them.
- Heading ids are written onto the heading events themselves instead of being matched onto `<h1>`–`<h6>` tags by position in the lol_html pass; `post_process_html_with_headings` is gone.

## Why

Third step of preparing the engine swap. With the parser built in four places, an engine whose options are declared differently would have four places to get out of sync and no way to trace a behaviour difference to one of them. The double parse also meant frontmatter extraction, autolink and alert pre-processing ran twice per document.

Assigning ids by tag position had a real defect: a heading written as raw HTML (or inside an alert body, which is pre-rendered HTML) was counted by the lol_html handler but not by the heading extractor, so the id meant for the next Markdown heading landed on the raw one. Writing the id on the event fixes that; the new `headings_inside_raw_html_do_not_shift_ids` test covers it.

Snapshots are unchanged.

## Test Plan

- [x] `just fmt check test`
- [x] Snapshot files unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HuXHcuVqExcZXRjWRRaR5t
