### PR TITLE
ci(dependabot): keep keyboard-types on the version Dioxus and muda use

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,15 @@ updates:
     groups:
       cargo-minor-and-patch:
         update-types: [minor, patch]
+    ignore:
+      # arto-keybindings shares Key / Code / Modifiers with dioxus-html, muda
+      # and global-hotkey, so keyboard-types has to stay on the version those
+      # crates use (0.7 as of dioxus 0.7.10 and muda 0.17). Drop this entry
+      # once they move; patch releases are still picked up.
+      - dependency-name: keyboard-types
+        update-types:
+          - version-update:semver-minor
+          - version-update:semver-major
 
   - package-ecosystem: npm
     directory: /frontend


### PR DESCRIPTION
## Summary

- Ignore minor and major bumps of `keyboard-types` in Dependabot's cargo config; patch releases are still proposed.

## Why

#238 proposed keyboard-types 0.7 → 0.8.3. Besides the breaking `Key` split, dioxus-html 0.7.10, muda 0.17 and global-hotkey still depend on 0.7, and `arto-keybindings` exists to share `Key` / `Code` / `Modifiers` with exactly those crates (`KeyChord::new(event.data().key(), …)` on the Dioxus side, `Accelerator::new(modifiers, code)` on the muda side). Taking 0.8 alone would mean two copies of the types in the binary and string round-trips at both boundaries, which defeats the crate's purpose. The rule documents that and stops the weekly PR until Dioxus and muda move.

## Test Plan

- [x] YAML validates against Dependabot's `ignore` schema (`dependency-name` + `update-types`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HuXHcuVqExcZXRjWRRaR5t
