### PR TITLE
feat: make Arto a single binary, and serve its assets over a protocol

### DIFF
--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -47,12 +47,17 @@ jobs:
           # installs only on Debian/Ubuntu, so the AppImage is what every
           # other distro runs), Windows an NSIS installer
           # (Arto_<version>_<arch>-setup.exe); see the justfile bundle recipes.
+          #
+          # `standalone` names the single executable a leg also publishes, and
+          # is empty where none is. macOS has none deliberately: what makes
+          # Arto worth installing there — the Finder associations and the
+          # Quick Look extension — lives in the bundle, not in the binary.
           legs='[
-            {"target":"macos","os":"macos-latest","artifacts":"./target/dx/arto/bundle/**/*.dmg"},
-            {"target":"ubuntu","os":"ubuntu-latest","artifacts":"./target/dx/arto/bundle/**/*.deb\n./target/dx/arto/bundle/**/*.AppImage"},
-            {"target":"ubuntu-arm64","os":"ubuntu-24.04-arm","artifacts":"./target/dx/arto/bundle/**/*.deb\n./target/dx/arto/bundle/**/*.AppImage"},
-            {"target":"windows","os":"windows-latest","artifacts":"./target/dx/arto/bundle/**/*-setup.exe"},
-            {"target":"windows-arm64","os":"windows-11-arm","artifacts":"./target/dx/arto/bundle/**/*-setup.exe"}
+            {"target":"macos","os":"macos-latest","standalone":"","artifacts":"./target/dx/arto/bundle/**/*.dmg"},
+            {"target":"ubuntu","os":"ubuntu-latest","standalone":"arto-linux-x86_64","artifacts":"./target/dx/arto/bundle/**/*.deb\n./target/dx/arto/bundle/**/*.AppImage\n./dist/arto-linux-x86_64"},
+            {"target":"ubuntu-arm64","os":"ubuntu-24.04-arm","standalone":"arto-linux-aarch64","artifacts":"./target/dx/arto/bundle/**/*.deb\n./target/dx/arto/bundle/**/*.AppImage\n./dist/arto-linux-aarch64"},
+            {"target":"windows","os":"windows-latest","standalone":"arto-windows-x86_64.exe","artifacts":"./target/dx/arto/bundle/**/*-setup.exe\n./dist/arto-windows-x86_64.exe"},
+            {"target":"windows-arm64","os":"windows-11-arm","standalone":"arto-windows-aarch64.exe","artifacts":"./target/dx/arto/bundle/**/*-setup.exe\n./dist/arto-windows-aarch64.exe"}
           ]'
           matrix="$(jq -c --argjson want "$TARGETS" '[.[] | select(.target as $t | $want | index($t))]' <<<"$legs")"
           if [ "$(jq length <<<"$matrix")" = "0" ]; then
@@ -157,6 +162,39 @@ jobs:
       - name: Verify bundle
         if: runner.os != 'Windows'
         run: just verify-bundle
+      # The single executable, for people who would rather download a file
+      # than install a package. It shares everything `just build` compiled, so
+      # this costs a link and no more.
+      - name: Build standalone binary
+        if: matrix.standalone != ''
+        run: just standalone
+      # What a standalone binary claims is that it runs from wherever it is
+      # put, and an empty working directory is where a binary that had gone
+      # back to looking for files beside itself would stop being able to hide
+      # it. `--version` exercises startup and exits, so it needs no display.
+      - name: Verify standalone binary (Unix)
+        if: matrix.standalone != '' && runner.os != 'Windows'
+        shell: bash
+        env:
+          NAME: ${{ matrix.standalone }}
+        run: |
+          mkdir -p dist "$RUNNER_TEMP/nothing-here"
+          cp target/release/arto "dist/$NAME"
+          cd "$RUNNER_TEMP/nothing-here"
+          "$GITHUB_WORKSPACE/dist/$NAME" --version
+      - name: Verify standalone binary (Windows)
+        if: matrix.standalone != '' && runner.os == 'Windows'
+        shell: pwsh
+        env:
+          NAME: ${{ matrix.standalone }}
+        run: |
+          $empty = Join-Path $env:RUNNER_TEMP 'nothing-here'
+          New-Item -ItemType Directory -Force -Path dist, $empty | Out-Null
+          Copy-Item target/release/arto.exe (Join-Path 'dist' $env:NAME)
+          $binary = Join-Path $env:GITHUB_WORKSPACE (Join-Path 'dist' $env:NAME)
+          Push-Location $empty
+          & $binary --version
+          Pop-Location
       - uses: actions/upload-artifact@v7
         with:
           name: arto-${{ matrix.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,8 @@ jobs:
 
   # TypeScript and CSS: lint, type-check, unit tests, and the production
   # bundle. The bundle is handed to the Rust legs as an artifact so none of
-  # them needs pnpm; asset!() and include_str! only need the files to exist.
+  # them needs pnpm; the build script and include_str! only need the files to
+  # be there.
   frontend:
     needs: changes
     if: needs.changes.outputs.code == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,10 @@ jobs:
           # mandatory macOS build, and the dispatch job fails if the aarch64
           # DMG is absent.
           artifactErrorsFailBuild: false
-          artifacts: ./artifacts/**/*.dmg,./artifacts/**/*.deb,./artifacts/**/*.AppImage,./artifacts/**/*-setup.exe
+          # The `arto-*` entries are the standalone binaries; the installers
+          # are all named `Arto_<version>_…` or `arto_<version>_…`, so nothing
+          # matches twice.
+          artifacts: ./artifacts/**/*.dmg,./artifacts/**/*.deb,./artifacts/**/*.AppImage,./artifacts/**/*-setup.exe,./artifacts/**/arto-linux-*,./artifacts/**/arto-windows-*
           removeArtifacts: true
           makeLatest: true
           bodyFile: release_body.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,6 +255,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
+ "sha2 0.11.0",
  "tempfile",
  "tracing",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,6 +172,7 @@ dependencies = [
  "dirs 7.0.0",
  "display-info",
  "dotenvy",
+ "flate2",
  "html-escape",
  "image",
  "indoc",

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ brew install --cask arto-app/tap/arto
 xattr -dr com.apple.quarantine /Applications/Arto.app
 ```
 
-Linux packages, Nix, and why that second line is needed: [Installation](./docs/installation.md).
+Linux packages, a single binary for Linux and Windows, Nix, and why that second line is needed: [Installation](./docs/installation.md).
 
 ## From the terminal
 

--- a/crates/arto-config/src/lib.rs
+++ b/crates/arto-config/src/lib.rs
@@ -172,6 +172,7 @@ mod tests {
             file_open: FileOpenBehavior::CurrentScreen,
             markdown: RenderOptions {
                 auto_link_urls: true,
+                ..Default::default()
             },
             directory: DirectoryConfig {
                 default_directory: Some(PathBuf::from("/home/user")),

--- a/crates/arto-markdown/Cargo.toml
+++ b/crates/arto-markdown/Cargo.toml
@@ -18,6 +18,7 @@ ox_content_parser = "3.1.0"
 ox_content_renderer = "3.1.0"
 serde.workspace = true
 serde_yaml_ng = "0.10"
+sha2.workspace = true
 tracing.workspace = true
 url = "2"
 

--- a/crates/arto-markdown/src/lib.rs
+++ b/crates/arto-markdown/src/lib.rs
@@ -210,6 +210,33 @@ fn prepend_frontmatter(frontmatter_html: &str, html_output: String) -> String {
     }
 }
 
+/// A local image the host agreed to serve, and the file it stands for.
+///
+/// Produced only under [`ImageResolution::Deferred`]; the id is the one that
+/// appears in the `<img src>` the render wrote.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeferredImage {
+    pub id: String,
+    pub path: PathBuf,
+    /// What to answer the request with, from the same table the inlined
+    /// path uses, so the two do not disagree about a format.
+    pub mime: &'static str,
+}
+
+/// What a render produced.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct RenderResult {
+    /// The rendered document.
+    pub html: String,
+    /// Every heading, when a table of contents was asked for; otherwise empty,
+    /// because a render without one writes no ids to point at.
+    pub headings: Vec<HeadingInfo>,
+    /// The images the host has to serve, in the order they were first
+    /// referenced. Always empty under [`ImageResolution::DataUrl`], where the
+    /// bytes are in the document already.
+    pub images: Vec<DeferredImage>,
+}
+
 /// Render Markdown to HTML.
 ///
 /// Relative links and images resolve against the directory of `base_path`.
@@ -217,30 +244,36 @@ pub fn render_to_html(
     markdown: impl AsRef<str>,
     base_path: impl AsRef<Path>,
     options: &RenderOptions,
-) -> Result<String> {
-    let pipeline = run_pipeline(markdown.as_ref(), base_path.as_ref(), options, false)?;
-
-    let html_output = post_process_html_tags(&pipeline.raw_html, &pipeline.base_dir);
-
-    Ok(prepend_frontmatter(&pipeline.frontmatter_html, html_output))
+) -> Result<RenderResult> {
+    render(markdown.as_ref(), base_path.as_ref(), options, false)
 }
 
-/// Render Markdown to HTML with TOC information
-///
-/// Returns a tuple of (rendered HTML with heading IDs, extracted headings)
+/// Render Markdown to HTML, keeping the heading ids and reporting the
+/// headings a table of contents is built from.
 pub fn render_to_html_with_toc(
     markdown: impl AsRef<str>,
     base_path: impl AsRef<Path>,
     options: &RenderOptions,
-) -> Result<(String, Vec<HeadingInfo>)> {
-    let pipeline = run_pipeline(markdown.as_ref(), base_path.as_ref(), options, true)?;
+) -> Result<RenderResult> {
+    render(markdown.as_ref(), base_path.as_ref(), options, true)
+}
 
-    let html_output = post_process_html_tags(&pipeline.raw_html, &pipeline.base_dir);
+fn render(
+    markdown: &str,
+    base_path: &Path,
+    options: &RenderOptions,
+    with_toc: bool,
+) -> Result<RenderResult> {
+    let pipeline = run_pipeline(markdown, base_path, options, with_toc)?;
 
-    Ok((
-        prepend_frontmatter(&pipeline.frontmatter_html, html_output),
-        pipeline.headings,
-    ))
+    let (html_output, images) =
+        post_process_html_tags(&pipeline.raw_html, &pipeline.base_dir, &options.images);
+
+    Ok(RenderResult {
+        html: prepend_frontmatter(&pipeline.frontmatter_html, html_output),
+        headings: pipeline.headings,
+        images,
+    })
 }
 
 #[cfg(test)]
@@ -256,7 +289,9 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let md_path = temp_dir.path().join("test.md");
 
-        let result = render_to_html(markdown, &md_path, &RenderOptions::default()).unwrap();
+        let result = render_to_html(markdown, &md_path, &RenderOptions::default())
+            .unwrap()
+            .html;
 
         assert!(result.contains("<h1 data-source-line="));
         assert!(result.contains("Hello"));
@@ -288,7 +323,9 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let md_path = temp_dir.path().join("test.md");
 
-        let result = render_to_html(markdown, &md_path, &RenderOptions::default()).unwrap();
+        let result = render_to_html(markdown, &md_path, &RenderOptions::default())
+            .unwrap()
+            .html;
 
         let has_rust = result.contains("language-rust") || result.contains("class=\"rust\"");
         let has_python = result.contains("language-python") || result.contains("class=\"python\"");
@@ -309,7 +346,9 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let md_path = temp_dir.path().join("test.md");
 
-        let result = render_to_html(markdown, &md_path, &RenderOptions::default()).unwrap();
+        let result = render_to_html(markdown, &md_path, &RenderOptions::default())
+            .unwrap()
+            .html;
 
         assert!(result.contains("markdown-alert-note"));
         assert!(result.contains("This is important"));
@@ -327,7 +366,9 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let md_path = temp_dir.path().join("test.md");
 
-        let result = render_to_html(markdown, &md_path, &RenderOptions::default()).unwrap();
+        let result = render_to_html(markdown, &md_path, &RenderOptions::default())
+            .unwrap()
+            .html;
 
         assert!(result.contains(r#"class="preprocessed-mermaid""#));
         assert!(result.contains("graph LR"));
@@ -349,7 +390,9 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let md_path = temp_dir.path().join("test.md");
 
-        let result = render_to_html(markdown, &md_path, &RenderOptions::default()).unwrap();
+        let result = render_to_html(markdown, &md_path, &RenderOptions::default())
+            .unwrap()
+            .html;
 
         assert!(
             result.contains(r#"class="preprocessed-math-inline""#),
@@ -393,7 +436,9 @@ mod tests {
 
         let md_path = temp_dir.path().join("test.md");
 
-        let result = render_to_html(markdown, &md_path, &RenderOptions::default()).unwrap();
+        let result = render_to_html(markdown, &md_path, &RenderOptions::default())
+            .unwrap()
+            .html;
 
         assert!(
             result.contains("<h1 data-source-line="),
@@ -431,7 +476,9 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let md_path = temp_dir.path().join("test.md");
 
-        let result = render_to_html(markdown, &md_path, &RenderOptions::default()).unwrap();
+        let result = render_to_html(markdown, &md_path, &RenderOptions::default())
+            .unwrap()
+            .html;
 
         assert!(result.contains(r#"<details class="frontmatter""#));
         assert!(result.contains("<th>title</th>"));
@@ -462,8 +509,9 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let md_path = temp_dir.path().join("test.md");
 
-        let (html, headings) =
+        let rendered =
             render_to_html_with_toc(markdown, &md_path, &RenderOptions::default()).unwrap();
+        let (html, headings) = (rendered.html, rendered.headings);
 
         assert_eq!(headings.len(), 2);
         assert_eq!(headings[0].text, "Title");
@@ -513,9 +561,12 @@ mod tests {
             > This is a note
         "};
 
-        let html_basic = render_to_html(markdown, &md_path, &RenderOptions::default()).unwrap();
-        let (html_toc, headings) =
+        let html_basic = render_to_html(markdown, &md_path, &RenderOptions::default())
+            .unwrap()
+            .html;
+        let rendered =
             render_to_html_with_toc(markdown, &md_path, &RenderOptions::default()).unwrap();
+        let (html_toc, headings) = (rendered.html, rendered.headings);
 
         // Strip heading IDs for comparison (without regex dependency)
         fn strip_heading_ids(s: &str) -> String {
@@ -559,7 +610,9 @@ mod tests {
         "};
         let temp_dir = TempDir::new().unwrap();
         let md_path = temp_dir.path().join("test.md");
-        let result = render_to_html(markdown, &md_path, &RenderOptions::default()).unwrap();
+        let result = render_to_html(markdown, &md_path, &RenderOptions::default())
+            .unwrap()
+            .html;
 
         assert!(
             result.contains(r#"<h1 data-source-line="1">"#),
@@ -596,7 +649,9 @@ mod tests {
         "};
         let temp_dir = TempDir::new().unwrap();
         let md_path = temp_dir.path().join("test.md");
-        let result = render_to_html(markdown, &md_path, &RenderOptions::default()).unwrap();
+        let result = render_to_html(markdown, &md_path, &RenderOptions::default())
+            .unwrap()
+            .html;
 
         assert!(
             result.contains(r#"<h1 data-source-line="5">"#),
@@ -619,7 +674,9 @@ mod tests {
         "};
         let temp_dir = TempDir::new().unwrap();
         let md_path = temp_dir.path().join("test.md");
-        let result = render_to_html(markdown, &md_path, &RenderOptions::default()).unwrap();
+        let result = render_to_html(markdown, &md_path, &RenderOptions::default())
+            .unwrap()
+            .html;
 
         assert!(
             result.contains(
@@ -640,7 +697,9 @@ mod tests {
         "};
         let temp_dir = TempDir::new().unwrap();
         let md_path = temp_dir.path().join("test.md");
-        let result = render_to_html(markdown, &md_path, &RenderOptions::default()).unwrap();
+        let result = render_to_html(markdown, &md_path, &RenderOptions::default())
+            .unwrap()
+            .html;
 
         assert!(
             result.contains(
@@ -659,7 +718,9 @@ mod tests {
         "};
         let temp_dir = TempDir::new().unwrap();
         let md_path = temp_dir.path().join("test.md");
-        let result = render_to_html(markdown, &md_path, &RenderOptions::default()).unwrap();
+        let result = render_to_html(markdown, &md_path, &RenderOptions::default())
+            .unwrap()
+            .html;
 
         assert!(
             result.contains(r#"<blockquote data-source-line="3">"#),
@@ -678,7 +739,9 @@ mod tests {
         "};
         let temp_dir = TempDir::new().unwrap();
         let md_path = temp_dir.path().join("test.md");
-        let result = render_to_html(markdown, &md_path, &RenderOptions::default()).unwrap();
+        let result = render_to_html(markdown, &md_path, &RenderOptions::default())
+            .unwrap()
+            .html;
 
         assert!(
             result.contains(r#"<hr data-source-line="3">"#),
@@ -694,7 +757,9 @@ mod tests {
         "};
         let temp_dir = TempDir::new().unwrap();
         let md_path = temp_dir.path().join("test.md");
-        let result = render_to_html(markdown, &md_path, &RenderOptions::default()).unwrap();
+        let result = render_to_html(markdown, &md_path, &RenderOptions::default())
+            .unwrap()
+            .html;
 
         assert!(
             result.contains(r#"<ol data-source-line="1""#),
@@ -711,7 +776,9 @@ mod tests {
         "};
         let temp_dir = TempDir::new().unwrap();
         let md_path = temp_dir.path().join("test.md");
-        let result = render_to_html(markdown, &md_path, &RenderOptions::default()).unwrap();
+        let result = render_to_html(markdown, &md_path, &RenderOptions::default())
+            .unwrap()
+            .html;
 
         assert!(
             result.contains(r#"data-source-line="1""#),
@@ -740,7 +807,9 @@ mod tests {
         "};
         let temp_dir = TempDir::new().unwrap();
         let md_path = temp_dir.path().join("test.md");
-        let result = render_to_html(markdown, &md_path, &RenderOptions::default()).unwrap();
+        let result = render_to_html(markdown, &md_path, &RenderOptions::default())
+            .unwrap()
+            .html;
 
         assert!(
             result.contains(r#"<tr data-source-line="3">"#),
@@ -768,7 +837,9 @@ mod tests {
         "};
         let temp_dir = TempDir::new().unwrap();
         let md_path = temp_dir.path().join("test.md");
-        let result = render_to_html(markdown, &md_path, &RenderOptions::default()).unwrap();
+        let result = render_to_html(markdown, &md_path, &RenderOptions::default())
+            .unwrap()
+            .html;
 
         assert!(
             result.contains(r#"data-source-line="1""#),
@@ -792,7 +863,9 @@ mod tests {
         "};
         let temp_dir = TempDir::new().unwrap();
         let md_path = temp_dir.path().join("test.md");
-        let result = render_to_html(markdown, &md_path, &RenderOptions::default()).unwrap();
+        let result = render_to_html(markdown, &md_path, &RenderOptions::default())
+            .unwrap()
+            .html;
 
         assert!(
             result.contains(r#"<h1 data-source-line="4">"#),
@@ -816,7 +889,9 @@ mod tests {
         "};
         let temp_dir = TempDir::new().unwrap();
         let md_path = temp_dir.path().join("test.md");
-        let result = render_to_html(markdown, &md_path, &RenderOptions::default()).unwrap();
+        let result = render_to_html(markdown, &md_path, &RenderOptions::default())
+            .unwrap()
+            .html;
 
         assert!(
             result.contains(
@@ -842,7 +917,9 @@ mod tests {
         "};
         let temp_dir = TempDir::new().unwrap();
         let md_path = temp_dir.path().join("test.md");
-        let result = render_to_html(markdown, &md_path, &RenderOptions::default()).unwrap();
+        let result = render_to_html(markdown, &md_path, &RenderOptions::default())
+            .unwrap()
+            .html;
 
         assert!(
             result.contains(r#"data-source-line="3""#),
@@ -865,7 +942,9 @@ mod tests {
         "};
         let temp_dir = TempDir::new().unwrap();
         let md_path = temp_dir.path().join("test.md");
-        let result = render_to_html(markdown, &md_path, &RenderOptions::default()).unwrap();
+        let result = render_to_html(markdown, &md_path, &RenderOptions::default())
+            .unwrap()
+            .html;
 
         assert!(
             result.contains(r#"data-source-line="3""#),
@@ -888,7 +967,9 @@ mod tests {
         "};
         let temp_dir = TempDir::new().unwrap();
         let md_path = temp_dir.path().join("test.md");
-        let result = render_to_html(markdown, &md_path, &RenderOptions::default()).unwrap();
+        let result = render_to_html(markdown, &md_path, &RenderOptions::default())
+            .unwrap()
+            .html;
 
         assert!(
             result.contains(r#"data-source-line="3""#),
@@ -917,7 +998,9 @@ mod tests {
         "};
         let temp_dir = TempDir::new().unwrap();
         let md_path = temp_dir.path().join("test.md");
-        let result = render_to_html(markdown, &md_path, &RenderOptions::default()).unwrap();
+        let result = render_to_html(markdown, &md_path, &RenderOptions::default())
+            .unwrap()
+            .html;
 
         // Table starts on line 5 of original (after 4 frontmatter lines)
         assert!(
@@ -943,7 +1026,9 @@ mod tests {
         "};
         let temp_dir = TempDir::new().unwrap();
         let md_path = temp_dir.path().join("test.md");
-        let result = render_to_html(markdown, &md_path, &RenderOptions::default()).unwrap();
+        let result = render_to_html(markdown, &md_path, &RenderOptions::default())
+            .unwrap()
+            .html;
 
         // Mermaid block starts on line 4 of original
         assert!(
@@ -969,7 +1054,9 @@ mod tests {
         "};
         let temp_dir = TempDir::new().unwrap();
         let md_path = temp_dir.path().join("test.md");
-        let result = render_to_html(markdown, &md_path, &RenderOptions::default()).unwrap();
+        let result = render_to_html(markdown, &md_path, &RenderOptions::default())
+            .unwrap()
+            .html;
 
         // First table: lines 1-3
         assert!(
@@ -996,7 +1083,16 @@ mod tests {
     // ========================================================================
 
     fn render_with_autolink(markdown: &str, base_path: &Path, auto_link_urls: bool) -> String {
-        render_to_html(markdown, base_path, &RenderOptions { auto_link_urls }).unwrap()
+        render_to_html(
+            markdown,
+            base_path,
+            &RenderOptions {
+                auto_link_urls,
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .html
     }
 
     #[test]
@@ -1081,7 +1177,9 @@ mod tests {
     fn test_render_to_html_empty_input() {
         let temp_dir = TempDir::new().unwrap();
         let md_path = temp_dir.path().join("test.md");
-        let result = render_to_html("", &md_path, &RenderOptions::default()).unwrap();
+        let result = render_to_html("", &md_path, &RenderOptions::default())
+            .unwrap()
+            .html;
 
         assert!(
             result.is_empty() || result.trim().is_empty(),
@@ -1094,7 +1192,9 @@ mod tests {
         let markdown = "---\ntitle: Test\n---\n";
         let temp_dir = TempDir::new().unwrap();
         let md_path = temp_dir.path().join("test.md");
-        let result = render_to_html(markdown, &md_path, &RenderOptions::default()).unwrap();
+        let result = render_to_html(markdown, &md_path, &RenderOptions::default())
+            .unwrap()
+            .html;
 
         assert!(
             result.contains("frontmatter"),
@@ -1118,7 +1218,9 @@ mod tests {
         "};
         let temp_dir = TempDir::new().unwrap();
         let md_path = temp_dir.path().join("test.md");
-        let result = render_to_html(markdown, &md_path, &RenderOptions::default()).unwrap();
+        let result = render_to_html(markdown, &md_path, &RenderOptions::default())
+            .unwrap()
+            .html;
 
         assert!(
             result.contains("markdown-alert-note"),

--- a/crates/arto-markdown/src/options.rs
+++ b/crates/arto-markdown/src/options.rs
@@ -4,6 +4,29 @@ fn default_true() -> bool {
     true
 }
 
+/// How a local image reaches the document.
+///
+/// The two consumers of the pipeline want opposite things from an image. A
+/// page that has to stand on its own — what `arto page` writes and what Quick
+/// Look previews — can only carry the bytes. The app has a window it serves
+/// itself, and inlining there costs it the memory twice over, in the HTML it
+/// builds and in the WebView that parses it.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum ImageResolution {
+    /// Read the file and inline it as a `data:` URL.
+    #[default]
+    DataUrl,
+    /// Emit `{base_url}/{id}` and report which path each id stands for, for a
+    /// host that serves the bytes at that URL itself.
+    ///
+    /// An id rather than the path itself, because a URL carrying an arbitrary
+    /// path would have to survive percent-encoding and the shape of a Windows
+    /// path. It is not a secret — the same file always hashes the same way —
+    /// so what a host may serve is decided by the ids a render actually
+    /// handed it, never by the id being hard to guess.
+    Deferred { base_url: String },
+}
+
 /// Choices that change how Markdown is rendered.
 ///
 /// This is also the `markdown` section of Arto's `config.json`, so every
@@ -15,12 +38,21 @@ pub struct RenderOptions {
     /// Turn bare URLs into links (default: true).
     #[serde(default = "default_true")]
     pub auto_link_urls: bool,
+    /// How local images reach the document.
+    ///
+    /// Deliberately not part of `config.json`: which of the two a consumer
+    /// needs follows from what that consumer is, not from anything the reader
+    /// would choose. Keeping it here rather than in a second parameter keeps
+    /// the pipeline's entry points to one options argument.
+    #[serde(skip)]
+    pub images: ImageResolution,
 }
 
 impl Default for RenderOptions {
     fn default() -> Self {
         Self {
             auto_link_urls: true,
+            images: ImageResolution::default(),
         }
     }
 }
@@ -40,8 +72,27 @@ mod tests {
     fn test_serializes_with_camel_case_keys() {
         let json = serde_json::to_string(&RenderOptions {
             auto_link_urls: false,
+            ..Default::default()
         })
         .unwrap();
         assert_eq!(json, r#"{"autoLinkUrls":false}"#);
+    }
+
+    /// The image strategy is the host's business, so `config.json` neither
+    /// carries it nor can set it.
+    #[test]
+    fn test_image_resolution_stays_out_of_the_configuration_file() {
+        let json = serde_json::to_string(&RenderOptions {
+            images: ImageResolution::Deferred {
+                base_url: "artoasset://localhost/img".to_string(),
+            },
+            ..Default::default()
+        })
+        .unwrap();
+        assert!(!json.contains("images"), "leaked into config.json: {json}");
+
+        let parsed: RenderOptions =
+            serde_json::from_str(r#"{"images":{"deferred":{"baseUrl":"x"}}}"#).unwrap();
+        assert_eq!(parsed.images, ImageResolution::DataUrl);
     }
 }

--- a/crates/arto-markdown/src/post_process.rs
+++ b/crates/arto-markdown/src/post_process.rs
@@ -1,7 +1,11 @@
 use base64::{engine::general_purpose, Engine as _};
 use lol_html::{element, HtmlRewriter, Settings};
+use sha2::{Digest, Sha256};
+use std::cell::RefCell;
 use std::io::Read;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+
+use crate::{DeferredImage, ImageResolution};
 
 /// Maximum byte size of a local image that will be inlined as a data URL.
 ///
@@ -121,6 +125,20 @@ pub(super) fn get_mime_type(path: &Path) -> &'static str {
 /// and its data URL would end in the `base64,` comma, which `srcset` parsing
 /// strips back off into a malformed URL.
 fn inline_local_image(src: &str, canonical_base: &Path) -> Option<String> {
+    let canonical_path = resolve_local_image(src, canonical_base)?;
+    let image_data = read_image_bounded(&canonical_path, MAX_INLINE_IMAGE_SIZE)?;
+    if image_data.is_empty() {
+        tracing::debug!(?canonical_path, "Image file is empty; nothing to inline");
+        return None;
+    }
+    let mime_type = get_mime_type(&canonical_path);
+    let base64_data = general_purpose::STANDARD.encode(&image_data);
+    Some(format!("data:{mime_type};base64,{base64_data}"))
+}
+
+/// The file a local image reference names, or `None` when the reference
+/// addresses something that needs no resolution or nothing that exists.
+fn resolve_local_image(src: &str, canonical_base: &Path) -> Option<PathBuf> {
     if src.starts_with("http://") || src.starts_with("https://") || src.starts_with("data:") {
         return None;
     }
@@ -166,14 +184,114 @@ fn inline_local_image(src: &str, canonical_base: &Path) -> Option<String> {
             "Image path resolved outside base directory; proceeding with inline read"
         );
     }
-    let image_data = read_image_bounded(&canonical_path, MAX_INLINE_IMAGE_SIZE)?;
-    if image_data.is_empty() {
-        tracing::debug!(?canonical_path, "Image file is empty; nothing to inline");
+    Some(canonical_path)
+}
+
+/// The images a render handed to the host, in the order first referenced.
+///
+/// Deduplicated by id, so the same file drawn several times is one entry and
+/// one URL — which is also what lets the host cache it.
+#[derive(Default)]
+struct DeferredImages {
+    entries: Vec<DeferredImage>,
+}
+
+impl DeferredImages {
+    fn url(&mut self, image: DeferredImage, base_url: &str) -> String {
+        // The extension rides along after the id, which the host ignores when
+        // it looks the id up. Nothing needs it to resolve the image, but a
+        // reader of the document and the frontend both do: the rasteriser
+        // scales an SVG differently from a photograph, and it has only the
+        // URL to tell them apart.
+        let url = match image
+            .path
+            .extension()
+            .and_then(|extension| extension.to_str())
+        {
+            Some(extension) => format!("{base_url}/{}.{extension}", image.id),
+            None => format!("{base_url}/{}", image.id),
+        };
+        if !self.entries.iter().any(|entry| entry.id == image.id) {
+            self.entries.push(image);
+        }
+        url
+    }
+}
+
+/// The image at `path`, or `None` when it is one no consumer could show.
+///
+/// The bound and the emptiness check are the same ones [`read_image_bounded`]
+/// applies, and they are made here rather than left to the host because the
+/// answer changes the markup: a `srcset` candidate that cannot be shown is
+/// dropped so the browser falls back to one that can, and the host serving
+/// the URL is far too late to drop it.
+fn deferred_image(path: PathBuf) -> Option<DeferredImage> {
+    let metadata = std::fs::metadata(&path).ok()?;
+    if metadata.len() > MAX_INLINE_IMAGE_SIZE {
+        tracing::debug!(
+            ?path,
+            size = metadata.len(),
+            limit = MAX_INLINE_IMAGE_SIZE,
+            "Image exceeds the size limit; not served"
+        );
         return None;
     }
-    let mime_type = get_mime_type(&canonical_path);
-    let base64_data = general_purpose::STANDARD.encode(&image_data);
-    Some(format!("data:{mime_type};base64,{base64_data}"))
+    if metadata.len() == 0 {
+        tracing::debug!(?path, "Image file is empty; nothing to serve");
+        return None;
+    }
+
+    Some(DeferredImage {
+        id: image_id(&path, &metadata),
+        mime: get_mime_type(&path),
+        path,
+    })
+}
+
+/// An id standing for the file at `path` as it is right now.
+///
+/// The path is hashed rather than the bytes, so naming an image costs no
+/// read; the path is already canonical, so two spellings of one file agree.
+/// The size and modification time go in as well, which is what makes an
+/// edited image a different URL — the app reloads a document when its file
+/// changes, and a URL that stayed the same would let the WebView answer the
+/// re-render from its cache with the bytes the reader just replaced.
+///
+/// The id is not a secret: anyone who can guess a path can compute its hash.
+/// What limits what the host will serve is the host's own registry — it
+/// answers for the ids a render gave it, and for nothing else.
+fn image_id(path: &Path, metadata: &std::fs::Metadata) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(path.as_os_str().as_encoded_bytes());
+    hasher.update(metadata.len().to_le_bytes());
+    if let Ok(modified) = metadata.modified() {
+        if let Ok(since_epoch) = modified.duration_since(std::time::UNIX_EPOCH) {
+            hasher.update(since_epoch.as_nanos().to_le_bytes());
+        }
+    }
+    hasher
+        .finalize()
+        .iter()
+        .take(16)
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+/// The `<img src>` value a local image reference becomes, or `None` when it
+/// is to be left as written.
+fn resolved_image_src(
+    src: &str,
+    canonical_base: &Path,
+    resolution: &ImageResolution,
+    collected: &RefCell<DeferredImages>,
+) -> Option<String> {
+    match resolution {
+        ImageResolution::DataUrl => inline_local_image(src, canonical_base),
+        ImageResolution::Deferred { base_url } => {
+            let image = deferred_image(resolve_local_image(src, canonical_base)?)?;
+            Some(collected.borrow_mut().url(image, base_url))
+        }
+    }
 }
 
 /// One entry of a `srcset` attribute: a URL and the descriptor that follows it.
@@ -232,15 +350,20 @@ fn parse_srcset(value: &str) -> Vec<SrcsetCandidate> {
 /// display. This is why a `srcset` is treated differently from an `img[src]`,
 /// which keeps an unreadable path because there is no alternative to fall back
 /// on.
-fn inline_srcset(value: &str, canonical_base: &Path) -> Option<String> {
+fn inline_srcset(
+    value: &str,
+    canonical_base: &Path,
+    resolution: &ImageResolution,
+    collected: &RefCell<DeferredImages>,
+) -> Option<String> {
     let mut changed = false;
     let candidates: Vec<String> = parse_srcset(value)
         .into_iter()
         .filter_map(|SrcsetCandidate { url, descriptor }| {
-            let url = match inline_local_image(&url, canonical_base) {
-                Some(data_url) => {
+            let url = match resolved_image_src(&url, canonical_base, resolution, collected) {
+                Some(resolved) => {
                     changed = true;
-                    data_url
+                    resolved
                 }
                 None if has_foreign_scheme(&url) => url,
                 None => {
@@ -261,26 +384,40 @@ fn inline_srcset(value: &str, canonical_base: &Path) -> Option<String> {
 /// Post-process HTML with lol_html.
 ///
 /// Handles:
-/// - `<img src="…">`, `<img srcset="…">` and `<source srcset="…">`: inline
-///   local images as data URLs, so a `<picture>` renders whichever candidate
-///   the browser picks. See [`inline_local_image`] for how a reference is
-///   resolved.
+/// - `<img src="…">`, `<img srcset="…">` and `<source srcset="…">`: resolve
+///   local images the way `resolution` asks for, so a `<picture>` renders
+///   whichever candidate the browser picks. See [`resolve_local_image`] for
+///   how a reference becomes a file.
 /// - `<a href="…">`: convert local links to `<span data-md-link="…">` for in-app
 ///   navigation; a Markdown target that does not exist is marked `md-link-missing`
-pub(super) fn post_process_html_tags(html_str: &str, base_dir: &Path) -> String {
+///
+/// Returns the rewritten HTML and, under [`ImageResolution::Deferred`], the
+/// images the host is now expected to serve.
+pub(super) fn post_process_html_tags(
+    html_str: &str,
+    base_dir: &Path,
+    resolution: &ImageResolution,
+) -> (String, Vec<DeferredImage>) {
     let canonical_base = base_dir
         .canonicalize()
         .unwrap_or_else(|_| base_dir.to_path_buf());
-    let srcset_base = canonical_base.clone();
     let link_base = canonical_base.clone();
     let mut output = Vec::new();
 
+    // Both image handlers write into the one list. They borrow it rather than
+    // share ownership of it, so that reading it back after the rewriter is
+    // done cannot fail — and a change that kept a handler alive too long
+    // would be a compile error rather than a silently empty list.
+    let collected = RefCell::new(DeferredImages::default());
+
     let mut rewriter = HtmlRewriter::new(
         Settings::new()
-            .append_element_content_handler(element!("img[src]", move |el| {
+            .append_element_content_handler(element!("img[src]", |el| {
                 if let Some(src) = el.get_attribute("src") {
-                    if let Some(data_url) = inline_local_image(&src, &canonical_base) {
-                        el.set_attribute("src", &data_url)?;
+                    if let Some(resolved) =
+                        resolved_image_src(&src, &canonical_base, resolution, &collected)
+                    {
+                        el.set_attribute("src", &resolved)?;
                     }
                 }
                 Ok(())
@@ -290,9 +427,9 @@ pub(super) fn post_process_html_tags(html_str: &str, base_dir: &Path) -> String 
             // or that theme shows nothing.
             .append_element_content_handler(element!(
                 "img[srcset], source[srcset]",
-                move |el| {
+                |el| {
                     if let Some(srcset) = el.get_attribute("srcset") {
-                        match inline_srcset(&srcset, &srcset_base) {
+                        match inline_srcset(&srcset, &canonical_base, resolution, &collected) {
                             // Nothing is left to pick from, so the attribute
                             // has to go rather than stay empty: an `<img>`
                             // then falls back to its `src` and a `<source>`
@@ -357,8 +494,12 @@ pub(super) fn post_process_html_tags(html_str: &str, base_dir: &Path) -> String 
     );
 
     let _ = rewriter.write(html_str.as_bytes());
+    // `end` consumes the rewriter, which is what releases the handlers' borrow
+    // of `output` and of the collected images.
     let _ = rewriter.end();
-    String::from_utf8(output).unwrap_or_else(|_| html_str.to_string())
+
+    let html = String::from_utf8(output).unwrap_or_else(|_| html_str.to_string());
+    (html, collected.into_inner().entries)
 }
 
 #[cfg(test)]
@@ -366,6 +507,11 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::TempDir;
+
+    /// The rewritten HTML alone, for the tests that only look at the markup.
+    fn post_process(html: &str, base_dir: &Path) -> String {
+        post_process_html_tags(html, base_dir, &ImageResolution::DataUrl).0
+    }
 
     // ========================================================================
     // Security regression tests
@@ -388,7 +534,7 @@ mod tests {
         fs::write(&image, [0x89, 0x50, 0x4E, 0x47]).unwrap();
 
         let html = r#"<img src="../images/image.png">"#;
-        let result = post_process_html_tags(html, &sub);
+        let result = post_process(html, &sub);
 
         // Relative path traversal should be resolved and image converted to data URL
         assert!(
@@ -407,7 +553,7 @@ mod tests {
         fs::write(&image, [0x89, 0x50, 0x4E, 0x47]).unwrap();
 
         let html = r#"<img src="image.png">"#;
-        let result = post_process_html_tags(html, &sub);
+        let result = post_process(html, &sub);
 
         assert!(
             result.contains("data:image/png;base64,"),
@@ -419,7 +565,7 @@ mod tests {
     #[test]
     fn test_link_single_quote_in_data_attribute() {
         let html = r#"<a href="file's.md">link</a>"#;
-        let result = post_process_html_tags(html, Path::new("/tmp"));
+        let result = post_process(html, Path::new("/tmp"));
         // href is stored in data-md-link, not interpolated into JS
         assert!(
             result.contains("data-md-link"),
@@ -435,7 +581,7 @@ mod tests {
     #[test]
     fn test_link_special_chars_safe_with_data_attribute() {
         let html = r#"<a href="test'-alert('xss').md">link</a>"#;
-        let result = post_process_html_tags(html, Path::new("/tmp"));
+        let result = post_process(html, Path::new("/tmp"));
         // href is stored in data attribute, never interpolated into JS string
         assert!(
             result.contains("data-md-link"),
@@ -460,7 +606,7 @@ mod tests {
         // Payload with .md extension so the anchor handler converts the link,
         // plus quotes and JS that would be dangerous if interpolated into JS.
         let html = r#"<a href="evil');alert(1).md">link</a>"#;
-        let result = post_process_html_tags(html, Path::new("/tmp"));
+        let result = post_process(html, Path::new("/tmp"));
 
         // The href must be stored in data-md-link, NOT spliced into inline JS
         assert!(
@@ -483,7 +629,7 @@ mod tests {
         // `mailto:contact@example.com` ends in something that looks like a
         // file extension; it is an address, not a document.
         let html = r#"<a href="mailto:contact@example.com">mail</a><a href="tel:+81-3-0000-0000">call</a>"#;
-        let result = post_process_html_tags(html, Path::new("/tmp"));
+        let result = post_process(html, Path::new("/tmp"));
 
         assert_eq!(result, html);
     }
@@ -496,7 +642,7 @@ mod tests {
         let url = url::Url::from_file_path(&target).unwrap();
 
         let html = format!(r#"<a href="{url}#section">note</a>"#);
-        let result = post_process_html_tags(&html, temp_dir.path());
+        let result = post_process(&html, temp_dir.path());
 
         // The app opens `data-md-link` as a filesystem path, so the URL must
         // not survive into it, and the target must be found rather than
@@ -515,7 +661,7 @@ mod tests {
     #[test]
     fn a_windows_drive_letter_is_still_a_path() {
         let html = r#"<a href="C:\notes\a.md">note</a>"#;
-        let result = post_process_html_tags(html, Path::new("/tmp"));
+        let result = post_process(html, Path::new("/tmp"));
 
         assert!(result.contains("data-md-link"), "{result}");
     }
@@ -524,7 +670,7 @@ mod tests {
     #[test]
     fn test_http_urls_not_converted() {
         let html = r#"<img src="https://example.com/img.png">"#;
-        let result = post_process_html_tags(html, Path::new("/tmp"));
+        let result = post_process(html, Path::new("/tmp"));
         assert!(result.contains("https://example.com/img.png"));
     }
 
@@ -549,7 +695,7 @@ mod tests {
         fs::write(&image_path, png_data).unwrap();
 
         let html = r#"<p><img src="test.png" alt="test" /></p>"#;
-        let result = post_process_html_tags(html, temp_dir.path());
+        let result = post_process(html, temp_dir.path());
 
         assert!(
             result.contains("data:image/png;base64,"),
@@ -572,7 +718,7 @@ mod tests {
     fn test_post_process_html_tags_anchor() {
         let temp = dir_with_doc();
         let html = r#"<a href="doc.md">Link</a>"#;
-        let result = post_process_html_tags(html, temp.path());
+        let result = post_process(html, temp.path());
 
         assert!(
             result.contains("<span ") && result.contains(r#"class="md-link""#),
@@ -593,7 +739,7 @@ mod tests {
     fn missing_markdown_target_is_marked() {
         let temp = TempDir::new().unwrap();
         let html = r#"<a href="./does-not-exist.md">Missing</a>"#;
-        let result = post_process_html_tags(html, temp.path());
+        let result = post_process(html, temp.path());
 
         assert!(
             result.contains(r#"class="md-link md-link-missing""#),
@@ -609,7 +755,7 @@ mod tests {
     fn fragment_does_not_hide_the_extension() {
         let temp = dir_with_doc();
         let html = r#"<a href="./doc.md#section">Section</a>"#;
-        let result = post_process_html_tags(html, temp.path());
+        let result = post_process(html, temp.path());
 
         assert!(result.contains(r#"class="md-link""#), "{result}");
         assert!(
@@ -621,7 +767,7 @@ mod tests {
     #[test]
     fn fragment_only_links_stay_anchors() {
         let html = r##"<a href="#section">Here</a>"##;
-        let result = post_process_html_tags(html, Path::new("."));
+        let result = post_process(html, Path::new("."));
 
         assert_eq!(result, html);
     }
@@ -630,7 +776,7 @@ mod tests {
     fn test_post_process_html_tags_http_urls() {
         let html =
             r#"<img src="https://example.com/image.png" /><a href="https://example.com">Link</a>"#;
-        let result = post_process_html_tags(html, Path::new("."));
+        let result = post_process(html, Path::new("."));
 
         assert!(
             result.contains(r#"src="https://example.com/image.png""#),
@@ -645,7 +791,7 @@ mod tests {
     #[test]
     fn test_post_process_html_tags_non_md_local_file() {
         let html = r#"<a href="file.txt">Text File</a>"#;
-        let result = post_process_html_tags(html, Path::new("."));
+        let result = post_process(html, Path::new("."));
 
         assert!(
             result.contains("<span ") && result.contains(r#"class="md-link md-link-invalid""#),
@@ -662,7 +808,7 @@ mod tests {
     fn test_post_process_html_tags_md_vs_other_files() {
         let temp = dir_with_doc();
         let html = r#"<a href="doc.md">MD</a><a href="file.txt">TXT</a>"#;
-        let result = post_process_html_tags(html, temp.path());
+        let result = post_process(html, temp.path());
 
         // MD file should have only md-link class
         assert!(
@@ -698,7 +844,7 @@ mod tests {
             .expect("valid file path")
             .to_string();
         let html = format!(r#"<img src="{}">"#, file_url);
-        let result = post_process_html_tags(&html, temp_dir.path());
+        let result = post_process(&html, temp_dir.path());
         assert!(
             result.contains("data:image/png;base64,"),
             "file:///... URL should be converted to data URL: {result}"
@@ -707,7 +853,7 @@ mod tests {
         // file://localhost/absolute/path form: replace the empty host with "localhost"
         let localhost_url = file_url.replacen("file:///", "file://localhost/", 1);
         let html2 = format!(r#"<img src="{}">"#, localhost_url);
-        let result2 = post_process_html_tags(&html2, temp_dir.path());
+        let result2 = post_process(&html2, temp_dir.path());
         assert!(
             result2.contains("data:image/png;base64,"),
             "file://localhost/... URL should be converted to data URL: {result2}"
@@ -811,7 +957,7 @@ mod tests {
         fs::write(temp.path().join("light.png"), [0x89, 0x50, 0x4E, 0x47]).unwrap();
 
         let html = r#"<picture><source media="(prefers-color-scheme: dark)" srcset="./dark.png"><img src="./light.png" alt="hero"></picture>"#;
-        let result = post_process_html_tags(html, temp.path());
+        let result = post_process(html, temp.path());
 
         assert_eq!(
             result.matches("data:image/png;base64,").count(),
@@ -828,7 +974,7 @@ mod tests {
         fs::write(temp.path().join("a@2x.png"), [0x89, 0x50, 0x4E, 0x47]).unwrap();
 
         let html = r#"<img src="a.png" srcset="a.png 1x, a@2x.png 2x">"#;
-        let result = post_process_html_tags(html, temp.path());
+        let result = post_process(html, temp.path());
 
         assert!(result.contains("base64,iVBORw== 1x,"), "{result}");
         assert!(result.contains("base64,iVBORw== 2x\""), "{result}");
@@ -840,7 +986,7 @@ mod tests {
         fs::write(temp.path().join("a.png"), [0x89, 0x50, 0x4E, 0x47]).unwrap();
 
         let html = r#"<source srcset="https://example.com/a.png 1x, a.png 2x">"#;
-        let result = post_process_html_tags(html, temp.path());
+        let result = post_process(html, temp.path());
 
         assert!(
             result.contains("https://example.com/a.png 1x, data:image/png;base64,"),
@@ -858,7 +1004,7 @@ mod tests {
         fs::write(temp.path().join("there.png"), [0x89, 0x50, 0x4E, 0x47]).unwrap();
 
         let html = r#"<source srcset="there.png 1x, missing.png 2x">"#;
-        let result = post_process_html_tags(html, temp.path());
+        let result = post_process(html, temp.path());
 
         assert!(!result.contains("missing.png"), "{result}");
         assert!(
@@ -878,7 +1024,7 @@ mod tests {
         fs::write(temp.path().join("there.png"), [0x89, 0x50, 0x4E, 0x47]).unwrap();
 
         let html = r#"<img src="empty.png" srcset="there.png 1x, empty.png 2x">"#;
-        let result = post_process_html_tags(html, temp.path());
+        let result = post_process(html, temp.path());
 
         assert!(!result.contains("base64,\""), "{result}");
         assert!(!result.contains("base64, "), "{result}");
@@ -896,7 +1042,7 @@ mod tests {
         fs::write(temp.path().join("there.png"), [0x89, 0x50, 0x4E, 0x47]).unwrap();
 
         let html = r#"<img src="there.png" srcset="missing.png 1x,  other.png 2x">"#;
-        let result = post_process_html_tags(html, temp.path());
+        let result = post_process(html, temp.path());
 
         assert!(!result.contains("srcset"), "{result}");
         assert!(
@@ -918,7 +1064,7 @@ mod tests {
 
         // ./../images/diagram.png resolves from docs/ to images/
         let html = r#"<img src="./../images/diagram.png">"#;
-        let result = post_process_html_tags(html, &docs);
+        let result = post_process(html, &docs);
 
         assert!(
             result.contains("data:image/png;base64,"),

--- a/crates/arto-markdown/tests/pipeline.rs
+++ b/crates/arto-markdown/tests/pipeline.rs
@@ -5,7 +5,9 @@
 //! engine swap. Internals that are only observable at the engine level
 //! (event streams, offset mapping) are tested next to that code.
 
-use arto_markdown::{render_to_html, render_to_html_with_toc, HeadingInfo, RenderOptions};
+use arto_markdown::{
+    render_to_html, render_to_html_with_toc, HeadingInfo, ImageResolution, RenderOptions,
+};
 use indoc::indoc;
 use std::path::Path;
 
@@ -16,6 +18,7 @@ fn render(markdown: &str) -> String {
         &RenderOptions::default(),
     )
     .expect("renders")
+    .html
 }
 
 fn headings(markdown: &str) -> Vec<HeadingInfo> {
@@ -25,7 +28,7 @@ fn headings(markdown: &str) -> Vec<HeadingInfo> {
         &RenderOptions::default(),
     )
     .expect("renders")
-    .1
+    .headings
 }
 
 /// Whether some `<tag …>` start tag in `html` carries every attribute in
@@ -182,10 +185,113 @@ fn a_picture_inlines_both_the_source_and_the_img() {
         dir.path().join("doc.md"),
         &RenderOptions::default(),
     )
-    .expect("renders");
+    .expect("renders")
+    .html;
 
     assert_eq!(html.matches("data:image/png;base64,").count(), 2, "{html}");
     assert!(!html.contains("./dark.png"), "{html}");
+}
+
+#[test]
+fn a_deferred_image_leaves_the_bytes_out_and_names_the_file() {
+    let dir = tempfile::TempDir::new().unwrap();
+    std::fs::write(dir.path().join("hero.png"), [0x89, 0x50, 0x4E, 0x47]).unwrap();
+
+    let rendered = render_to_html(
+        "![hero](./hero.png)\n\n![again](./hero.png)\n",
+        dir.path().join("doc.md"),
+        &RenderOptions {
+            images: ImageResolution::Deferred {
+                base_url: "artoasset://localhost/img".to_string(),
+            },
+            ..Default::default()
+        },
+    )
+    .expect("renders");
+
+    assert!(
+        !rendered.html.contains("base64"),
+        "the bytes stayed in the document: {}",
+        rendered.html
+    );
+    // One file drawn twice is one entry and one URL, which is what lets the
+    // host serve it once and the WebView cache it.
+    assert_eq!(rendered.images.len(), 1, "{:?}", rendered.images);
+    assert_eq!(
+        rendered.images[0].path,
+        dir.path().join("hero.png").canonicalize().unwrap()
+    );
+    let url = format!("artoasset://localhost/img/{}", rendered.images[0].id);
+    assert_eq!(rendered.html.matches(&url).count(), 2, "{}", rendered.html);
+}
+
+/// Whether an image can be shown decides the markup, so it is decided while
+/// the markup is written — the host serving the URL is far too late to drop a
+/// candidate the browser has already preferred.
+#[test]
+fn a_deferred_srcset_drops_the_candidate_it_cannot_serve() {
+    let dir = tempfile::TempDir::new().unwrap();
+    std::fs::write(dir.path().join("small.png"), [0x89, 0x50, 0x4E, 0x47]).unwrap();
+    std::fs::write(dir.path().join("empty.png"), []).unwrap();
+
+    let rendered = render_to_html(
+        r#"<img src="./small.png" srcset="./empty.png 2x, ./small.png 1x">"#,
+        dir.path().join("doc.md"),
+        &RenderOptions {
+            images: ImageResolution::Deferred {
+                base_url: "artoasset://localhost/img".to_string(),
+            },
+            ..Default::default()
+        },
+    )
+    .expect("renders");
+
+    assert_eq!(rendered.images.len(), 1, "{:?}", rendered.images);
+    assert!(
+        rendered
+            .images
+            .iter()
+            .all(|image| image.path.ends_with("small.png")),
+        "{:?}",
+        rendered.images
+    );
+    assert!(!rendered.html.contains("empty.png"), "{}", rendered.html);
+}
+
+#[test]
+fn a_deferred_image_carries_the_type_to_answer_with() {
+    let dir = tempfile::TempDir::new().unwrap();
+    std::fs::write(dir.path().join("diagram.svg"), b"<svg/>").unwrap();
+
+    let rendered = render_to_html(
+        "![diagram](./diagram.svg)",
+        dir.path().join("doc.md"),
+        &RenderOptions {
+            images: ImageResolution::Deferred {
+                base_url: "artoasset://localhost/img".to_string(),
+            },
+            ..Default::default()
+        },
+    )
+    .expect("renders");
+
+    assert_eq!(rendered.images[0].mime, "image/svg+xml");
+}
+
+#[test]
+fn an_inlined_image_leaves_nothing_for_the_host_to_serve() {
+    let dir = tempfile::TempDir::new().unwrap();
+    std::fs::write(dir.path().join("hero.png"), [0x89, 0x50, 0x4E, 0x47]).unwrap();
+
+    let rendered = render_to_html(
+        "![hero](./hero.png)",
+        dir.path().join("doc.md"),
+        &RenderOptions::default(),
+    )
+    .expect("renders");
+
+    assert!(rendered.html.contains("data:image/png;base64,"));
+    assert!(rendered.images.is_empty(), "{:?}", rendered.images);
 }
 
 // ----------------------------------------------------------------------
@@ -517,12 +623,13 @@ fn duplicate_headings_get_numbered_ids() {
 #[test]
 fn heading_ids_are_written_only_when_a_toc_is_requested() {
     let markdown = "# Title\n\n## Section\n";
-    let (with_toc, headings) = render_to_html_with_toc(
+    let rendered = render_to_html_with_toc(
         markdown,
         Path::new("/nonexistent/test.md"),
         &RenderOptions::default(),
     )
     .expect("renders");
+    let (with_toc, headings) = (rendered.html, rendered.headings);
     let plain = render(markdown);
 
     assert_eq!(headings.len(), 2);
@@ -575,12 +682,13 @@ fn headings_inside_raw_html_do_not_shift_ids() {
     // A heading written as HTML is not a Markdown heading: it gets no id
     // and must not consume the id of the Markdown heading after it.
     let markdown = "<h2>Raw</h2>\n\n## Real\n";
-    let (with_toc, headings) = render_to_html_with_toc(
+    let rendered = render_to_html_with_toc(
         markdown,
         Path::new("/nonexistent/test.md"),
         &RenderOptions::default(),
     )
     .expect("renders");
+    let (with_toc, headings) = (rendered.html, rendered.headings);
 
     let texts: Vec<&str> = headings.iter().map(|h| h.text.as_str()).collect();
     assert_eq!(texts, ["Real"]);
@@ -593,12 +701,13 @@ fn headings_inside_raw_html_do_not_shift_ids() {
 
 #[test]
 fn a_document_without_headings_has_an_empty_toc() {
-    let (html, headings) = render_to_html_with_toc(
+    let rendered = render_to_html_with_toc(
         "Just text.",
         Path::new("/nonexistent/test.md"),
         &RenderOptions::default(),
     )
     .expect("renders");
+    let (html, headings) = (rendered.html, rendered.headings);
 
     assert!(headings.is_empty());
     assert!(html.contains("Just text."));

--- a/crates/arto-markdown/tests/samples.rs
+++ b/crates/arto-markdown/tests/samples.rs
@@ -24,8 +24,9 @@ fn the_stress_sample_renders() {
     ));
     let markdown = std::fs::read_to_string(path).expect("sample is readable");
 
-    let (html, headings) = render_to_html_with_toc(&markdown, path, &RenderOptions::default())
+    let rendered = render_to_html_with_toc(&markdown, path, &RenderOptions::default())
         .unwrap_or_else(|err| panic!("{}: {err:#}", path.display()));
+    let (html, headings) = (rendered.html, rendered.headings);
 
     assert!(headings.len() > 100, "{} headings", headings.len());
     assert!(
@@ -43,7 +44,8 @@ fn samples_render_as_before() {
     insta::glob!("../../../samples", "[0-9]*.md", |path| {
         let markdown = std::fs::read_to_string(path).expect("sample is readable");
         let html = render_to_html(&markdown, path, &RenderOptions::default())
-            .unwrap_or_else(|err| panic!("{}: {err:#}", path.display()));
+            .unwrap_or_else(|err| panic!("{}: {err:#}", path.display()))
+            .html;
         insta::assert_snapshot!(html);
     });
 }
@@ -58,9 +60,11 @@ fn samples_headings_as_before() {
         let markdown = std::fs::read_to_string(path).expect("sample is readable");
         let options = RenderOptions::default();
         let plain = render_to_html(&markdown, path, &options)
+            .unwrap_or_else(|err| panic!("{}: {err:#}", path.display()))
+            .html;
+        let rendered = render_to_html_with_toc(&markdown, path, &options)
             .unwrap_or_else(|err| panic!("{}: {err:#}", path.display()));
-        let (with_toc, headings) = render_to_html_with_toc(&markdown, path, &options)
-            .unwrap_or_else(|err| panic!("{}: {err:#}", path.display()));
+        let (with_toc, headings) = (rendered.html, rendered.headings);
 
         assert_eq!(
             strip_ids(&with_toc),

--- a/crates/arto-page/src/lib.rs
+++ b/crates/arto-page/src/lib.rs
@@ -189,9 +189,17 @@ pub fn render_markdown(
     base_path: impl AsRef<Path>,
     options: &PageOptions,
 ) -> Result<String, PageError> {
-    let body_html = arto_markdown::render_to_html(markdown, base_path, &options.render)
-        .map_err(PageError::Render)?;
-    Ok(build_document(&body_html, options))
+    // Imposed rather than assumed: the page is one file, with nothing to
+    // serve an image from, so a caller that had set `Deferred` in the shared
+    // render options would otherwise get a document of URLs that answer to
+    // nobody.
+    let render = arto_markdown::RenderOptions {
+        images: arto_markdown::ImageResolution::DataUrl,
+        ..options.render.clone()
+    };
+    let rendered =
+        arto_markdown::render_to_html(markdown, base_path, &render).map_err(PageError::Render)?;
+    Ok(build_document(&rendered.html, options))
 }
 
 /// Read a file to a string, refusing to read more than [`MAX_FILE_BYTES`].
@@ -405,6 +413,7 @@ mod tests {
         let config = Config {
             markdown: RenderOptions {
                 auto_link_urls: false,
+                ..Default::default()
             },
             theme: arto_config::ThemeConfig {
                 default_theme: Theme::Dark,
@@ -464,6 +473,7 @@ mod tests {
             &PageOptions {
                 render: RenderOptions {
                     auto_link_urls: false,
+                    ..Default::default()
                 },
                 ..PageOptions::default()
             },

--- a/crates/arto/Cargo.toml
+++ b/crates/arto/Cargo.toml
@@ -48,6 +48,7 @@ ureq = "3.4"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "fmt"] }
 uuid = { version = "1.0", features = ["v4"] }
 display-info = "0.5.9"
+flate2 = "1.1"
 mouse_position = "0.1.4"
 
 [target.'cfg(unix)'.dependencies]
@@ -60,6 +61,9 @@ objc2-foundation = "0.3.2"
 core-graphics = "0.25"
 core-foundation = "0.10.1"
 tracing-oslog = "0.3.0"
+
+[build-dependencies]
+flate2 = "1.1"
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/arto/build.rs
+++ b/crates/arto/build.rs
@@ -1,4 +1,12 @@
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
 fn main() {
+    stamp_version();
+    compress_frontend();
+}
+
+fn stamp_version() {
     // 1. If ARTO_BUILD_VERSION is already set (e.g., by Nix), use it as-is
     println!("cargo:rerun-if-env-changed=ARTO_BUILD_VERSION");
     if let Ok(v) = std::env::var("ARTO_BUILD_VERSION") {
@@ -41,6 +49,46 @@ fn main() {
         "cargo:rustc-env=ARTO_BUILD_VERSION={}",
         std::env::var("CARGO_PKG_VERSION").unwrap()
     );
+}
+
+/// The frontend files a release binary carries, gzipped into `OUT_DIR`.
+///
+/// A released Arto has to be one file that runs from wherever it is put, so
+/// the stylesheet and the script are compiled into it rather than looked up
+/// next to the executable. Raw they add about 8 MB to a 26 MB binary,
+/// compressed about 2.5 MB.
+///
+/// A debug build embeds nothing — `src/assets/frontend.rs` reads the same
+/// files from the source tree at run time — and nothing is watched here
+/// either, so editing a stylesheet stays a job for the development loop's
+/// watcher rather than a reason to relink the app.
+fn compress_frontend() {
+    if std::env::var_os("CARGO_CFG_DEBUG_ASSERTIONS").is_some() {
+        return;
+    }
+
+    let out_dir = PathBuf::from(std::env::var_os("OUT_DIR").expect("OUT_DIR is set by cargo"));
+    for name in ["main.js", "main.css"] {
+        let source = Path::new("assets/frontend").join(name);
+        println!("cargo:rerun-if-changed={}", source.display());
+        compress(&source, &out_dir.join(format!("{name}.gz")));
+    }
+}
+
+fn compress(source: &Path, destination: &Path) {
+    let bytes = std::fs::read(source).unwrap_or_else(|error| {
+        panic!(
+            "{}: {error}. Run `just frontend::assets` to build the bundle first.",
+            source.display()
+        )
+    });
+
+    let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::best());
+    encoder
+        .write_all(&bytes)
+        .and_then(|()| encoder.finish())
+        .and_then(|compressed| std::fs::write(destination, compressed))
+        .unwrap_or_else(|error| panic!("{}: {error}", destination.display()));
 }
 
 /// Run `git` with `args` and return its trimmed stdout on success.

--- a/crates/arto/justfile
+++ b/crates/arto/justfile
@@ -61,7 +61,6 @@ clean:
 # embed the extension into it, then package the DMG from the embedded app.
 [macos]
 build:
-  @rm -rf {{target}}/dx/arto/release/macos/Arto.app/Contents/Resources/assets
   dx bundle --release --macos --package-types macos
   just _apply-bundle-metadata
   just _embed-quicklook
@@ -182,7 +181,6 @@ _package-dmg:
 build:
   #!/usr/bin/env bash
   set -euo pipefail
-  rm -rf "{{target}}/dx/arto/release/linux/app/assets"
   # Drop every previously built Linux artifact first. CI caches the workspace
   # `target/` (which contains `bundle/`), and the build job also runs on
   # non-release pushes where the version stays 0.0.0; without this sweep a
@@ -192,6 +190,12 @@ build:
     find "{{target}}/dx/arto/bundle" -type f \( -name '*.deb' -o -name '*.AppImage' \) -delete
   fi
   dx bundle --release --linux --package-types deb --package-types appimage
+
+# Not `dx build`: there is nothing left for it to collect. The frontend is
+# compiled into the binary, so a plain cargo build is the whole story, and it
+# is the same compilation the bundle recipes above already drive.
+standalone:
+  cargo build --release --package arto
 
 # Release artifacts are built with the platform's native toolchain, but a
 # bundle built inside the Nix devShell links against /nix/store paths and is

--- a/crates/arto/src/assets.rs
+++ b/crates/arto/src/assets.rs
@@ -1,9 +1,124 @@
-use arto_keybindings::BindingSet;
-use dioxus::asset_resolver::asset_path;
-use dioxus::prelude::*;
+//! What the app serves to its own WebViews, and the protocol it serves it on.
+//!
+//! # Why a protocol of its own
+//!
+//! The obvious alternative, writing the stylesheet and the script straight
+//! into each window's HTML, costs a megabyte of markup per window, cannot be
+//! cached, and makes the sources unreadable in the developer tools. A URL
+//! keeps all three.
+//!
+//! `dioxus://` would have been the natural origin, but Dioxus builds its own
+//! asset handler after `Config` is consumed, so nothing can be added to it
+//! from here. A protocol registered on the `Config` is a second origin, which
+//! is why the responses carry `Access-Control-Allow-Origin` and why the icon
+//! sprite is inlined into the document instead of being fetched: a
+//! `<use href="…#id">` across origins is refused, and no CORS header changes
+//! that.
+//!
+//! # The origin
+//!
+//! Windows' WebView2 cannot register a non-standard scheme, so wry rewrites
+//! `{protocol}://` requests to `http://{protocol}.` and undoes the rewrite
+//! before the handler sees them. The handler therefore reads one origin on
+//! every platform, and only the URL written into the HTML differs.
+//!
+//! The host is `localhost` because of what that rewrite leaves behind: on
+//! Windows these become plain `http://` requests, and a document Dioxus
+//! serves from a secure origin refuses insecure subresources. Chromium counts
+//! `*.localhost` as potentially trustworthy, so the stylesheet and the script
+//! load rather than being blocked as mixed content. A host such as
+//! `artoasset.assets` would be neither trustworthy nor obviously unresolvable.
 
-pub static MAIN_SCRIPT: Asset = asset!("/assets/frontend/main.js");
-pub static MAIN_STYLE: Asset = asset!("/assets/frontend/main.css");
+mod frontend;
+
+use arto_keybindings::BindingSet;
+use dioxus::desktop::wry::http::{Request, Response};
+use dioxus::desktop::wry::WebViewId;
+use dioxus::desktop::Config;
+use std::borrow::Cow;
+
+/// The scheme the app answers on.
+///
+/// Not `arto`: wry's Windows rewrite catches `http://{protocol}.*`, and with
+/// `arto` that would take requests to real hosts such as `arto.app` with it.
+const PROTOCOL: &str = "artoasset";
+
+/// The origin the HTML asks for. See the module docs for the two shapes.
+#[cfg(windows)]
+const ORIGIN: &str = "http://artoasset.localhost";
+#[cfg(not(windows))]
+const ORIGIN: &str = "artoasset://localhost";
+
+/// Answer requests for the embedded frontend on this configuration's windows.
+///
+/// Registered on the `Config` rather than through `use_asset_handler`, which
+/// only exists after the first render — far too late for the stylesheet the
+/// custom head asks for while the page is still parsing.
+pub fn with_asset_protocol(config: Config) -> Config {
+    config.with_custom_protocol(PROTOCOL, |_id: WebViewId, request: Request<Vec<u8>>| {
+        respond(request.uri().path())
+    })
+}
+
+fn respond(path: &str) -> Response<Cow<'static, [u8]>> {
+    let Some(file) = path.strip_prefix("/assets/").and_then(frontend::bundled) else {
+        return not_found();
+    };
+    let Some(bytes) = frontend::bytes(file) else {
+        return not_found();
+    };
+
+    Response::builder()
+        .status(200)
+        .header("Content-Type", file.mime)
+        // The document is served from `dioxus://`, so every one of these
+        // requests is cross-origin.
+        .header("Access-Control-Allow-Origin", "*")
+        .header("Cache-Control", CACHE_CONTROL)
+        .body(bytes)
+        .expect("a response with a body and valid headers")
+}
+
+fn not_found() -> Response<Cow<'static, [u8]>> {
+    Response::builder()
+        .status(404)
+        .header("Access-Control-Allow-Origin", "*")
+        .body(Cow::Borrowed(&b""[..]))
+        .expect("a response with a body and valid headers")
+}
+
+/// A release binary's bundle cannot change while it runs, and the URL carries
+/// the version it was built from. A debug build reads the file on every
+/// request, so that rebuilding the bundle and reloading a window is enough to
+/// see the change.
+#[cfg(not(debug_assertions))]
+const CACHE_CONTROL: &str = "public, max-age=31536000, immutable";
+#[cfg(debug_assertions)]
+const CACHE_CONTROL: &str = "no-store";
+
+/// The URL of one bundled file.
+///
+/// The app's version is in the query so that an upgrade cannot be answered
+/// from the cache of the version before it — which matters because a release
+/// answers with `immutable` and a year of freshness.
+///
+/// `ARTO_BUILD_VERSION`, not `CARGO_PKG_VERSION`: the workspace manifest says
+/// `0.0.0` and only the release workflow patches it, so a Nix build (which
+/// stamps the version through the environment instead) and every local
+/// release build would otherwise share one query for every version they ever
+/// have.
+fn url(file: frontend::Bundled) -> String {
+    format!(
+        "{ORIGIN}/assets/{}?v={}",
+        file.name,
+        env!("ARTO_BUILD_VERSION")
+    )
+}
+
+/// The URL of the module every window imports.
+pub fn main_script_url() -> String {
+    url(frontend::MAIN_SCRIPT)
+}
 
 /// The `<head>` markup that loads the main stylesheet, for
 /// `Config::with_custom_head` on every window.
@@ -13,42 +128,63 @@ pub static MAIN_STYLE: Asset = asset!("/assets/frontend/main.css");
 /// render, so the window would paint unstyled for a moment on every open.
 /// Head markup is parsed with the page and applies before anything shows.
 pub fn main_stylesheet_head() -> String {
-    format!(r#"<link rel="stylesheet" href="{MAIN_STYLE}">"#)
+    format!(
+        r#"<link rel="stylesheet" href="{}">"#,
+        url(frontend::MAIN_STYLE)
+    )
 }
 
-/// The welcome header, in the two flavours the page switches between. The
-/// stylesheet shows one and hides the other by theme, so both are always in
-/// the document.
-static ARTO_HEADER_LIGHT: Asset = asset!("/assets/arto-header-welcome-light.png");
-static ARTO_HEADER_DARK: Asset = asset!("/assets/arto-header-welcome-dark.png");
-static WELCOME_TEMPLATE: Asset = asset!("/assets/welcome.md");
-
-// Embed and process default markdown content at runtime
+/// The welcome page, with its images and shortcuts filled in.
 pub fn get_default_markdown_content() -> String {
-    let template_path = asset_path(WELCOME_TEMPLATE).expect("Failed to resolve WELCOME_TEMPLATE");
-    let template = std::fs::read_to_string(template_path).expect("Failed to read WELCOME_TEMPLATE");
+    let template = include_str!("../assets/welcome.md");
 
-    // The template names the images by their source-relative paths so that it
-    // is readable (and renderable) on its own; here they become the paths the
-    // running app can actually load.
+    // The template names its images by their source-relative paths so that it
+    // stays a document that renders on its own; here they become data URLs,
+    // which the page can carry because they are small and are drawn once.
     let template = template
         .replace(
             "../assets/arto-header-welcome-light.png",
-            &resolved_asset_path(ARTO_HEADER_LIGHT),
+            &data_url(
+                "image/png",
+                include_bytes!("../assets/arto-header-welcome-light.png"),
+            ),
         )
         .replace(
             "../assets/arto-header-welcome-dark.png",
-            &resolved_asset_path(ARTO_HEADER_DARK),
+            &data_url(
+                "image/png",
+                include_bytes!("../assets/arto-header-welcome-dark.png"),
+            ),
         );
 
     with_current_shortcuts(&template)
 }
 
-fn resolved_asset_path(asset: Asset) -> String {
-    asset_path(asset)
-        .expect("Failed to resolve asset")
-        .to_string_lossy()
-        .into_owned()
+/// The app icon, for the About tab.
+///
+/// Encoded once: the tab re-renders on every configuration change, and the
+/// icon it shows is the same 31 KB either way.
+pub fn app_icon_data_url() -> &'static str {
+    static ICON: std::sync::LazyLock<String> =
+        std::sync::LazyLock::new(|| data_url("image/png", crate::window::icon::APP_ICON_PNG));
+    &ICON
+}
+
+/// The icon sprite, inlined into every window's document.
+///
+/// Not served from the protocol: `<use href="…#id">` is same-origin only, so
+/// a sprite behind a second origin would leave every icon blank, with nothing
+/// reported anywhere.
+pub fn icon_sprite() -> &'static str {
+    include_str!("../assets/frontend/icons/tabler-sprite.svg")
+}
+
+fn data_url(mime: &str, bytes: &[u8]) -> String {
+    use base64::Engine as _;
+    format!(
+        "data:{mime};base64,{}",
+        base64::engine::general_purpose::STANDARD.encode(bytes)
+    )
 }
 
 /// What a shortcut reads as when the action has none bound.
@@ -128,5 +264,23 @@ mod tests {
             rendered.ends_with(" after {{"),
             "unterminated tail lost: {rendered}"
         );
+    }
+
+    /// A request for anything but a bundled file is refused rather than
+    /// answered from the filesystem.
+    #[test]
+    fn the_protocol_serves_the_bundle_and_nothing_else() {
+        assert_eq!(respond("/assets/main.css").status(), 200);
+        assert_eq!(respond("/assets/main.js").status(), 200);
+        assert_eq!(respond("/assets/../../etc/passwd").status(), 404);
+        assert_eq!(respond("/etc/passwd").status(), 404);
+        assert_eq!(respond("/assets/").status(), 404);
+    }
+
+    #[test]
+    fn the_stylesheet_is_asked_for_over_the_protocol() {
+        let head = main_stylesheet_head();
+        assert!(head.contains(ORIGIN), "{head}");
+        assert!(head.contains("main.css"), "{head}");
     }
 }

--- a/crates/arto/src/assets.rs
+++ b/crates/arto/src/assets.rs
@@ -30,12 +30,14 @@
 //! `artoasset.assets` would be neither trustworthy nor obviously unresolvable.
 
 mod frontend;
+pub mod images;
 
 use arto_keybindings::BindingSet;
 use dioxus::desktop::wry::http::{Request, Response};
-use dioxus::desktop::wry::WebViewId;
+use dioxus::desktop::wry::{RequestAsyncResponder, WebViewId};
 use dioxus::desktop::Config;
 use std::borrow::Cow;
+use std::io::Read;
 
 /// The scheme the app answers on.
 ///
@@ -49,15 +51,33 @@ const ORIGIN: &str = "http://artoasset.localhost";
 #[cfg(not(windows))]
 const ORIGIN: &str = "artoasset://localhost";
 
-/// Answer requests for the embedded frontend on this configuration's windows.
+/// Answer requests for the frontend, and for the images a document
+/// references, on this configuration's windows.
 ///
 /// Registered on the `Config` rather than through `use_asset_handler`, which
 /// only exists after the first render — far too late for the stylesheet the
 /// custom head asks for while the page is still parsing.
+///
+/// The asynchronous form, because one of the two things served is a file of
+/// unknown size: an image is read on a thread of its own rather than on the
+/// one the window is drawn on.
 pub fn with_asset_protocol(config: Config) -> Config {
-    config.with_custom_protocol(PROTOCOL, |_id: WebViewId, request: Request<Vec<u8>>| {
-        respond(request.uri().path())
-    })
+    config.with_asynchronous_custom_protocol(
+        PROTOCOL,
+        |_id: WebViewId, request: Request<Vec<u8>>, responder: RequestAsyncResponder| {
+            let path = request.uri().path().to_string();
+
+            if let Some(segment) = path.strip_prefix("/img/") {
+                // The id is hexadecimal; anything from the first dot on is the
+                // extension the render put there for the reader's benefit.
+                let id = segment.split('.').next().unwrap_or_default().to_string();
+                std::thread::spawn(move || responder.respond(respond_with_image(&id)));
+                return;
+            }
+
+            responder.respond(respond(&path));
+        },
+    )
 }
 
 fn respond(path: &str) -> Response<Cow<'static, [u8]>> {
@@ -77,6 +97,50 @@ fn respond(path: &str) -> Response<Cow<'static, [u8]>> {
         .header("Cache-Control", CACHE_CONTROL)
         .body(bytes)
         .expect("a response with a body and valid headers")
+}
+
+/// Answer with the image `id` stands for, if any render ever named it.
+///
+/// The bound is the one the rendering pipeline applies when it inlines an
+/// image instead. It has to be repeated here because the file is only read
+/// now: it may have grown, or been replaced by something that is not an
+/// image at all, since the document was rendered.
+fn respond_with_image(id: &str) -> Response<Cow<'static, [u8]>> {
+    let Some(image) = images::resolve(id) else {
+        tracing::debug!(id, "Image was never registered by a render");
+        return not_found();
+    };
+
+    let Some(bytes) = read_bounded(&image.path, MAX_IMAGE_SIZE) else {
+        return not_found();
+    };
+
+    Response::builder()
+        .status(200)
+        .header("Content-Type", image.mime)
+        .header("Access-Control-Allow-Origin", "*")
+        // The id changes when the file does, so what it names cannot.
+        .header("Cache-Control", "public, max-age=31536000, immutable")
+        .body(Cow::Owned(bytes))
+        .expect("a response with a body and valid headers")
+}
+
+/// The largest image the app will read, matching the pipeline's own bound.
+/// Guards against a path that has come to name a device file or a log.
+const MAX_IMAGE_SIZE: u64 = 32 * 1024 * 1024;
+
+fn read_bounded(path: &std::path::Path, max_size: u64) -> Option<Vec<u8>> {
+    let file = std::fs::File::open(path)
+        .inspect_err(|error| tracing::debug!(?path, %error, "Image could not be opened"))
+        .ok()?;
+
+    let mut bytes = Vec::new();
+    file.take(max_size + 1).read_to_end(&mut bytes).ok()?;
+    if bytes.len() as u64 > max_size {
+        tracing::debug!(?path, limit = max_size, "Image is over the size limit");
+        return None;
+    }
+    Some(bytes)
 }
 
 fn not_found() -> Response<Cow<'static, [u8]>> {
@@ -118,6 +182,11 @@ fn url(file: frontend::Bundled) -> String {
 /// The URL of the module every window imports.
 pub fn main_script_url() -> String {
     url(frontend::MAIN_SCRIPT)
+}
+
+/// Where a rendered document points at the images the app serves for it.
+pub fn image_base_url() -> String {
+    format!("{ORIGIN}/img")
 }
 
 /// The `<head>` markup that loads the main stylesheet, for
@@ -275,6 +344,33 @@ mod tests {
         assert_eq!(respond("/assets/../../etc/passwd").status(), 404);
         assert_eq!(respond("/etc/passwd").status(), 404);
         assert_eq!(respond("/assets/").status(), 404);
+    }
+
+    /// The registry, not the path in the URL, is what decides that an image
+    /// may be read: an id no render handed over names nothing.
+    #[test]
+    fn an_image_nobody_registered_is_refused() {
+        assert_eq!(respond_with_image("0123456789abcdef").status(), 404);
+        assert_eq!(respond_with_image("").status(), 404);
+    }
+
+    /// The extension is for whoever reads the URL; the id alone resolves it.
+    #[test]
+    fn a_registered_image_is_served_under_its_extension() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("hero.png");
+        std::fs::write(&path, [0x89, 0x50, 0x4E, 0x47]).unwrap();
+
+        images::register(vec![arto_markdown::DeferredImage {
+            id: "testserved".to_string(),
+            path,
+            mime: "image/png",
+        }]);
+
+        let response = respond_with_image("testserved");
+        assert_eq!(response.status(), 200);
+        assert_eq!(response.headers()["Content-Type"], "image/png");
+        assert_eq!(response.body().as_ref(), [0x89, 0x50, 0x4E, 0x47]);
     }
 
     #[test]

--- a/crates/arto/src/assets/frontend.rs
+++ b/crates/arto/src/assets/frontend.rs
@@ -1,0 +1,104 @@
+//! The stylesheet and the script every window loads, and where they come from.
+//!
+//! A release binary carries them: `dioxus`'s `asset!` embeds a hashed path
+//! rather than a file, and the file itself is put in place by `dx bundle`, so
+//! a binary from a plain `cargo build` had a stylesheet and a script that
+//! resolved to nothing. Carrying them is what makes one file enough to run.
+//!
+//! A debug build reads the same files from the source tree instead, so that
+//! editing a stylesheet stays a job for the development loop's watcher rather
+//! than a reason to relink the app.
+
+use std::borrow::Cow;
+
+/// One file the app serves to its own WebViews.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct Bundled {
+    /// The name it is requested by, which is also its name in `assets/frontend`.
+    pub name: &'static str,
+    pub mime: &'static str,
+}
+
+pub const MAIN_SCRIPT: Bundled = Bundled {
+    name: "main.js",
+    mime: "text/javascript; charset=utf-8",
+};
+
+pub const MAIN_STYLE: Bundled = Bundled {
+    name: "main.css",
+    mime: "text/css; charset=utf-8",
+};
+
+const BUNDLE: [Bundled; 2] = [MAIN_SCRIPT, MAIN_STYLE];
+
+/// The file a request names, or `None` when it names nothing the app serves.
+pub fn bundled(name: &str) -> Option<Bundled> {
+    BUNDLE.into_iter().find(|file| file.name == name)
+}
+
+#[cfg(not(debug_assertions))]
+mod source {
+    use super::{Bundled, MAIN_SCRIPT, MAIN_STYLE};
+    use std::borrow::Cow;
+    use std::io::Read;
+    use std::sync::OnceLock;
+
+    const MAIN_SCRIPT_GZ: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/main.js.gz"));
+    const MAIN_STYLE_GZ: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/main.css.gz"));
+
+    /// The file's bytes, decompressed once for the whole process rather than
+    /// once per window.
+    ///
+    /// Matched against the constants themselves rather than re-typing their
+    /// names, which would be a second spelling of `Bundled::name` free to
+    /// drift from the first — and a name that drifted would answer 404 in a
+    /// release while every debug build kept working.
+    pub fn bytes(file: Bundled) -> Option<Cow<'static, [u8]>> {
+        static SCRIPT: OnceLock<Vec<u8>> = OnceLock::new();
+        static STYLE: OnceLock<Vec<u8>> = OnceLock::new();
+
+        let (cell, compressed) = match file {
+            MAIN_SCRIPT => (&SCRIPT, MAIN_SCRIPT_GZ),
+            MAIN_STYLE => (&STYLE, MAIN_STYLE_GZ),
+            _ => return None,
+        };
+        Some(Cow::Borrowed(
+            cell.get_or_init(|| decompress(compressed)).as_slice(),
+        ))
+    }
+
+    fn decompress(compressed: &[u8]) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        flate2::read::GzDecoder::new(compressed)
+            .read_to_end(&mut bytes)
+            .expect("the embedded bundle was compressed by this build");
+        bytes
+    }
+}
+
+#[cfg(debug_assertions)]
+mod source {
+    use super::Bundled;
+    use std::borrow::Cow;
+    use std::path::PathBuf;
+
+    /// The file as it is on disk right now, so that a rebuilt bundle shows up
+    /// in a running window without rebuilding the app.
+    pub fn bytes(file: Bundled) -> Option<Cow<'static, [u8]>> {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("assets/frontend")
+            .join(file.name);
+        match std::fs::read(&path) {
+            Ok(bytes) => Some(Cow::Owned(bytes)),
+            Err(error) => {
+                tracing::error!(?path, %error, "Frontend bundle is missing; run `just frontend::assets`");
+                None
+            }
+        }
+    }
+}
+
+/// The bytes to answer a request for `file` with.
+pub fn bytes(file: Bundled) -> Option<Cow<'static, [u8]>> {
+    source::bytes(file)
+}

--- a/crates/arto/src/assets/images.rs
+++ b/crates/arto/src/assets/images.rs
@@ -1,0 +1,206 @@
+//! The local images the app agreed to serve, by the id its documents name.
+//!
+//! A render hands back the images it referenced instead of the bytes, and
+//! this is where they are kept until a WebView asks for one. What the app
+//! will serve is exactly what some render put here: an id nobody registered
+//! is a 404, which is what keeps a URL from naming any file on the disk.
+//!
+//! The map is process-wide, not per window, because the window that asks is
+//! not always the window that rendered: opening an image in its own window
+//! hands that window the URL to resolve for itself.
+//!
+//! Entries are only ever added. Each is a path and a content type, so even a
+//! reading session of thousands of images stays well under a megabyte, and
+//! nothing has to decide when an id stops being valid — a document being
+//! re-rendered would otherwise race the WebView still loading the last one.
+
+use arto_markdown::DeferredImage;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{LazyLock, RwLock};
+
+/// What serving an image needs: where it is, and what to call it.
+#[derive(Clone)]
+pub struct Registered {
+    pub path: PathBuf,
+    pub mime: &'static str,
+}
+
+static REGISTRY: LazyLock<RwLock<HashMap<String, Registered>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
+
+/// Agree to serve every image in `images`.
+pub fn register(images: Vec<DeferredImage>) {
+    if images.is_empty() {
+        return;
+    }
+    let mut registry = REGISTRY.write().expect("image registry is not poisoned");
+    for image in images {
+        registry.entry(image.id).or_insert(Registered {
+            path: image.path,
+            mime: image.mime,
+        });
+    }
+}
+
+/// The image an id stands for, or `None` when no render ever named it.
+pub fn resolve(id: &str) -> Option<Registered> {
+    REGISTRY
+        .read()
+        .expect("image registry is not poisoned")
+        .get(id)
+        .cloned()
+}
+
+/// The file behind one of the app's own image URLs, or `None` when `src` is
+/// not one of them.
+pub fn path_for(src: &str) -> Option<PathBuf> {
+    Some(resolve(id_in(src)?)?.path)
+}
+
+/// Every one of the app's image URLs in `text`, replaced by the file it
+/// stands for.
+///
+/// What the reader means by an image is the file on their disk. The URL is an
+/// arrangement between the renderer and the WebView, and it resolves nowhere
+/// else — so anything copied out of the app, a Markdown link or a path, says
+/// where the image actually is.
+pub fn with_paths_for_urls(text: &str) -> String {
+    let mut rewritten = String::with_capacity(text.len());
+    let mut rest = text;
+
+    while let Some(start) = rest.find(URL_PREFIX) {
+        rewritten.push_str(&rest[..start]);
+        let url_end = rest[start..]
+            .find(|c: char| c.is_whitespace() || matches!(c, ')' | '"' | '\'' | '>'))
+            .map_or(rest.len(), |end| start + end);
+        let url = &rest[start..url_end];
+
+        match path_for(url) {
+            Some(path) => rewritten.push_str(&path.to_string_lossy()),
+            None => rewritten.push_str(url),
+        }
+        rest = &rest[url_end..];
+    }
+
+    rewritten.push_str(rest);
+    rewritten
+}
+
+/// The id inside one of the app's image URLs.
+///
+/// The whole origin has to match, not just the `/img/` segment: `https://…
+/// /img/<something>.png` is somebody else's URL, and resolving it against this
+/// registry would hand a remote reference a local file.
+fn id_in(src: &str) -> Option<&str> {
+    src.strip_prefix(URL_PREFIX)?
+        .split(['.', '?', '#'])
+        .next()
+        .filter(|id| !id.is_empty())
+}
+
+/// How one of those URLs starts, whichever shape the platform uses.
+const URL_PREFIX: &str = if cfg!(windows) {
+    "http://artoasset.localhost/img/"
+} else {
+    "artoasset://localhost/img/"
+};
+
+/// One of the app's own image URLs as a `data:` URL, or `None` when `src` is
+/// not one of them.
+///
+/// For the paths that have to put an image somewhere other than in a
+/// document: the clipboard, mostly. A WebView cannot rasterize an image it
+/// fetched from the app's origin — the canvas it draws to is tainted and
+/// reading it back throws — so the bytes go the other way instead.
+pub fn data_url_for(src: &str) -> Option<String> {
+    use base64::Engine as _;
+
+    let id = id_in(src)?;
+    let image = resolve(id)?;
+    // Bounded for the same reason serving one is: the file is read now, not
+    // when the document was rendered, and by now it may have grown or been
+    // replaced by something that is not an image at all.
+    let bytes = super::read_bounded(&image.path, super::MAX_IMAGE_SIZE)?;
+
+    Some(format!(
+        "data:{};base64,{}",
+        image.mime,
+        base64::engine::general_purpose::STANDARD.encode(&bytes)
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn image(id: &str, path: &str) -> DeferredImage {
+        DeferredImage {
+            id: id.to_string(),
+            path: PathBuf::from(path),
+            mime: "image/png",
+        }
+    }
+
+    #[test]
+    fn an_unregistered_id_resolves_to_nothing() {
+        assert!(resolve("never-rendered-this-one").is_none());
+    }
+
+    #[test]
+    fn a_registered_id_resolves_to_its_file() {
+        register(vec![image("test-registered", "/tmp/hero.png")]);
+
+        let found = resolve("test-registered").expect("registered");
+        assert_eq!(found.path, PathBuf::from("/tmp/hero.png"));
+        assert_eq!(found.mime, "image/png");
+    }
+
+    /// What leaves the app names the file, not the arrangement between the
+    /// renderer and the WebView.
+    #[test]
+    fn copied_text_names_the_file_rather_than_the_url() {
+        register(vec![image("testrewrite", "/tmp/hero.png")]);
+        let url = format!("{URL_PREFIX}testrewrite.png");
+
+        assert_eq!(with_paths_for_urls(&url), "/tmp/hero.png");
+        assert_eq!(
+            with_paths_for_urls(&format!("![alt]({url})")),
+            "![alt](/tmp/hero.png)"
+        );
+    }
+
+    /// An id from a session that is gone, or a URL of somebody else's, is
+    /// left exactly as it was rather than turned into nothing.
+    #[test]
+    fn text_that_names_no_registered_image_is_untouched() {
+        let unknown = format!("![alt]({URL_PREFIX}0123456789abcdef.png)");
+        assert_eq!(with_paths_for_urls(&unknown), unknown);
+
+        let remote = "![alt](https://example.com/hero.png)";
+        assert_eq!(with_paths_for_urls(remote), remote);
+    }
+
+    /// A remote URL that happens to be shaped like one of the app's own is
+    /// still a remote URL: the registry answers for this origin only.
+    #[test]
+    fn a_foreign_url_shaped_like_the_apps_resolves_to_nothing() {
+        register(vec![image("testforeign", "/tmp/hero.png")]);
+
+        assert!(path_for("https://example.com/img/testforeign.png").is_none());
+        assert!(data_url_for("https://example.com/img/testforeign.png").is_none());
+    }
+
+    /// Re-rendering the same document registers the same ids again, which
+    /// must not disturb what the WebView is already loading.
+    #[test]
+    fn registering_an_id_twice_keeps_the_first_answer() {
+        register(vec![image("test-twice", "/tmp/first.png")]);
+        register(vec![image("test-twice", "/tmp/second.png")]);
+
+        assert_eq!(
+            resolve("test-twice").expect("registered").path,
+            PathBuf::from("/tmp/first.png")
+        );
+    }
+}

--- a/crates/arto/src/components/app.rs
+++ b/crates/arto/src/components/app.rs
@@ -25,7 +25,7 @@ use super::search_bar::SearchBar;
 use super::sidebar::file_explorer::SidebarContextMenuHost;
 use super::sidebar::Sidebar;
 use super::tab::TabBar;
-use crate::assets::MAIN_SCRIPT;
+use crate::assets::main_script_url;
 use crate::drag;
 use crate::events::{ActiveDragUpdate, ACTIVE_DRAG_UPDATE};
 #[cfg(not(target_os = "windows"))]
@@ -168,13 +168,14 @@ pub fn App(
                 r#"
                 (async () => {{
                     try {{
-                        const {{ init }} = await import("{MAIN_SCRIPT}");
+                        const {{ init }} = await import("{main_script}");
                         init();
                     }} catch (error) {{
                         console.error("Failed to load main module:", error);
                     }}
                 }})();
-                "#
+                "#,
+                main_script = main_script_url()
             ))
             .await;
         });

--- a/crates/arto/src/components/content/context_menu/image_ops.rs
+++ b/crates/arto/src/components/content/context_menu/image_ops.rs
@@ -52,6 +52,7 @@ pub(super) fn CopyImageAsSubmenu(
                     let alt_text = alt.as_deref().unwrap_or("").to_string();
                     let src = src.clone();
                     move |_| {
+                        let src = crate::assets::images::with_paths_for_urls(&src);
                         let md = format!("![{}]({})", alt_text, src);
                         crate::utils::clipboard::copy_text(&md);
                         crate::keybindings::dispatcher::show_action_feedback("Copied");
@@ -66,6 +67,7 @@ pub(super) fn CopyImageAsSubmenu(
                 on_click: {
                     let src = src.clone();
                     move |_| {
+                        let src = crate::assets::images::with_paths_for_urls(&src);
                         crate::utils::clipboard::copy_text(&src);
                         crate::keybindings::dispatcher::show_action_feedback("Copied");
                         on_close.call(());

--- a/crates/arto/src/components/content/preferences_view/tabs/about_tab.rs
+++ b/crates/arto/src/components/content/preferences_view/tabs/about_tab.rs
@@ -3,10 +3,9 @@ use crate::config::Config;
 use crate::utils::file_operations;
 use dioxus::prelude::*;
 
-const ARTO_ICON: Asset = asset!("/assets/Arto.png");
-
 #[component]
 pub fn AboutTab() -> Element {
+    let icon = crate::assets::app_icon_data_url();
     let version_text = format!("Version {}", env!("ARTO_BUILD_VERSION"));
     let config_dir_path = Config::path()
         .parent()
@@ -25,7 +24,7 @@ pub fn AboutTab() -> Element {
                 div {
                     class: "about-icon",
                     img {
-                        src: "{ARTO_ICON}",
+                        src: "{icon}",
                         alt: "Arto",
                     }
                 }

--- a/crates/arto/src/components/icon.rs
+++ b/crates/arto/src/components/icon.rs
@@ -1,8 +1,6 @@
 use dioxus::prelude::*;
 use std::fmt;
 
-const TABLER_SPRITE: Asset = asset!("/assets/frontend/icons/tabler-sprite.svg");
-
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum IconName {
     Add,
@@ -111,7 +109,6 @@ pub fn Icon(
     #[props(default = 20)] size: u32,
     #[props(default = "")] class: &'static str,
 ) -> Element {
-    let sprite_url = TABLER_SPRITE.to_string();
     let icon_id = format!("tabler-{}", name);
 
     rsx! {
@@ -120,8 +117,12 @@ pub fn Icon(
             width: "{size}",
             height: "{size}",
             "aria-hidden": "true",
+            // A bare fragment, because the sprite is in this very document:
+            // `crate::window::index` writes it into the body. A `<use>` that
+            // names another origin is refused, and unlike a stylesheet or a
+            // script no header makes it allowed.
             r#use {
-                href: "{sprite_url}#{icon_id}"
+                href: "#{icon_id}"
             }
         }
     }

--- a/crates/arto/src/components/image_window.rs
+++ b/crates/arto/src/components/image_window.rs
@@ -72,7 +72,13 @@ pub fn ImageWindow(props: ImageWindowProps) -> Element {
 
     // Load viewer script on mount
     use_effect(move || {
-        let src_json = serde_json::to_string(&props.src).unwrap_or_default();
+        // The copy button rasterizes what this window shows, and a canvas that
+        // drew an image from the app's own origin is tainted — reading it back
+        // throws. An image the app serves therefore reaches the window as its
+        // bytes instead of as its URL.
+        let src =
+            crate::assets::images::data_url_for(&props.src).unwrap_or_else(|| props.src.clone());
+        let src_json = serde_json::to_string(&src).unwrap_or_default();
         let image_id_json = serde_json::to_string(&props.image_id).unwrap_or_default();
 
         let main_script = main_script_url();

--- a/crates/arto/src/components/image_window.rs
+++ b/crates/arto/src/components/image_window.rs
@@ -1,7 +1,7 @@
 use dioxus::prelude::*;
 use sha2::{Digest, Sha256};
 
-use crate::assets::MAIN_SCRIPT;
+use crate::assets::main_script_url;
 use crate::components::theme_selector::ThemeSelector;
 use crate::hooks::{
     use_clipboard_image_handler, use_theme_dispatch, use_window_close_handler, use_zoom_sync,
@@ -75,11 +75,12 @@ pub fn ImageWindow(props: ImageWindowProps) -> Element {
         let src_json = serde_json::to_string(&props.src).unwrap_or_default();
         let image_id_json = serde_json::to_string(&props.image_id).unwrap_or_default();
 
+        let main_script = main_script_url();
         spawn(async move {
             let eval_result = document::eval(&indoc::formatdoc! {r#"
                 (async () => {{
                     try {{
-                        const {{ initImageWindow }} = await import("{MAIN_SCRIPT}");
+                        const {{ initImageWindow }} = await import("{main_script}");
                         await initImageWindow({src_json}, {image_id_json});
                     }} catch (error) {{
                         console.error("Failed to load image window module:", error);

--- a/crates/arto/src/components/math_window.rs
+++ b/crates/arto/src/components/math_window.rs
@@ -1,7 +1,7 @@
 use dioxus::prelude::*;
 use sha2::{Digest, Sha256};
 
-use crate::assets::MAIN_SCRIPT;
+use crate::assets::main_script_url;
 use crate::components::theme_selector::ThemeSelector;
 use crate::hooks::{
     use_clipboard_image_handler, use_theme_dispatch, use_window_close_handler, use_zoom_sync,
@@ -59,11 +59,12 @@ pub fn MathWindow(props: MathWindowProps) -> Element {
         // Resolve "auto" and the configured choice before passing to JS
         let theme_str = crate::theme::resolve_color_theme(*current_theme.read()).as_str();
 
+        let main_script = main_script_url();
         spawn(async move {
             let eval_result = document::eval(&indoc::formatdoc! {r#"
                 (async () => {{
                     try {{
-                        const {{ initMathWindow }} = await import("{MAIN_SCRIPT}");
+                        const {{ initMathWindow }} = await import("{main_script}");
                         await initMathWindow({source_json}, {math_id_json}, "{theme_str}");
                     }} catch (error) {{
                         console.error("Failed to load math window module:", error);

--- a/crates/arto/src/components/mermaid_window.rs
+++ b/crates/arto/src/components/mermaid_window.rs
@@ -1,7 +1,7 @@
 use dioxus::prelude::*;
 use sha2::{Digest, Sha256};
 
-use crate::assets::MAIN_SCRIPT;
+use crate::assets::main_script_url;
 use crate::components::icon::{Icon, IconName};
 use crate::components::theme_selector::ThemeSelector;
 use crate::hooks::{use_theme_dispatch, use_window_close_handler, use_zoom_sync, CopyStatus};
@@ -43,11 +43,12 @@ pub fn MermaidWindow(props: MermaidWindowProps) -> Element {
         let source_json = serde_json::to_string(&props.source).unwrap_or_default();
         let diagram_id_json = serde_json::to_string(&props.diagram_id).unwrap_or_default();
 
+        let main_script = main_script_url();
         spawn(async move {
             let eval_result = document::eval(&indoc::formatdoc! {r#"
                 (async () => {{
                     try {{
-                        const {{ initMermaidWindow }} = await import("{MAIN_SCRIPT}");
+                        const {{ initMermaidWindow }} = await import("{main_script}");
                         await initMermaidWindow({source_json}, {diagram_id_json});
                     }} catch (error) {{
                         console.error("Failed to load mermaid window module:", error);

--- a/crates/arto/src/hooks/viewer_window.rs
+++ b/crates/arto/src/hooks/viewer_window.rs
@@ -5,7 +5,7 @@ use dioxus::desktop::use_muda_event_handler;
 use dioxus::desktop::window;
 use dioxus::prelude::*;
 
-use crate::assets::MAIN_SCRIPT;
+use crate::assets::main_script_url;
 use crate::components::icon::{Icon, IconName};
 
 #[derive(serde::Deserialize)]
@@ -143,12 +143,13 @@ pub fn CopyImageButton(js_function: String, label: String) -> Element {
 
     let handle_click = move |_| {
         let js_function = js_function.clone();
+        let main_script = main_script_url();
         spawn(async move {
             copy_status.set(CopyStatus::Copying);
 
             let mut eval = document::eval(&indoc::formatdoc! {r#"
                 (async () => {{
-                    const {{ {js_function} }} = await import("{MAIN_SCRIPT}");
+                    const {{ {js_function} }} = await import("{main_script}");
                     try {{
                         await {js_function}();
                         dioxus.send(true);

--- a/crates/arto/src/keybindings/dispatcher.rs
+++ b/crates/arto/src/keybindings/dispatcher.rs
@@ -684,6 +684,9 @@ fn copy_content_cursor_text(js_getter: &'static str) {
         let mut eval = document::eval(&js);
         match eval.recv::<String>().await {
             Ok(text) if !text.is_empty() => {
+                // What the document shows for an image is a URL only this app
+                // can resolve, so anything leaving it says where the file is.
+                let text = crate::assets::images::with_paths_for_urls(&text);
                 crate::utils::clipboard::copy_text(&text);
                 show_action_feedback("Copied");
             }
@@ -793,7 +796,15 @@ async fn copy_special_block_from_cursor(kind: &str, opaque: bool) {
 }
 
 pub(crate) async fn copy_image_from_src(src: String, opaque: bool) {
-    let rasterize_src = if src.starts_with("http://") || src.starts_with("https://") {
+    // An image the app serves for the document is read here rather than in the
+    // WebView. Drawing it to a canvas there would taint the canvas — it comes
+    // from the app's own origin, not the document's — and asking for it as a
+    // CORS request is worse still, because a custom scheme does not take part
+    // in CORS and the load simply fails. Reading it costs one encode of an
+    // image somebody deliberately asked to copy.
+    let rasterize_src = if let Some(data_url) = crate::assets::images::data_url_for(&src) {
+        data_url
+    } else if src.starts_with("http://") || src.starts_with("https://") {
         let (tx, rx) = tokio::sync::oneshot::channel();
         std::thread::spawn({
             let src = src.clone();
@@ -835,7 +846,9 @@ fn copy_image_path_from_cursor() {
         let mut eval = document::eval(js);
         match eval.recv::<String>().await {
             Ok(src) if !src.is_empty() => {
-                crate::utils::clipboard::copy_text(src);
+                // The path the reader means, not the URL the WebView was given.
+                let src = crate::assets::images::with_paths_for_urls(&src);
+                crate::utils::clipboard::copy_text(&src);
                 show_action_feedback("Copied");
             }
             Ok(_) => {}
@@ -1136,6 +1149,10 @@ fn save_image_from_cursor() {
         match target {
             SaveImageTarget::Image { src } => {
                 std::thread::spawn(move || {
+                    // `save_image` knows `data:` and `http(s)`; the app's own
+                    // protocol resolves nowhere outside a WebView, so an image
+                    // the app serves is read here and handed over as bytes.
+                    let src = crate::assets::images::data_url_for(&src).unwrap_or(src);
                     crate::utils::image::save_image(&src);
                 });
             }

--- a/crates/arto/src/markdown.rs
+++ b/crates/arto/src/markdown.rs
@@ -23,7 +23,7 @@ fn render_options() -> RenderOptions {
 
 /// Render Markdown to HTML, honoring the user's rendering preferences.
 pub fn render_to_html(markdown: impl AsRef<str>, base_path: impl AsRef<Path>) -> Result<String> {
-    arto_markdown::render_to_html(markdown, base_path, &render_options())
+    Ok(arto_markdown::render_to_html(markdown, base_path, &render_options())?.html)
 }
 
 /// Render Markdown to HTML with TOC information, honoring the user's
@@ -32,5 +32,6 @@ pub fn render_to_html_with_toc(
     markdown: impl AsRef<str>,
     base_path: impl AsRef<Path>,
 ) -> Result<(String, Vec<HeadingInfo>)> {
-    arto_markdown::render_to_html_with_toc(markdown, base_path, &render_options())
+    let rendered = arto_markdown::render_to_html_with_toc(markdown, base_path, &render_options())?;
+    Ok((rendered.html, rendered.headings))
 }

--- a/crates/arto/src/markdown.rs
+++ b/crates/arto/src/markdown.rs
@@ -9,7 +9,7 @@
 //! functions below share their names with arto-markdown's three-argument
 //! originals, and a glob would import those only to shadow them.
 
-pub use arto_markdown::{extract_source_selection, HeadingInfo, RenderOptions};
+pub use arto_markdown::{extract_source_selection, HeadingInfo, ImageResolution, RenderOptions};
 
 use crate::config::CONFIG;
 use anyhow::Result;
@@ -17,13 +17,26 @@ use std::path::Path;
 
 /// The user's rendering preferences, copied out so the config lock is not
 /// held while rendering.
+///
+/// The app serves the images a document references rather than carrying them
+/// in it: inlining costs the bytes twice over, once in the HTML built here
+/// and once in the document the WebView parses, and a page of screenshots
+/// pays that on every re-render. `arto page` and Quick Look still inline,
+/// having nothing to serve from.
 fn render_options() -> RenderOptions {
-    CONFIG.read().markdown.clone()
+    RenderOptions {
+        images: ImageResolution::Deferred {
+            base_url: crate::assets::image_base_url(),
+        },
+        ..CONFIG.read().markdown.clone()
+    }
 }
 
 /// Render Markdown to HTML, honoring the user's rendering preferences.
 pub fn render_to_html(markdown: impl AsRef<str>, base_path: impl AsRef<Path>) -> Result<String> {
-    Ok(arto_markdown::render_to_html(markdown, base_path, &render_options())?.html)
+    let rendered = arto_markdown::render_to_html(markdown, base_path, &render_options())?;
+    crate::assets::images::register(rendered.images);
+    Ok(rendered.html)
 }
 
 /// Render Markdown to HTML with TOC information, honoring the user's
@@ -33,5 +46,6 @@ pub fn render_to_html_with_toc(
     base_path: impl AsRef<Path>,
 ) -> Result<(String, Vec<HeadingInfo>)> {
     let rendered = arto_markdown::render_to_html_with_toc(markdown, base_path, &render_options())?;
+    crate::assets::images::register(rendered.images);
     Ok((rendered.html, rendered.headings))
 }

--- a/crates/arto/src/window/child.rs
+++ b/crates/arto/src/window/child.rs
@@ -5,7 +5,7 @@ use dioxus::prelude::*;
 use std::cell::RefCell;
 use std::collections::HashMap;
 
-use crate::assets::main_stylesheet_head;
+use crate::assets::{main_stylesheet_head, with_asset_protocol};
 use crate::components::image_window::{generate_image_id, ImageWindow, ImageWindowProps};
 use crate::components::math_window::{generate_math_id, MathWindow, MathWindowProps};
 use crate::components::mermaid_window::{generate_diagram_id, MermaidWindow, MermaidWindowProps};
@@ -178,7 +178,7 @@ pub fn open_or_focus_mermaid_window(source: String, theme: Theme) {
                 theme,
             },
         );
-        let config = Config::new()
+        let config = with_asset_protocol(Config::new())
             .with_menu(None)
             .with_window(super::icon::apply_app_icon(
                 WindowBuilder::new().with_title("Mermaid Viewer"),
@@ -205,7 +205,7 @@ pub fn open_or_focus_math_window(source: String, theme: Theme) {
                 theme,
             },
         );
-        let config = Config::new()
+        let config = with_asset_protocol(Config::new())
             .with_menu(None)
             .with_window(super::icon::apply_app_icon(
                 WindowBuilder::new().with_title("Math Viewer"),
@@ -233,7 +233,7 @@ pub fn open_or_focus_image_window(src: String, alt: Option<String>, theme: Theme
                 theme,
             },
         );
-        let config = Config::new()
+        let config = with_asset_protocol(Config::new())
             .with_menu(None)
             .with_window(super::icon::apply_app_icon(
                 WindowBuilder::new().with_title("Image Viewer"),

--- a/crates/arto/src/window/icon.rs
+++ b/crates/arto/src/window/icon.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 /// filesystem (the bundled asset directory sits in a different place relative
 /// to the binary on every platform, and a missing icon must not be able to fail
 /// a window).
-const ICON_PNG: &[u8] = include_bytes!("../../assets/Arto.png");
+pub const APP_ICON_PNG: &[u8] = include_bytes!("../../assets/Arto.png");
 
 /// Edge length for the icon Windows draws in the title bar. Windows happily
 /// scales an icon of any size into the 16px slot, but does it without
@@ -67,7 +67,7 @@ fn app_icon(size: u32) -> Option<Icon> {
 }
 
 fn load_app_icon(size: u32) -> Option<Icon> {
-    let image = match image::load_from_memory_with_format(ICON_PNG, image::ImageFormat::Png) {
+    let image = match image::load_from_memory_with_format(APP_ICON_PNG, image::ImageFormat::Png) {
         Ok(image) => image,
         Err(err) => {
             tracing::warn!("Failed to decode the application icon: {err}");

--- a/crates/arto/src/window/index.rs
+++ b/crates/arto/src/window/index.rs
@@ -1,7 +1,9 @@
+use crate::assets::icon_sprite;
 use crate::theme::{resolve_color_theme, Theme};
 
 pub fn build_custom_index(theme: Theme) -> String {
     let resolved = resolve_color_theme(theme).as_str();
+    let sprite = icon_sprite();
     indoc::formatdoc! {r#"
     <!DOCTYPE html>
     <html data-theme="{resolved}">
@@ -11,6 +13,7 @@ pub fn build_custom_index(theme: Theme) -> String {
             <!-- CUSTOM HEAD -->
         </head>
         <body>
+            {sprite}
             <div id="main"></div>
             <!-- MODULE LOADER -->
         </body>
@@ -20,6 +23,7 @@ pub fn build_custom_index(theme: Theme) -> String {
 
 fn build_viewer_window_index(title: &str, body_class: &str, theme: Theme) -> String {
     let resolved = resolve_color_theme(theme).as_str();
+    let sprite = icon_sprite();
     indoc::formatdoc! {r#"
     <!DOCTYPE html>
     <html data-theme="{resolved}">
@@ -29,6 +33,7 @@ fn build_viewer_window_index(title: &str, body_class: &str, theme: Theme) -> Str
             <!-- CUSTOM HEAD -->
         </head>
         <body class="{body_class}">
+            {sprite}
             <div id="main"></div>
             <!-- MODULE LOADER -->
         </body>
@@ -46,4 +51,28 @@ pub(crate) fn build_math_window_index(theme: Theme) -> String {
 
 pub(crate) fn build_image_window_index(theme: Theme) -> String {
     build_viewer_window_index("Image Viewer", "image-window-body", theme)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The icons are `<use href="#tabler-…">`, which resolves in the document
+    /// it is written in and nowhere else, so every window has to carry the
+    /// sprite. Without it the interface renders with every icon blank and
+    /// nothing reported anywhere.
+    #[test]
+    fn every_window_carries_the_icon_sprite() {
+        for index in [
+            build_custom_index(Theme::Light),
+            build_mermaid_window_index(Theme::Light),
+            build_math_window_index(Theme::Light),
+            build_image_window_index(Theme::Light),
+        ] {
+            assert!(
+                index.contains("id=\"tabler-"),
+                "sprite missing: {index:.200}"
+            );
+        }
+    }
 }

--- a/crates/arto/src/window/main.rs
+++ b/crates/arto/src/window/main.rs
@@ -12,7 +12,7 @@ use std::rc::Rc;
 
 use crate::state::AppState;
 
-use crate::assets::main_stylesheet_head;
+use crate::assets::{main_stylesheet_head, with_asset_protocol};
 use crate::components::app::{App, AppProps};
 use crate::components::right_sidebar::RightSidebarTab;
 use crate::config::{WindowPositionOffset, CONFIG};
@@ -32,7 +32,7 @@ const MAX_POSITION_SHIFT_ATTEMPTS: usize = 20;
 pub fn create_main_window_config(params: &CreateMainWindowConfigParams) -> Config {
     let initial_size = params.size;
 
-    Config::new()
+    with_asset_protocol(Config::new())
         .with_window(icon::apply_app_icon(
             WindowBuilder::new()
                 .with_title("Arto")

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -42,6 +42,29 @@ The AppImage needs WebKitGTK 4.1 present on the system; on Fedora that is `sudo 
 
 Both artifacts are built on Ubuntu 24.04, so they require glibc 2.39 or newer (Ubuntu 24.04+, Debian 13+, Fedora 40+). On older distributions, build from source or use Nix.
 
+## A single binary
+
+Every release also carries the application as one executable, for Linux and
+Windows, when a package is more ceremony than you want. Download the one for
+your machine from the [releases] page and run it from wherever you put it —
+the stylesheet, the scripts and the icons are compiled into it, so there is
+nothing to install beside it.
+
+```sh
+chmod +x arto-linux-x86_64
+./arto-linux-x86_64 README.md
+```
+
+It is the same application, without what an installer arranges around it: no
+menu entry, no file associations, and no `arto` on your `PATH` unless you put
+it there. The Linux binary still needs WebKitGTK 4.1 on the system, exactly as
+the `.deb` and the AppImage do.
+
+macOS has no such download on purpose. Most of what makes Arto worth
+installing there — the Finder associations and the Quick Look preview — is
+carried by the app bundle rather than by the executable inside it, so the DMG
+is the whole story.
+
 ## Nix
 
 [Nix] works on both macOS and Linux. To try Arto without installing it:
@@ -74,7 +97,7 @@ nix run github:arto-app/Arto#arto-page -- README.md > README.html
 | --- | --- |
 | macOS | Supported. Developed and tested here, and the only platform with Quick Look integration. |
 | Linux | Experimental. Builds are published and CI runs the test suite, but the desktop integration gets far less real use. |
-| Windows | Experimental. CI builds and tests it; there is no published installer yet. |
+| Windows | Experimental. CI builds and tests it, and a release carries an installer and a single binary when that build succeeds, but almost nobody runs it. |
 
 Bug reports for the experimental platforms are welcome, and so are PRs.
 
@@ -84,8 +107,9 @@ Launch Arto to see the welcome screen, which lists the keyboard shortcuts and
 how to get started.
 
 Homebrew, the `.deb` and Nix also put an `arto` command on your `PATH`. The
-AppImage does not — it is one self-contained file, so run it by its own path
-instead. Either way, see [CLI usage](./cli.md) for what you can hand it.
+AppImage and the single binary do not — each is one self-contained file, so run
+it by its own path instead. Either way, see [CLI usage](./cli.md) for what you
+can hand it.
 
 [Homebrew]: https://brew.sh/
 [homebrew-tap]: https://github.com/arto-app/homebrew-tap

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -232,6 +232,10 @@ export function init(): void {
         const shortSrc = src.length > 120 ? `${src.slice(0, 120)}…` : src;
         return new Promise((resolve) => {
           const img = new Image();
+          // No `crossOrigin` here: a custom scheme does not take part in CORS
+          // in every engine, and asking for it is enough to make the load
+          // itself fail. Whatever calls this hands over a `data:` URL when the
+          // image is not the document's own — see `copy_image_from_src`.
           img.onload = () => {
             try {
               // SVG: 2x for Retina (vector scales perfectly)

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -176,7 +176,11 @@ function syncBundlePlugin(consumers: BundleConsumer[], replace: boolean): Plugin
         fs.mkdirSync(dir, { recursive: true });
         if (files) {
           for (const file of files) {
-            fs.copyFileSync(path.join(outDir, file), path.join(dir, file));
+            const destination = path.join(dir, file);
+            // A listed file may sit in a subdirectory of its own (the icon
+            // sprite does), which `replace` above has just removed.
+            fs.mkdirSync(path.dirname(destination), { recursive: true });
+            fs.copyFileSync(path.join(outDir, file), destination);
           }
         } else {
           fs.cpSync(outDir, dir, { recursive: true });
@@ -188,8 +192,14 @@ function syncBundlePlugin(consumers: BundleConsumer[], replace: boolean): Plugin
 
 /** Crates that embed the bundle. */
 const bundleConsumers: BundleConsumer[] = [
-  // The app serves everything (ES module, stylesheet, icon sprite) as assets.
-  { dir: path.resolve(import.meta.dirname, "../crates/arto/assets/frontend") },
+  // The app compiles in the ES module and the stylesheet and serves them from
+  // its own protocol; the sprite it writes into each window's document. The
+  // IIFE build is the Quick Look extension's and is listed below, so naming
+  // these three keeps 4.8 MB the app never reads out of its binary.
+  {
+    dir: path.resolve(import.meta.dirname, "../crates/arto/assets/frontend"),
+    files: ["main.js", "main.css", "icons/tabler-sprite.svg"],
+  },
   // The page crate inlines only the stylesheet and the IIFE bundle.
   {
     dir: path.resolve(import.meta.dirname, "../crates/arto-page/assets/frontend"),

--- a/justfile
+++ b/justfile
@@ -54,6 +54,13 @@ dev:
 
 build: frontend::assets arto::build
 
+# What an installer sets up — file associations, a desktop entry, the Quick
+# Look extension — is exactly what this does not carry. Everything the app
+# itself needs is compiled in, so the binary runs from wherever it is put.
+#
+# The application as one executable, at target/release/arto
+standalone: frontend::assets arto::standalone
+
 # Gate for release artifacts; see the arto recipe for what it rejects.
 [macos]
 verify-bundle: arto::verify-bundle


### PR DESCRIPTION
## Summary

- `arto-markdown` gains `ImageResolution`, so a consumer chooses whether a local image is inlined as a `data:` URL or left to the host to serve. `render_to_html` / `render_to_html_with_toc` now return a `RenderResult` carrying the images the render referenced. The default stays `DataUrl`, so `arto page` and Quick Look are unchanged.
- The frontend stylesheet and script are compiled into a release binary (gzipped by the build script) and answered from the app's own protocol, `artoasset://localhost`. A debug build reads the same two files from the source tree, so the development loop is untouched. The icon sprite, the welcome header and the About logo are carried differently — inline markup and `data:` URLs — for reasons noted in the commits.
- `asset!` is gone. The app renders documents with `Deferred` images and serves them itself over `/img/<id>`, from a process-wide registry a render fills in.
- A release now publishes the app as a single executable for Linux and Windows, alongside the existing packages.

## Why

A build of Arto was never one file. `asset!` embeds a hashed path rather than the file it names, and putting the file where that path resolves is the bundler's job — so a binary from a plain `cargo build` had a stylesheet and a script that answered 404, and a welcome page whose template read panicked on startup. Only the installers worked, and only because they build the directory layout the resolver walks.

Serving user images over the same protocol is the second half of it, and it pays for itself separately. Inlining costs the bytes twice over — once base64 in the HTML the app builds, once again in the document the WebView parsed — and a page of screenshots pays that on every re-render. What the reader sees is unchanged; the WebView now caches each image across renders instead of decoding it out of a string.

Which images may be read is decided by the registry, not by the URL: a render hands over the images it referenced and nothing else is servable, so an id nobody registered is a 404 and no URL can name an arbitrary file. The id hashes the path together with the file's size and mtime, so an edited image becomes a different URL — which matters because the app reloads a document when its file changes, and a stable URL would let the WebView answer from cache with the bytes the reader just replaced.

## What to look at

- `crates/arto/src/assets.rs` — why a protocol rather than markup, and why the host is `localhost` (mixed content, not secure context).
- `crates/arto/src/assets/images.rs` — the registry, and why entries are only ever added.
- `crates/arto-markdown/src/post_process.rs` — a srcset candidate that is empty or over the size bound is still dropped by the render, because the host answering the URL is far too late to drop it.
- `frontend/vite.config.ts` — the app bundle consumer is narrowed to what the binary actually carries.

## Test Plan

- [x] `just fmt check test`
- [x] macOS: a release binary launches from a directory with nothing beside it — styles, icons and the welcome page all render
- [x] Icons: the sprite is inlined into every window's document, with a test asserting it
- [x] Images: rendering, the image window, and copy (copy was broken before this branch too; fixed separately in #257)
- [x] `arto-markdown` snapshots unchanged
- [ ] Linux / Windows: the standalone binary renders (CI only runs it from an empty directory with `--version`)
- [ ] Windows: Mermaid still draws — the secure-context question the protocol raises
- [ ] macOS: the DMG and the Finder associations, and the Quick Look preview
- [ ] `arto page` output is still a self-contained single HTML file

Add the `ci:bundle` label to run the full bundle matrix, which covers most of the unchecked boxes.

## Left for later

- One `std::thread::spawn` per `/img/` request, unbounded. A document with a few hundred images fans out a few hundred short-lived threads at load. Correct, just wasteful.
- `images::data_url_for` does bounded (32 MB) but blocking I/O plus base64 on the UI thread, in `copy_image_from_src` and in `ImageWindow`'s effect. User-initiated and bounded, so a hitch rather than a hang; the fix restructures the async plumbing at both sites.
- Cross-origin dynamic `import()` of `main.js` is unverified on Linux WebKitGTK. Checking the standalone Linux binary covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S5iFuYMo5cY9QjeWSDWz5f

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/arto-app/codesmith/Arto/pr/258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791394194&installation_model_id=435827&pr_number=258&repository=arto-app%2FArto&return_to=https%3A%2F%2Fgithub.com%2Farto-app%2FArto%2Fpull%2F258&signature=c9faeadf8b93ce120d53da3505b732fae6aaf59ff8b779e388dc58e788757140"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->