### PR TITLE
refactor(arto): follow the system appearance without dioxus-sdk-window

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,7 +169,6 @@ dependencies = [
  "dark-light",
  "dioxus",
  "dioxus-desktop",
- "dioxus-sdk-window",
  "dirs 7.0.0",
  "display-info",
  "dotenvy",
@@ -1612,18 +1611,6 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "dioxus-sdk-window"
-version = "0.7.0"
-source = "git+https://github.com/iynaix/dioxus-sdk?rev=28fc2264#28fc22642f726b98ac89c92dd3813a8d51e3a33c"
-dependencies = [
- "dioxus",
- "dioxus-config-macro",
- "dioxus-desktop",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,3 @@ sha2 = "0.11.0"
 tempfile = "3.27.0"
 thiserror = "2.0.20"
 tracing = "0.1.44"
-
-[patch.crates-io]
-# Fix overlapping cfg conditions that cause duplicate function definitions on Linux.
-# https://github.com/DioxusLabs/sdk/pull/103
-dioxus-sdk-window = { git = "https://github.com/iynaix/dioxus-sdk", rev = "28fc2264" }

--- a/crates/arto/Cargo.toml
+++ b/crates/arto/Cargo.toml
@@ -29,7 +29,6 @@ compile-time = "0.3"
 dirs.workspace = true
 dioxus = { version = "0.7.10", features = ["desktop"] }
 dioxus-desktop = "0.7.10"
-dioxus-sdk-window = "0.7.0"
 dotenvy = "0.15.7"
 html-escape.workspace = true
 image = "0.25.10"

--- a/crates/arto/src/components/math_window.rs
+++ b/crates/arto/src/components/math_window.rs
@@ -57,10 +57,7 @@ pub fn MathWindow(props: MathWindowProps) -> Element {
         let source_json = serde_json::to_string(&props.source).unwrap_or_default();
         let math_id_json = serde_json::to_string(&props.math_id).unwrap_or_default();
         // Resolve "auto" to actual light/dark before passing to JS
-        let theme_str = match crate::theme::resolve_theme(*current_theme.read()) {
-            crate::theme::DioxusTheme::Light => "light",
-            crate::theme::DioxusTheme::Dark => "dark",
-        };
+        let theme_str = crate::theme::resolve_theme(*current_theme.read()).as_str();
 
         spawn(async move {
             let eval_result = document::eval(&indoc::formatdoc! {r#"

--- a/crates/arto/src/components/theme_selector.rs
+++ b/crates/arto/src/components/theme_selector.rs
@@ -1,33 +1,27 @@
 use dioxus::document;
 use dioxus::prelude::*;
-use dioxus_sdk_window::theme::use_system_theme;
 
 use crate::components::icon::{Icon, IconName};
-use crate::theme::{DioxusTheme, Theme};
+use crate::theme::{use_system_theme, ResolvedTheme, Theme};
 
 #[component]
 pub fn ThemeSelector(current_theme: Signal<Theme>) -> Element {
     let system_theme = use_system_theme();
     let resolved_theme = use_memo(move || match current_theme() {
-        Theme::Auto => system_theme().unwrap_or(DioxusTheme::Light),
-        Theme::Light => DioxusTheme::Light,
-        Theme::Dark => DioxusTheme::Dark,
+        Theme::Auto => system_theme(),
+        Theme::Light => ResolvedTheme::Light,
+        Theme::Dark => ResolvedTheme::Dark,
     });
 
     // Dispatch custom event when resolved theme changes
     use_effect(move || {
-        let theme = resolved_theme();
-        let theme_str = match theme {
-            DioxusTheme::Light => "light",
-            DioxusTheme::Dark => "dark",
-        };
+        let theme_str = resolved_theme().as_str();
         tracing::info!("Theme changed to: {}", theme_str);
-        let theme_str_owned = theme_str.to_string();
         spawn(async move {
-            tracing::info!("Dispatching theme-changed event: {}", theme_str_owned);
+            tracing::info!("Dispatching theme-changed event: {}", theme_str);
             let _ = document::eval(&format!(
                 "document.dispatchEvent(new CustomEvent('arto:theme-changed', {{ detail: '{}' }}))",
-                theme_str_owned
+                theme_str
             ))
             .await;
         });

--- a/crates/arto/src/hooks/viewer_window.rs
+++ b/crates/arto/src/hooks/viewer_window.rs
@@ -205,10 +205,7 @@ pub fn use_theme_dispatch(current_theme: Signal<crate::theme::Theme>) {
     use_effect(move || {
         // Resolve "auto" to actual light/dark before dispatching to JS,
         // since the renderer theme system only supports "light" and "dark".
-        let theme_str = match crate::theme::resolve_theme(*current_theme.read()) {
-            crate::theme::DioxusTheme::Light => "light",
-            crate::theme::DioxusTheme::Dark => "dark",
-        };
+        let theme_str = crate::theme::resolve_theme(*current_theme.read()).as_str();
 
         spawn(async move {
             if let Err(e) = document::eval(&format!(

--- a/crates/arto/src/theme.rs
+++ b/crates/arto/src/theme.rs
@@ -1,25 +1,106 @@
 //! Resolving the user's theme preference against the system appearance.
 //!
 //! The preference itself (`Theme`) is a configuration type and lives in
-//! arto-config; this module turns `Auto` into light or dark.
+//! arto-config; this module turns `Auto` into light or dark, and reports the
+//! system appearance to the components that follow it.
+
+use dioxus::desktop::tao::event::{Event as TaoEvent, WindowEvent};
+use dioxus::desktop::tao::window::Theme as TaoTheme;
+use dioxus::desktop::{use_wry_event_handler, window};
+use dioxus::prelude::*;
 
 pub use crate::config::Theme;
-pub use dioxus_sdk_window::theme::Theme as DioxusTheme;
 
-pub fn resolve_theme(theme: Theme) -> DioxusTheme {
+/// A [`Theme`] with `Auto` already resolved: what actually gets rendered.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ResolvedTheme {
+    #[default]
+    Light,
+    Dark,
+}
+
+impl ResolvedTheme {
+    /// The name the frontend knows this theme by, in `data-theme` and in the
+    /// detail of the `arto:theme-changed` event.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Light => "light",
+            Self::Dark => "dark",
+        }
+    }
+}
+
+impl std::fmt::Display for ResolvedTheme {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+pub fn resolve_theme(theme: Theme) -> ResolvedTheme {
     match theme {
         // NOTE:
-        // We cannot use dioxus_sdk_window::theme::get_theme here because
-        // it requires a Dioxus runtime and cannot be called from outside
-        // of Dioxus context (this runs while building a window's index
-        // page). That's why we use the dark_light crate instead.
+        // This also runs while building a window's index page, outside any
+        // Dioxus or window context, so it cannot ask the window for its
+        // appearance. That is why the dark_light crate is used here.
         Theme::Auto => match detect_system_mode() {
-            Some(dark_light::Mode::Light) => DioxusTheme::Light,
-            Some(dark_light::Mode::Dark) => DioxusTheme::Dark,
-            Some(dark_light::Mode::Unspecified) | None => DioxusTheme::Light,
+            Some(dark_light::Mode::Dark) => ResolvedTheme::Dark,
+            Some(dark_light::Mode::Light | dark_light::Mode::Unspecified) | None => {
+                ResolvedTheme::Light
+            }
         },
-        Theme::Light => DioxusTheme::Light,
-        Theme::Dark => DioxusTheme::Dark,
+        Theme::Light => ResolvedTheme::Light,
+        Theme::Dark => ResolvedTheme::Dark,
+    }
+}
+
+/// A signal of the system appearance, kept current while the window lives.
+///
+/// Components use this to render `Theme::Auto` without knowing how the
+/// appearance is obtained. tao reports a change through `ThemeChanged` on
+/// macOS and Windows; on Linux it never does, so there the signal keeps the
+/// value it started with.
+pub fn use_system_theme() -> ReadSignal<ResolvedTheme> {
+    let mut theme = use_signal(current_system_theme);
+
+    use_wry_event_handler(move |event, _| {
+        if let TaoEvent::WindowEvent {
+            event: WindowEvent::ThemeChanged(changed),
+            window_id,
+            ..
+        } = event
+        {
+            // Every window registers this handler and tao delivers each
+            // event to all of them, so only the addressed window reacts.
+            if *window_id == window().id() {
+                theme.set(from_tao(*changed));
+            }
+        }
+    });
+
+    use_hook(|| ReadSignal::new(theme))
+}
+
+/// The system appearance right now.
+fn current_system_theme() -> ResolvedTheme {
+    // tao knows the appearance on macOS and Windows, and it is the same
+    // source the change events come from. Its Linux answer is guessed from
+    // the GTK theme name and misses the portal setting, so ask the same
+    // probe that window creation uses instead.
+    #[cfg(target_os = "linux")]
+    {
+        resolve_theme(Theme::Auto)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        from_tao(window().theme())
+    }
+}
+
+/// `tao::window::Theme` is `#[non_exhaustive]`; anything but dark renders light.
+fn from_tao(theme: TaoTheme) -> ResolvedTheme {
+    match theme {
+        TaoTheme::Dark => ResolvedTheme::Dark,
+        _ => ResolvedTheme::Light,
     }
 }
 
@@ -67,4 +148,23 @@ fn detect_system_mode() -> Option<dark_light::Mode> {
     // `recv_timeout` also returns an error when the thread panicked, because
     // dropping the sender disconnects the channel.
     rx.recv_timeout(SYSTEM_MODE_PROBE_TIMEOUT).ok().flatten()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The frontend switches on these exact strings, in `data-theme` and in
+    /// the `arto:theme-changed` detail.
+    #[test]
+    fn theme_names_match_the_frontend() {
+        assert_eq!(ResolvedTheme::Light.as_str(), "light");
+        assert_eq!(ResolvedTheme::Dark.as_str(), "dark");
+    }
+
+    #[test]
+    fn explicit_preferences_do_not_consult_the_system() {
+        assert_eq!(resolve_theme(Theme::Light), ResolvedTheme::Light);
+        assert_eq!(resolve_theme(Theme::Dark), ResolvedTheme::Dark);
+    }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -58,7 +58,6 @@ wildcards = "allow"
 
 [sources]
 unknown-registry = "deny"
+# Every dependency comes from crates.io; a git source in the lockfile means
+# a fork someone has to keep following, so it has to be argued for here.
 unknown-git = "deny"
-# The dioxus-sdk-window fork carried in [patch.crates-io] until
-# DioxusLabs/sdk#103 merges.
-allow-git = ["https://github.com/iynaix/dioxus-sdk"]


### PR DESCRIPTION
## Summary

- Replace `dioxus_sdk_window::theme::use_system_theme` with a hook of the same shape in `crates/arto/src/theme.rs`, built on the `use_wry_event_handler` and tao events the app already uses.
- Rename `DioxusTheme` to `ResolvedTheme` and give it `as_str` and `Display`, so the `"light"` and `"dark"` the frontend reads are written once instead of in four places.
- Drop the `dioxus-sdk-window` dependency, the `[patch.crates-io]` fork it needed, and the git-source exception in `deny.toml`. No dependency comes from git any more.

## Why

The SDK was carried for exactly two things: a Light/Dark enum and one hook with one call site. Both are cheaper to own than to depend on, and depending on them cost more than the code they saved.

The hook was also wrong on Linux. `use_system_theme` returns `Unsupported` there, so the theme selector resolved `Theme::Auto` to Light regardless of the desktop setting, while window creation resolved the same preference correctly through the `dark_light` probe in `resolve_theme`. The replacement seeds from that same probe on Linux, so the two agree. On macOS and Windows it seeds from the window and follows tao's `ThemeChanged`, which is what the SDK did. Live switching still does not work on Linux, because tao does not report it there.

The dependency was also pinned to a fork of the SDK, taken for a Linux build fix in `window_size`, a module the app does not use. That left a git source in the lockfile, an exception in `deny.toml`, and an upstream PR to keep watching. All three go away.

## Test Plan

- [x] `just fmt check test`
- [x] `just arto::deny` (sources ok with the exception removed)
- [x] `nix build --dry-run .#arto`
- [x] No `git` source left in `Cargo.lock`
- [ ] macOS: switch the system appearance while Arto is open with the theme set to Auto, and confirm the view follows
- [ ] macOS: Mermaid, math and image windows follow the same switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HuXHcuVqExcZXRjWRRaR5t
