### PR TITLE
Fix Copy Image putting nothing on the clipboard

### DIFF
--- a/.claude/rules/dioxus-async.md
+++ b/.claude/rules/dioxus-async.md
@@ -13,8 +13,15 @@ paths: "crates/arto/src/**/*.rs"
   an `async move ||` closure that touches a capture does not implement
   `FnMut` on the current toolchain.
 - `use_drop()`: synchronous cleanup only; call blocking `save()` directly.
-- Avoid `spawn_forever()` in components: the task outlives the window and
-  keeps writing to dropped signals.
+- `utils::task::spawn_detached()`: one-shot work that has to finish even
+  though the component that started it is gone. A scope's tasks are dropped
+  when it unmounts, so a menu item that closes its menu and then awaits — a
+  clipboard copy round-tripping through the WebView — loses the task at its
+  first `.await`, silently. The dispatcher spawns every action this way,
+  because actions are triggered from menus as well as from the keyboard.
+- Avoid raw `spawn_forever()` in components: nothing stops the task, so a
+  loop keeps writing to signals whose component is gone. `spawn_detached()`
+  is the one-shot form that is safe to reach for.
 
 Files:
 

--- a/crates/arto/Cargo.toml
+++ b/crates/arto/Cargo.toml
@@ -42,7 +42,7 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
-tokio = { version = "1.52.3", features = ["time"] }
+tokio = { version = "1.52.3", features = ["sync", "time"] }
 tracing.workspace = true
 ureq = "3.4"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "fmt"] }
@@ -63,3 +63,4 @@ tracing-oslog = "0.3.0"
 
 [dev-dependencies]
 tempfile.workspace = true
+tokio = { version = "1.52.3", features = ["macros", "rt", "sync", "time"] }

--- a/crates/arto/src/components/content/context_menu.rs
+++ b/crates/arto/src/components/content/context_menu.rs
@@ -16,6 +16,7 @@ use crate::components::context_menu::{ContextMenuItem, ContextMenuSeparator};
 use crate::components::icon::IconName;
 use crate::keybindings::dispatcher::dispatch_action;
 use crate::keybindings::{shortcut_hint_for_context_action, Action, KeyContext};
+use crate::utils::task::spawn_detached;
 use copy_as::CopyAsSubmenu;
 use copy_code_as::CopyCodeAsSubmenu;
 use copy_path_as::CopyPathAsSubmenu;
@@ -194,7 +195,7 @@ pub fn ContentContextMenu(
                         let src = src.clone();
                         move |_| {
                             let src = src.clone();
-                            spawn(async move {
+                            spawn_detached(async move {
                                 crate::keybindings::dispatcher::copy_image_from_src(src, false).await;
                             });
                             on_close.call(());
@@ -385,15 +386,11 @@ fn copy_special_block_image(is_mermaid: bool, opaque: bool) {
         "mathBlock"
     };
     let opaque_str = if opaque { "true" } else { "false" };
-    spawn(async move {
+    spawn_detached(async move {
         let js = format!(
             "(async () => {{ dioxus.send(await window.Arto.rasterize.{kind}({opaque_str})); }})()"
         );
-        let mut eval = document::eval(&js);
-        if let Ok(Some(data_url)) = eval.recv::<Option<String>>().await {
-            crate::utils::clipboard::copy_image_from_data_url(&data_url);
-            crate::keybindings::dispatcher::show_action_feedback("Copied");
-        }
+        crate::keybindings::dispatcher::copy_rasterized_image(document::eval(&js), kind).await;
     });
 }
 
@@ -404,7 +401,7 @@ fn copy_markdown_source_direct(
     source_line_end: u32,
     selected_text: String,
 ) {
-    spawn(async move {
+    spawn_detached(async move {
         let handle = std::thread::spawn(move || {
             let source = crate::utils::source_lines::extract_source_lines(
                 &file,
@@ -444,7 +441,7 @@ fn copy_path_shortcut_action_str(
 }
 
 fn exec_edit_command(command: &'static str) {
-    spawn(async move {
+    spawn_detached(async move {
         let js = format!("document.execCommand('{command}');");
         let _ = document::eval(&js).await;
     });

--- a/crates/arto/src/components/content/context_menu/image_ops.rs
+++ b/crates/arto/src/components/content/context_menu/image_ops.rs
@@ -2,6 +2,7 @@ use dioxus::prelude::*;
 
 use crate::components::context_menu::{ContextMenuItem, ContextMenuSubmenu};
 use crate::keybindings::{shortcut_hint_for_context_action, KeyContext};
+use crate::utils::task::spawn_detached;
 
 /// "Copy Image As..." submenu: Image / Image with Background / Markdown / Path
 #[component]
@@ -22,7 +23,7 @@ pub(super) fn CopyImageAsSubmenu(
                     let src = src.clone();
                     move |_| {
                         let src = src.clone();
-                        spawn(async move {
+                        spawn_detached(async move {
                             crate::keybindings::dispatcher::copy_image_from_src(src, false).await;
                         });
                         on_close.call(());
@@ -37,7 +38,7 @@ pub(super) fn CopyImageAsSubmenu(
                     let src = src.clone();
                     move |_| {
                         let src = src.clone();
-                        spawn(async move {
+                        spawn_detached(async move {
                             crate::keybindings::dispatcher::copy_image_from_src(src, true).await;
                         });
                         on_close.call(());

--- a/crates/arto/src/components/win_hamburger.rs
+++ b/crates/arto/src/components/win_hamburger.rs
@@ -3,6 +3,7 @@
 use crate::components::context_menu::{ContextMenuItem, ContextMenuSeparator, ContextMenuSubmenu};
 use crate::components::icon::IconName;
 use crate::state::AppState;
+use crate::utils::task::spawn_detached;
 use dioxus::prelude::*;
 
 #[component]
@@ -110,11 +111,11 @@ pub fn WindowsMenu(on_close: EventHandler<()>) -> Element {
                     close();
                 } }
                 ContextMenuItem { label: "Find Next", shortcut: shortcut("search.next"), on_click: move |_| {
-                    spawn(async move { let _ = document::eval("window.Arto.search.navigate('next')").await; });
+                    spawn_detached(async move { let _ = document::eval("window.Arto.search.navigate('next')").await; });
                     close();
                 } }
                 ContextMenuItem { label: "Find Previous", shortcut: shortcut("search.prev"), on_click: move |_| {
-                    spawn(async move { let _ = document::eval("window.Arto.search.navigate('prev')").await; });
+                    spawn_detached(async move { let _ = document::eval("window.Arto.search.navigate('prev')").await; });
                     close();
                 } }
             }

--- a/crates/arto/src/keybindings/dispatcher.rs
+++ b/crates/arto/src/keybindings/dispatcher.rs
@@ -7,6 +7,7 @@ use crate::pinned_search::add_pinned_search;
 use crate::state::sidebar_cursor;
 use crate::state::{AppState, FocusedPanel};
 use crate::theme::Theme;
+use crate::utils::task::spawn_detached;
 
 use super::Action;
 
@@ -15,6 +16,11 @@ use super::Action;
 /// This is the main entry point for action execution after the engine
 /// matches a keybinding. `Cancel` is handled separately in app.rs
 /// (cancel chain logic) and should not reach here.
+///
+/// Actions are dispatched from menu items as well as from the keyboard, and
+/// a menu closes as part of the click that picks an item. Everything async
+/// here is therefore spawned with [`spawn_detached`], so an action outlives
+/// the widget that asked for it.
 pub fn dispatch_action(action: &Action, mut state: AppState) {
     match action {
         // --- Scroll (JS eval) ---
@@ -487,7 +493,7 @@ fn open_right_sidebar(state: &mut AppState) {
         })
     };
     let Some(id) = heading_id else { return };
-    spawn(async move {
+    spawn_detached(async move {
         let id_json = serde_json::to_string(&id).unwrap_or_else(|_| "null".to_string());
         let js = format!(
             r#"
@@ -559,7 +565,7 @@ fn dispatch_cursor_collapse(state: &mut AppState) {
 
 /// Scroll the keyboard-focused element into view using JS.
 fn scroll_cursor_into_view() {
-    spawn(async move {
+    spawn_detached(async move {
         if let Err(e) = document::eval(
             r#"
             requestAnimationFrame(() => {
@@ -575,7 +581,7 @@ fn scroll_cursor_into_view() {
 }
 
 fn search_navigate_eval(direction: &'static str) {
-    spawn(async move {
+    spawn_detached(async move {
         let js = format!("window.Arto.search.navigate('{direction}')");
         if let Err(e) = document::eval(&js).await {
             tracing::debug!(%direction, "Search navigate failed: {e}");
@@ -585,7 +591,7 @@ fn search_navigate_eval(direction: &'static str) {
 
 fn search_open(state: &mut AppState) {
     let mut app_state = *state;
-    spawn(async move {
+    spawn_detached(async move {
         let js = r#"
             (() => {
                 const s = window.getSelection();
@@ -605,7 +611,7 @@ fn search_open(state: &mut AppState) {
 }
 
 fn search_clear_eval() {
-    spawn(async move {
+    spawn_detached(async move {
         if let Err(e) = document::eval("window.Arto.search.clear();").await {
             tracing::debug!("Search clear failed: {e}");
         }
@@ -614,7 +620,7 @@ fn search_clear_eval() {
 
 fn search_pin_current(state: &mut AppState) {
     let mut app_state = *state;
-    spawn(async move {
+    spawn_detached(async move {
         #[derive(serde::Deserialize)]
         struct QueryValue {
             value: String,
@@ -653,7 +659,7 @@ fn search_pin_current(state: &mut AppState) {
 }
 
 fn scroll_eval(method: &'static str) {
-    spawn(async move {
+    spawn_detached(async move {
         let js = format!("window.Arto.scroll.{method}();");
         if let Err(e) = document::eval(&js).await {
             tracing::debug!(%method, "Scroll eval failed: {e}");
@@ -662,7 +668,7 @@ fn scroll_eval(method: &'static str) {
 }
 
 pub(crate) fn content_cursor_eval(method: &'static str) {
-    spawn(async move {
+    spawn_detached(async move {
         let js = format!("window.Arto.contentCursor.{method}()");
         if let Err(e) = document::eval(&js).await {
             tracing::debug!(%method, "Content cursor eval failed: {e}");
@@ -671,7 +677,7 @@ pub(crate) fn content_cursor_eval(method: &'static str) {
 }
 
 fn copy_content_cursor_text(js_getter: &'static str) {
-    spawn(async move {
+    spawn_detached(async move {
         let js = format!(
             "(() => {{ const t = window.Arto?.contentCursor?.{js_getter}() ?? ''; dioxus.send(t); }})()"
         );
@@ -688,7 +694,7 @@ fn copy_content_cursor_text(js_getter: &'static str) {
 }
 
 fn copy_image_from_cursor(opaque: bool) {
-    spawn(async move {
+    spawn_detached(async move {
         #[derive(serde::Deserialize)]
         #[serde(tag = "kind", rename_all = "snake_case")]
         enum CopyImageTarget {
@@ -750,6 +756,27 @@ fn copy_image_from_cursor(opaque: bool) {
     });
 }
 
+/// Put the PNG a rasterization returns on the clipboard, and say so when
+/// there is none.
+///
+/// `subject` names what was being rasterized, for the log line. Every way
+/// this can fail is reported: silence is what let a Copy Image that copied
+/// nothing look like a menu item nobody had clicked.
+pub(crate) async fn copy_rasterized_image(mut eval: document::Eval, subject: &str) {
+    match eval.recv::<Option<String>>().await {
+        Ok(Some(data_url)) => {
+            crate::utils::clipboard::copy_image_from_data_url(&data_url);
+            show_action_feedback("Copied");
+        }
+        Ok(None) => {
+            tracing::warn!(%subject, "Rasterizing for clipboard copy produced no image")
+        }
+        Err(e) => {
+            tracing::warn!(%e, %subject, "Rasterizing for clipboard copy failed")
+        }
+    }
+}
+
 async fn copy_special_block_from_cursor(kind: &str, opaque: bool) {
     let opaque_str = if opaque { "true" } else { "false" };
     let js = format!(
@@ -762,11 +789,7 @@ async fn copy_special_block_from_cursor(kind: &str, opaque: bool) {
         }})();
         "#,
     );
-    let mut eval = document::eval(&js);
-    if let Ok(Some(data_url)) = eval.recv::<Option<String>>().await {
-        crate::utils::clipboard::copy_image_from_data_url(&data_url);
-        show_action_feedback("Copied");
-    }
+    copy_rasterized_image(document::eval(&js), kind).await;
 }
 
 pub(crate) async fn copy_image_from_src(src: String, opaque: bool) {
@@ -802,15 +825,11 @@ pub(crate) async fn copy_image_from_src(src: String, opaque: bool) {
         "(async () => {{ dioxus.send(await window.Arto.rasterize.image({}, {})); }})();",
         src_json, opaque_str
     );
-    let mut eval = document::eval(&js);
-    if let Ok(Some(data_url)) = eval.recv::<Option<String>>().await {
-        crate::utils::clipboard::copy_image_from_data_url(&data_url);
-        show_action_feedback("Copied");
-    }
+    copy_rasterized_image(document::eval(&js), "image").await;
 }
 
 fn copy_image_path_from_cursor() {
-    spawn(async move {
+    spawn_detached(async move {
         let js =
             "(() => { const src = window.Arto?.contentCursor?.getImageSrc?.() ?? ''; dioxus.send(src); })()";
         let mut eval = document::eval(js);
@@ -826,7 +845,7 @@ fn copy_image_path_from_cursor() {
 }
 
 fn copy_link_path_from_cursor() {
-    spawn(async move {
+    spawn_detached(async move {
         let js =
             "(() => { const href = window.Arto?.contentCursor?.getLinkHref?.() ?? ''; dioxus.send(href); })()";
         let mut eval = document::eval(js);
@@ -842,7 +861,7 @@ fn copy_link_path_from_cursor() {
 }
 
 fn copy_file_path_with_line(file: std::path::PathBuf, is_range: bool) {
-    spawn(async move {
+    spawn_detached(async move {
         let js =
             "(() => { dioxus.send(window.Arto?.contentCursor?.getSourceLineRange() ?? null); })()";
         let mut eval = document::eval(js);
@@ -860,7 +879,7 @@ fn copy_file_path_with_line(file: std::path::PathBuf, is_range: bool) {
 }
 
 fn copy_markdown_source(file: std::path::PathBuf) {
-    spawn(async move {
+    spawn_detached(async move {
         #[derive(serde::Deserialize)]
         struct MarkdownSourceRequest {
             range: Option<(u32, u32)>,
@@ -906,7 +925,7 @@ fn copy_markdown_source(file: std::path::PathBuf) {
 pub(crate) fn show_action_feedback(message: &str) {
     let msg = serde_json::to_string(message).unwrap_or_else(|_| "\"Done\"".to_string());
     let js = format!("window.Arto?.feedback?.show?.({msg});");
-    spawn(async move {
+    spawn_detached(async move {
         let _ = document::eval(&js).await;
     });
 }
@@ -966,7 +985,7 @@ fn get_bookmark_target_path(state: &AppState) -> Option<std::path::PathBuf> {
 
 fn open_content_viewer_from_cursor(state: &AppState) {
     let theme = *state.current_theme.read();
-    spawn(async move {
+    spawn_detached(async move {
         #[derive(serde::Deserialize)]
         #[serde(tag = "kind", rename_all = "snake_case")]
         enum ViewerTarget {
@@ -1039,7 +1058,7 @@ fn open_link_from_cursor(state: &mut AppState, open_in_new_tab: bool) {
     };
     let mut app_state = *state;
 
-    spawn(async move {
+    spawn_detached(async move {
         let js =
             "(() => { const href = window.Arto?.contentCursor?.getLinkHref?.() ?? ''; dioxus.send(href); })()";
         let mut eval = document::eval(js);
@@ -1067,7 +1086,7 @@ fn open_link_from_cursor(state: &mut AppState, open_in_new_tab: bool) {
 }
 
 fn save_image_from_cursor() {
-    spawn(async move {
+    spawn_detached(async move {
         #[derive(serde::Deserialize)]
         #[serde(tag = "kind", rename_all = "snake_case")]
         enum SaveImageTarget {
@@ -1143,10 +1162,14 @@ async fn save_special_block_from_cursor(kind: &str) {
         "#,
     );
     let mut eval = document::eval(&js);
-    if let Ok(Some(data_url)) = eval.recv::<Option<String>>().await {
-        std::thread::spawn(move || {
-            crate::utils::image::save_image(&data_url);
-        });
+    match eval.recv::<Option<String>>().await {
+        Ok(Some(data_url)) => {
+            std::thread::spawn(move || {
+                crate::utils::image::save_image(&data_url);
+            });
+        }
+        Ok(None) => tracing::warn!(%kind, "Rasterizing for save produced no image"),
+        Err(e) => tracing::warn!(%e, %kind, "Rasterizing for save failed"),
     }
 }
 

--- a/crates/arto/src/utils.rs
+++ b/crates/arto/src/utils.rs
@@ -5,4 +5,5 @@ pub mod image;
 pub mod print;
 pub mod screen;
 pub mod source_lines;
+pub mod task;
 pub mod window_title;

--- a/crates/arto/src/utils/print.rs
+++ b/crates/arto/src/utils/print.rs
@@ -10,7 +10,8 @@
 use std::path::PathBuf;
 
 use dioxus::document;
-use dioxus::prelude::spawn;
+
+use super::task::spawn_detached;
 
 /// Open the native print dialog for the current window's webview.
 ///
@@ -18,7 +19,7 @@ use dioxus::prelude::spawn;
 /// "Save as PDF" for PDF export. `file` names the print job, which becomes
 /// the default file name offered by "Save as PDF".
 pub fn print_window(file: Option<PathBuf>) {
-    spawn(async move {
+    spawn_detached(async move {
         // Forcing the light theme for print (and restoring it afterwards)
         // only runs on macOS. There `run_print_dialog` awaits the print
         // sheet, so the light theme stays active until the content is

--- a/crates/arto/src/utils/task.rs
+++ b/crates/arto/src/utils/task.rs
@@ -1,0 +1,132 @@
+//! Spawning for work that has to outlive the widget that started it.
+
+use std::future::Future;
+
+use dioxus::core::spawn_forever;
+
+/// Spawn a one-shot task that keeps running once the component that started
+/// it is gone.
+///
+/// Dioxus drops every task a scope spawned the moment that scope unmounts. A
+/// menu item that closes its menu as part of the same click therefore loses
+/// whatever it started: the task is cancelled at its first `.await`, so a
+/// clipboard copy that round-trips through the WebView never comes back —
+/// nothing is copied, no feedback is shown, and not even the error paths run,
+/// because the code that would have reported the failure is dropped with it.
+///
+/// A detached task belongs to the window's root scope instead, so it runs to
+/// completion and is cancelled only when the window itself goes away.
+///
+/// This is for work that should finish regardless of what is on screen —
+/// clipboard copies, file dialogs, one JS round-trip. A listener that must
+/// stop with its component still belongs in `use_future`.
+pub fn spawn_detached(future: impl Future<Output = ()> + 'static) {
+    spawn_forever(future);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use dioxus::core::NoOpMutations;
+    use dioxus::prelude::*;
+    use std::cell::{Cell, RefCell};
+    use std::rc::Rc;
+    use std::time::Duration;
+
+    /// What the child does on its first render, handed over by the test.
+    struct TaskSetup {
+        /// Spawn detached instead of on the child's own scope.
+        detached: bool,
+        /// Released by the test once the child is unmounted.
+        gate: tokio::sync::oneshot::Receiver<()>,
+        /// Set when the task gets past the gate.
+        finished: Rc<Cell<bool>>,
+    }
+
+    thread_local! {
+        /// Whether the child that spawns the task is still rendered.
+        static CHILD_MOUNTED: Cell<bool> = const { Cell::new(true) };
+        static TASK_SETUP: RefCell<Option<TaskSetup>> = const { RefCell::new(None) };
+    }
+
+    #[component]
+    fn Child() -> Element {
+        use_hook(|| {
+            let TaskSetup {
+                detached,
+                gate,
+                finished,
+            } = TASK_SETUP
+                .with(|slot| slot.borrow_mut().take())
+                .expect("task setup handed over before the first render");
+            let body = async move {
+                let _ = gate.await;
+                finished.set(true);
+            };
+            if detached {
+                spawn_detached(body);
+            } else {
+                spawn(body);
+            }
+        });
+        rsx! { div {} }
+    }
+
+    #[component]
+    fn Parent() -> Element {
+        rsx! {
+            if CHILD_MOUNTED.with(Cell::get) {
+                Child {}
+            }
+        }
+    }
+
+    /// Poll the dom until it runs out of work, or the timeout expires.
+    async fn settle(dom: &mut VirtualDom) {
+        tokio::select! {
+            _ = dom.wait_for_work() => {}
+            _ = tokio::time::sleep(Duration::from_millis(100)) => {}
+        }
+    }
+
+    /// Spawn a task from the child, unmount the child, then let the task
+    /// finish. Answers whether it ever got there.
+    async fn task_finishes_after_unmount(detached: bool) -> bool {
+        let finished = Rc::new(Cell::new(false));
+        let (release, gate) = tokio::sync::oneshot::channel();
+        CHILD_MOUNTED.with(|mounted| mounted.set(true));
+        TASK_SETUP.with(|slot| {
+            *slot.borrow_mut() = Some(TaskSetup {
+                detached,
+                gate,
+                finished: Rc::clone(&finished),
+            });
+        });
+
+        let mut dom = VirtualDom::new(Parent);
+        dom.rebuild(&mut NoOpMutations);
+        settle(&mut dom).await;
+
+        CHILD_MOUNTED.with(|mounted| mounted.set(false));
+        dom.mark_dirty(ScopeId::APP);
+        dom.render_immediate(&mut NoOpMutations);
+
+        let _ = release.send(());
+        settle(&mut dom).await;
+
+        finished.get()
+    }
+
+    #[tokio::test]
+    async fn detached_task_survives_the_component_that_spawned_it() {
+        assert!(task_finishes_after_unmount(true).await);
+    }
+
+    /// The reason [`spawn_detached`] exists: the plain `spawn` a component
+    /// would otherwise reach for dies with the component.
+    #[tokio::test]
+    async fn scope_bound_task_dies_with_the_component_that_spawned_it() {
+        assert!(!task_finishes_after_unmount(false).await);
+    }
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -227,6 +227,9 @@ export function init(): void {
     },
     rasterize: {
       image: (src: string, opaque: boolean): Promise<string | null> => {
+        // A data URL runs to megabytes; the console only needs enough of it
+        // to tell one image from another.
+        const shortSrc = src.length > 120 ? `${src.slice(0, 120)}…` : src;
         return new Promise((resolve) => {
           const img = new Image();
           img.onload = () => {
@@ -246,7 +249,10 @@ export function init(): void {
                 scaledHeight > maxDimension ||
                 scaledWidth * scaledHeight > maxPixels
               ) {
-                console.error(`Image too large to rasterize: ${scaledWidth}x${scaledHeight}`);
+                console.error(
+                  `Image too large to rasterize: ${scaledWidth}x${scaledHeight}`,
+                  shortSrc,
+                );
                 resolve(null);
                 return;
               }
@@ -270,11 +276,14 @@ export function init(): void {
               ctx.drawImage(img, 0, 0);
               resolve(canvas.toDataURL("image/png"));
             } catch (e) {
-              console.error("Failed to rasterize image:", e);
+              console.error("Failed to rasterize image:", shortSrc, e);
               resolve(null);
             }
           };
-          img.onerror = () => resolve(null);
+          img.onerror = () => {
+            console.error("Failed to load image for rasterization:", shortSrc);
+            resolve(null);
+          };
           img.src = src;
         });
       },


### PR DESCRIPTION
Closes #256.

## Summary

- Add `utils::task::spawn_detached`, a one-shot spawn that puts the task on the window's root scope so it outlives the component that started it, with tests that drive a `VirtualDom` through an unmount.
- Detach every async action in the keybinding dispatcher and in the content context menu, so Copy Image — and Save Image As..., and the "Copied" feedback — survive the menu closing.
- Fold the three copies of the eval-then-clipboard tail into `copy_rasterized_image`, which reports a missing image and a failed round-trip instead of dropping both; the save path says the same.
- Let `rasterize.image` in the frontend name the source it failed on, truncated, instead of resolving to `null` in silence.

## Why

The issue narrowed the fault to the frontend, but it was one step earlier, in Rust. The context-menu click spawns the copy and then closes the menu. Closing sets `CONTENT_CONTEXT_MENU` to `None`, which unmounts `ContentContextMenu`, and Dioxus drops every task a scope spawned when that scope unmounts (`Runtime::remove_scope`). An event handler's `spawn` belongs to the scope that defined the handler, so the copy was cancelled at the first `.await` — the round-trip through the WebView — before it ever reached the clipboard.

That also explains the silence the issue describes. Nothing was logged because the error paths were dropped along with the task, not because they were unreachable: `copy_image_from_data_url`, the download failure branch, and the rasterizer's own `console.error` never got the chance to run. The keyboard shortcut was unaffected throughout, because it dispatches from the App-scoped keyboard loop, which stays mounted — which is why only the right-click route was broken.

`close_context_menu` already documented the intent that "async rasterization tasks may still need [the element references] after menu close". The intent was right; nothing enforced it. Detaching the dispatcher's tasks rather than only Copy Image's follows from what the dispatcher is: an action reaches it from a menu as readily as from a keystroke, and should outlive the widget that asked for it.

Both halves of that are pinned by tests, so the reasoning is not left to the reader: a detached task finishes after its component unmounts, a scope-bound one never does.

## Test Plan

- [x] `just fmt check test` (278 tests in `arto`, including the two new ones; 89 frontend tests)
- [ ] Right-click the local image in `samples/01-inline.md` (line 131) → Copy Image → paste; "Copied" appears and the image is on the clipboard
- [ ] The same for the remote image (line 127), which is downloaded in Rust and handed over as a `data:` URL
- [ ] Copy Image As... → Image / Image with Background from the same menu
- [ ] Right-click a Mermaid and a Math block → Copy Image
- [ ] Save Image As... from the context menu, which was losing its task the same way
- [ ] The keyboard shortcut for Copy Image still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mv5SMQipQeGv5YX9TyCUd5

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/arto-app/codesmith/Arto/pr/257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791392743&installation_model_id=435827&pr_number=257&repository=arto-app%2FArto&return_to=https%3A%2F%2Fgithub.com%2Farto-app%2FArto%2Fpull%2F257&signature=04b9b36a1898a784606c74a0e380c03eede342b056880205769cdc95bdfadcae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->