### PR TITLE
fix: give the published crates a README, keywords and categories

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,27 +169,36 @@ ask each other for the workspace version, so stamping one line would leave
 them requiring `^0.0.0` from crates that had just become `X.Y.Z`, and the
 workspace would stop resolving at all.
 
-### A new crate name has to be published by hand once
+### Claiming a new name
 
 crates.io only lets a trusted publisher be configured on a crate that already
-exists, so the first version of each name cannot come from CI. To add a name
-to the registry:
+exists, so a name has to reach the registry once before CI can ever publish
+it. That first version is `0.0.0` — the version this repository already
+carries in git, so nothing needs stamping and no release has to be spent on
+it:
 
 ```bash
-git checkout vX.Y.Z
-perl -i -pe 's/= "0\.0\.0"/= "X.Y.Z"/g' Cargo.toml
 just frontend::assets   # arto and arto-page carry the bundle in their packages
 cargo publish --workspace --allow-dirty
 ```
 
 `--workspace` orders the members by their dependencies and waits for each to
 reach the index before the next one asks for it, so nothing has to be
-sequenced by hand. `--allow-dirty` is for the two edits above; the
-verification build is worth the wait, because it is what proves each package
-carries the files its `include` list names.
+sequenced by hand. `--allow-dirty` is for the bundle, which git ignores
+because it is build output. The verification build is worth the wait: it is
+what proves each package carries the files its `include` list names.
+
+`--exclude <name>` leaves out a crate the registry already carries at `0.0.0`
+— what crates.io has, not what the working tree says, since every member in
+git reads `0.0.0` whether it was ever published or not. There is no
+`--skip-existing`, so a run that stopped partway is resumed by excluding the
+members that did get through.
 
 Then, on each crate's settings page on crates.io, add a trusted publisher for
-this repository naming `release.yml`. From the next release on, the job does it.
+this repository naming `release.yml`. From the next release on, the job does
+it, and `0.0.0` is superseded by the first real version — which is also when
+the registry page starts showing the README, keywords and categories, since
+crates.io renders the latest version's metadata.
 
 [Trusted Publishing]: https://crates.io/docs/trusted-publishing
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,13 @@ authors = ["Alisue <lambdalisue@gmail.com>"]
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/arto-app/Arto"
+homepage = "https://arto-app.github.io"
+# The repository README, which every member shows on its registry page. There
+# is no per-crate README: what a reader of any of these wants first is what
+# Arto is, and a stub saying "part of Arto, see the repository" would be a
+# worse answer than the page it points at. Resolved from the workspace root,
+# and copied into each package.
+readme = "README.md"
 
 # Versions for crates used by more than one member live here so the members
 # cannot drift apart again (arto and the Quick Look crate once declared different `sha2`

--- a/crates/arto-config/Cargo.toml
+++ b/crates/arto-config/Cargo.toml
@@ -6,6 +6,10 @@ authors.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+keywords = ["config", "markdown", "settings"]
+categories = ["config"]
 
 [dependencies]
 # Sections owned by the crates that consume them.

--- a/crates/arto-ipc/Cargo.toml
+++ b/crates/arto-ipc/Cargo.toml
@@ -6,6 +6,10 @@ authors.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+keywords = ["ipc", "single-instance", "socket"]
+categories = ["os", "network-programming"]
 
 [dependencies]
 # `FileOpenBehavior` travels on the wire exactly as it is spelled in

--- a/crates/arto-keybindings/Cargo.toml
+++ b/crates/arto-keybindings/Cargo.toml
@@ -6,6 +6,10 @@ authors.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+keywords = ["keybindings", "shortcuts", "keyboard", "gui"]
+categories = ["gui", "config"]
 
 [dependencies]
 # The same crate Dioxus and muda re-export their `Key`, `Code` and

--- a/crates/arto-markdown/Cargo.toml
+++ b/crates/arto-markdown/Cargo.toml
@@ -6,6 +6,10 @@ authors.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+keywords = ["markdown", "html", "github", "renderer", "commonmark"]
+categories = ["text-processing"]
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/arto-page/Cargo.toml
+++ b/crates/arto-page/Cargo.toml
@@ -6,6 +6,10 @@ authors.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+keywords = ["markdown", "html", "github", "renderer", "cli"]
+categories = ["text-processing", "command-line-utilities"]
 # The frontend bundle under assets/ is build output copied in by the frontend
 # build (see frontend/vite.config.ts); list it so a package cannot be
 # published without it.

--- a/crates/arto/Cargo.toml
+++ b/crates/arto/Cargo.toml
@@ -6,6 +6,10 @@ authors.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+keywords = ["markdown", "viewer", "github", "desktop", "dioxus"]
+categories = ["gui", "text-processing"]
 # The frontend bundle under assets/frontend is build output copied in by the
 # frontend build (see frontend/vite.config.ts), so git ignores it and a
 # package would not carry it. A release binary compiles those two files in,


### PR DESCRIPTION
Follow-up to #259, which shipped crates that publish correctly and land on a registry page with nothing on it.

## Summary

- Every crate gains `readme`, `homepage`, `keywords` and `categories`. The README is the repository's own, shared by all of them via `[workspace.package]`.
- CONTRIBUTING.md's "claim a name" procedure is corrected: it described checking out a release tag, and no tag can work.

## Why

`cargo publish` accepts a package with a description and nothing else, and that is exactly what went to crates.io: no README, no keywords, no categories. A visitor is told the crate's name and left there, and search never sends anyone in the first place. The names are already reserved at `0.0.0` with that emptiness — the registry shows the newest version's metadata, so the first real release fixes every page, and `0.0.0` stays bare where nobody looks.

A per-crate README stub would have been worse than the page it points at: what a reader of `arto-ipc` or `arto-markdown` wants first is what Arto is. Cargo copies the shared one into each package even where an `include` list would otherwise have dropped it — verified, since `arto` and `arto-page` both have one.

Categories come from the registry's own list rather than from invention. An unknown slug is refused at upload and `--dry-run` never sees it, so guessing would have failed at the worst moment.

| crate | keywords | categories |
| --- | --- | --- |
| `arto` | markdown, viewer, github, desktop, dioxus | gui, text-processing |
| `arto-markdown` | markdown, html, github, renderer, commonmark | text-processing |
| `arto-page` | markdown, html, github, renderer, cli | text-processing, command-line-utilities |
| `arto-keybindings` | keybindings, shortcuts, keyboard, gui | gui, config |
| `arto-config` | config, markdown, settings | config |
| `arto-ipc` | ipc, single-instance, socket | os, network-programming |

## The docs correction

The procedure told you to `git checkout vX.Y.Z` and stamp a version in. Every existing tag predates the manifests `cargo publish` will accept — `v0.33.1` still carries `publish = false` on `arto` — so the one case it was written for was the one it could not do.

Claiming a name needs no release. The version in git is `0.0.0`, which the registry takes, so a name is reserved from the branch as it stands and the first real version supersedes it. That also removes the release this was going to cost: there is no longer an ordering in which the publish job must fail once before it can start working, and the section that told you to expect a red leg is gone.

## Test Plan

- [x] `just fmt check test`, `just docs`
- [x] `cargo publish --workspace --dry-run --allow-dirty` — clean
- [x] `cargo package --list` carries `README.md` for `arto` and `arto-page` (the two with `include` lists) as well as for a crate without one
- [x] Category slugs taken from `GET /api/v1/categories`; keyword counts and lengths within the registry's limits
- [ ] The pages themselves, which cannot be seen until a release publishes a version above `0.0.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S5iFuYMo5cY9QjeWSDWz5f

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/arto-app/codesmith/Arto/pr/261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791398348&installation_model_id=435827&pr_number=261&repository=arto-app%2FArto&return_to=https%3A%2F%2Fgithub.com%2Farto-app%2FArto%2Fpull%2F261&signature=25d00e320327891aaa96fe8e867e2bd7dd7f6eb7aac0c8510a70c049693df177"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->