### PR TITLE
feat: publish every crate to crates.io from the release

### DIFF
--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -138,13 +138,18 @@ jobs:
       # pwsh on Windows) rather than relying on Git Bash's perl on the
       # otherwise-native Windows leg.
       # Accepts the release tag as-is: a leading `v` is dropped here.
+      #
+      # Every 0.0.0 in the manifest, not just the `[workspace.package]` one:
+      # the members ask each other for the workspace version, and stamping
+      # only that line would leave them requiring ^0.0.0 from crates that had
+      # just become the release version — the workspace would stop resolving.
       - name: Set package version (Unix)
         if: inputs.version != '' && runner.os != 'Windows'
         env:
           VERSION: ${{ inputs.version }}
         run: |
           VERSION="${VERSION#v}"
-          perl -i -pe 's/^version = "0\.0\.0"/version = "'"${VERSION}"'"/' Cargo.toml
+          perl -i -pe 's/= "0\.0\.0"/= "'"${VERSION}"'"/g' Cargo.toml
           echo "${VERSION}" > crates/arto/VERSION
       - name: Set package version (Windows)
         if: inputs.version != '' && runner.os == 'Windows'
@@ -153,7 +158,7 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           $v = $env:VERSION -replace '^v', ''
-          (Get-Content Cargo.toml) -replace '^version = "0\.0\.0"', "version = `"$v`"" | Set-Content Cargo.toml
+          (Get-Content Cargo.toml) -replace '= "0\.0\.0"', "= `"$v`"" | Set-Content Cargo.toml
           Set-Content -NoNewline crates/arto/VERSION $v
       - run: just build
       # Refuse to publish a bundle that carries build-environment dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,8 @@
 name: "Release"
 
 # On a published GitHub release: bundle every leg with the release version,
-# attach the installers to the release, and tell the Homebrew tap.
+# attach the installers to the release, publish the crates, and tell the
+# Homebrew tap.
 
 on:
   release:
@@ -15,6 +16,64 @@ jobs:
     uses: ./.github/workflows/bundle.yml
     with:
       version: ${{ github.event.release.tag_name }}
+
+  # The crates at the version the installers carry. After `bundle`, because a
+  # published version can only be yanked, never replaced or corrected — so a
+  # release that could not even be built must not reach the registry.
+  #
+  # macOS because the verification build has to compile `arto`, and macOS
+  # needs no GTK/WebKit packages to do it.
+  #
+  # This job cannot make a crate that does not exist yet: crates.io only lets
+  # a trusted publisher be configured on a crate that is already there, so
+  # each name's first version was published by hand. See CONTRIBUTING.md.
+  publish:
+    needs: bundle
+    runs-on: blacksmith-6vcpu-macos-15
+    timeout-minutes: 45
+    # No registry token lives in this repository. crates.io trusts this
+    # workflow by name, and the action below exchanges GitHub's OIDC claim for
+    # a token that expires with the job — which is why `id-token: write` is
+    # here and why the trusted publisher on crates.io must name this file.
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-toolchain
+        with:
+          toolchain: native
+      # The same stamp the bundle legs apply, and for the same reason it has
+      # to cover every 0.0.0: a package on the registry has no `path` to fall
+      # back on, so what it says about the crates it depends on is all a
+      # consumer gets.
+      - name: Set package version
+        env:
+          VERSION: ${{ github.event.release.tag_name }}
+        run: |
+          VERSION="${VERSION#v}"
+          perl -i -pe 's/= "0\.0\.0"/= "'"${VERSION}"'"/g' Cargo.toml
+          echo "${VERSION}" > crates/arto/VERSION
+      # `arto` and `arto-page` name the frontend bundle in their `include`
+      # lists, and git does not track it — it is build output.
+      - run: just frontend::assets
+      # `--workspace` orders the members by their dependencies and waits for
+      # each to reach the index before the next one asks for it. The
+      # verification build is the point of not passing `--no-verify`: it is
+      # what proves each package actually carries the files its `include`
+      # list claims, which nothing else in CI checks.
+      #
+      # `--allow-dirty` because the two steps above deliberately leave the
+      # tree modified.
+      - name: Authenticate with crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@v1
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: cargo publish --workspace --allow-dirty
 
   release:
     needs: bundle

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,31 +147,51 @@ When updating by hand:
   nixpkgs must agree; check `nix develop -c dx --version` after
   `nix flake update`.
 
-## Publishing the Library Crates
+## Publishing to crates.io
 
-The version in git is always `0.0.0`; CI stamps the release version into
-the working copy at build time and never commits it. So a manual publish
-starts from the release tag and repeats that stamp locally:
+Publishing a release takes no action: the `publish` job in
+`.github/workflows/release.yml` runs on every published GitHub release and
+sends every member of the workspace — `arto` included — to crates.io at the
+release version.
+
+No registry token lives in this repository. The job authenticates with
+[Trusted Publishing]: crates.io is told which repository and workflow file it
+trusts, and `rust-lang/crates-io-auth-action` exchanges GitHub's OIDC claim
+for a token that expires when the job ends. That is what `id-token: write` on
+the job is for.
+
+### Version stamping
+
+The version in git is always `0.0.0`, and CI stamps the release tag into the
+working copy without ever committing it. The stamp replaces **every** `0.0.0`
+in the root `Cargo.toml`, not only the `[workspace.package]` one: the members
+ask each other for the workspace version, so stamping one line would leave
+them requiring `^0.0.0` from crates that had just become `X.Y.Z`, and the
+workspace would stop resolving at all.
+
+### A new crate name has to be published by hand once
+
+crates.io only lets a trusted publisher be configured on a crate that already
+exists, so the first version of each name cannot come from CI. To add a name
+to the registry:
 
 ```bash
 git checkout vX.Y.Z
-perl -i -pe 's/^version = "0\.0\.0"/version = "X.Y.Z"/' Cargo.toml
-just frontend::assets   # arto-page embeds the stylesheet and bundle
+perl -i -pe 's/= "0\.0\.0"/= "X.Y.Z"/g' Cargo.toml
+just frontend::assets   # arto and arto-page carry the bundle in their packages
+cargo publish --workspace --allow-dirty
 ```
 
-Then publish leaf first; each crate depends on the ones before it:
+`--workspace` orders the members by their dependencies and waits for each to
+reach the index before the next one asks for it, so nothing has to be
+sequenced by hand. `--allow-dirty` is for the two edits above; the
+verification build is worth the wait, because it is what proves each package
+carries the files its `include` list names.
 
-1. `arto-markdown`
-2. `arto-keybindings`
-3. `arto-config` (depends on the two above)
-4. `arto-ipc` (depends on `arto-config`)
-5. `arto-page` (depends on `arto-markdown` and `arto-config`; its
-   `include` list expects `crates/arto-page/assets/frontend/` to exist)
+Then, on each crate's settings page on crates.io, add a trusted publisher for
+this repository naming `release.yml`. From the next release on, the job does it.
 
-Path dependencies between the crates need a `version` next to `path` before
-`cargo publish` accepts them. The `arto` app itself carries
-`publish = false`: its assets are resolved next to the executable at
-runtime, so `cargo install` would produce a binary that cannot find them.
+[Trusted Publishing]: https://crates.io/docs/trusted-publishing
 
 ## Code Style
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,11 @@ members = ["crates/*"]
 # is cheap (the Quick Look static library is tiny) and keeps `dx` working.
 
 [workspace.package]
-# Stays 0.0.0 in git; CI stamps the release tag here before bundling
-# (see .github/workflows/bundle.yml and crates/arto/build.rs).
+# Stays 0.0.0 in git; CI stamps the release tag over every 0.0.0 in this file
+# before bundling and publishing (see .github/workflows/bundle.yml,
+# .github/workflows/release.yml and crates/arto/build.rs). Stamping only this
+# line would leave the members asking each other for ^0.0.0, which no longer
+# matches what they are — the workspace stops resolving at all.
 version = "0.0.0"
 authors = ["Alisue <lambdalisue@gmail.com>"]
 edition = "2021"
@@ -21,6 +24,17 @@ repository = "https://github.com/arto-app/Arto"
 # such as wry may still pull an older major alongside. Members reference these
 # with `<name>.workspace = true`.
 [workspace.dependencies]
+# The members, as they depend on each other. A `path` alone is enough to
+# build, but not to publish: what goes to the registry has to say which
+# released version it wants, and a version that lived in five manifests would
+# be five chances to forget one. It is the workspace version, so the release
+# patch that stamps `[workspace.package]` above stamps these in the same pass.
+arto-config = { path = "crates/arto-config", version = "0.0.0" }
+arto-ipc = { path = "crates/arto-ipc", version = "0.0.0" }
+arto-keybindings = { path = "crates/arto-keybindings", version = "0.0.0" }
+arto-markdown = { path = "crates/arto-markdown", version = "0.0.0" }
+arto-page = { path = "crates/arto-page", version = "0.0.0" }
+
 anyhow = "1.0.104"
 base64 = "0.23.1"
 clap = { version = "4.6.6", features = ["derive"] }

--- a/crates/arto-config/Cargo.toml
+++ b/crates/arto-config/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 
 [dependencies]
 # Sections owned by the crates that consume them.
-arto-keybindings = { path = "../arto-keybindings" }
-arto-markdown = { path = "../arto-markdown" }
+arto-keybindings.workspace = true
+arto-markdown.workspace = true
 dirs.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/arto-ipc/Cargo.toml
+++ b/crates/arto-ipc/Cargo.toml
@@ -14,7 +14,7 @@ repository.workspace = true
 # (and through it the Markdown and keybinding types) into the dependency
 # graph; that is accepted because any client of a running instance also
 # wants the user's configured default behavior, which lives in that crate.
-arto-config = { path = "../arto-config" }
+arto-config.workspace = true
 dirs.workspace = true
 interprocess = "2.4"
 serde.workspace = true

--- a/crates/arto-page/Cargo.toml
+++ b/crates/arto-page/Cargo.toml
@@ -36,8 +36,8 @@ ffi = []
 anyhow.workspace = true
 # The page honours the user's config.json (rendering options, default theme)
 # so `arto page` and Quick Look look like the app does.
-arto-config = { path = "../arto-config" }
-arto-markdown = { path = "../arto-markdown" }
+arto-config.workspace = true
+arto-markdown.workspace = true
 base64.workspace = true
 clap = { workspace = true, optional = true }
 sha2.workspace = true

--- a/crates/arto/Cargo.toml
+++ b/crates/arto/Cargo.toml
@@ -6,21 +6,33 @@ authors.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-# Assets are resolved next to the executable at run time, so a `cargo
-# install`ed binary would start without its stylesheet and bundle. Keep the
-# app off crates.io until the assets are embedded.
-publish = false
+# The frontend bundle under assets/frontend is build output copied in by the
+# frontend build (see frontend/vite.config.ts), so git ignores it and a
+# package would not carry it. A release binary compiles those two files in,
+# which is what makes `cargo install arto` produce something that runs; list
+# them so a package that lost them cannot be published.
+include = [
+  "src/**",
+  "build.rs",
+  "assets/Arto.png",
+  "assets/arto-header-welcome-dark.png",
+  "assets/arto-header-welcome-light.png",
+  "assets/welcome.md",
+  "assets/frontend/main.css",
+  "assets/frontend/main.js",
+  "assets/frontend/icons/tabler-sprite.svg",
+]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 anyhow.workspace = true
 arboard = "3.6.1"
-arto-config = { path = "../arto-config" }
-arto-ipc = { path = "../arto-ipc" }
-arto-keybindings = { path = "../arto-keybindings" }
-arto-markdown = { path = "../arto-markdown" }
-arto-page = { path = "../arto-page" }
+arto-config.workspace = true
+arto-ipc.workspace = true
+arto-keybindings.workspace = true
+arto-markdown.workspace = true
+arto-page.workspace = true
 base64.workspace = true
 dark-light = "3.0.0"
 chrono = { version = "0.4", features = ["serde"] }


### PR DESCRIPTION
Stacked on #258 — review that first; the base here is `feat/asset-protocol`.

## Summary

- `arto` loses `publish = false`. The reason it carried it — assets resolved next to the executable, so `cargo install arto` would produce a binary that cannot find its stylesheet — is what #258 removed.
- Dependencies between members move to `[workspace.dependencies]` with a version beside the path, so every crate is publishable and the version lives in one place.
- `arto` gains an `include` list naming the frontend bundle, which git ignores because it is build output.
- The release workflow publishes the whole workspace to crates.io via [Trusted Publishing]. No registry token is kept in this repository.

## Why

Nothing on crates.io is called `arto`, `arto-markdown`, `arto-config`, `arto-keybindings`, `arto-ipc` or `arto-page` today, and the app has just become a single binary — so `cargo install arto` can now mean what it says.

Publishing from the release rather than by hand is the part worth arguing for. A publish that has to be remembered drifts: the crates end up a release or two behind the installers, at versions nobody can line up against the tags. The release already knows the version and already gates on a build that succeeded.

Trusted Publishing rather than a `CARGO_REGISTRY_TOKEN` secret: crates.io is told which repository and workflow file it trusts, and `rust-lang/crates-io-auth-action` exchanges GitHub's OIDC claim for a token that expires with the job. There is no long-lived credential in this repository to leak or rotate.

The verification build is kept rather than skipped with `--no-verify`. It is the only thing in CI that proves a package actually carries the files its `include` list names, and a silently-wrong `include` list is the specific way this could publish a crate that compiles into something broken.

## A latent break this fixes

Giving the members versions turned the release version stamp into a correctness problem. `bundle.yml` replaced only `^version = "0.0.0"`, so the members would have gone on requiring `^0.0.0` from crates that had just become `X.Y.Z`:

```
error: failed to select a version for the requirement `arto-config = "^0.0.0"`
candidate versions found which didn't match: 9.9.9
```

That is not a publishing failure — the workspace stops resolving at all, so every bundle leg would have died on the next release tag. The stamp is now global, in the bash and the pwsh form alike.

## What still needs a human, once

crates.io only accepts a trusted publisher on a crate that already exists, so the first version of each name cannot come from CI. The procedure is in CONTRIBUTING.md; in short, from the release tag:

```sh
perl -i -pe 's/= "0\.0\.0"/= "X.Y.Z"/g' Cargo.toml
just frontend::assets
cargo publish --workspace --allow-dirty
```

Then add a trusted publisher for this repository naming `release.yml` on each crate's settings page. From the next release on, the job does it.

## Test Plan

- [x] `just fmt check test`, `just workflows`, `just docs`
- [x] `cargo publish --workspace --dry-run --allow-dirty` — all members package and verify, in dependency order
- [x] `cargo package --list -p arto` carries the frontend bundle, the sprite, the welcome template and the header images
- [x] The stamping failure above reproduced, then confirmed fixed by the global substitution
- [ ] The `publish` job itself, which cannot run until the crates exist and trust this workflow

[Trusted Publishing]: https://crates.io/docs/trusted-publishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S5iFuYMo5cY9QjeWSDWz5f

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/arto-app/codesmith/Arto/pr/259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791395060&installation_model_id=435827&pr_number=259&repository=arto-app%2FArto&return_to=https%3A%2F%2Fgithub.com%2Farto-app%2FArto%2Fpull%2F259&signature=544c60e0ca0a74827410ca15fab0e51f08b80ef93d0cd42d49355e9430dfb8c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->