### PR TITLE
Add --behind to open without pulling Arto forward

### DIFF
--- a/.claude/rules/ipc.md
+++ b/.claude/rules/ipc.md
@@ -13,10 +13,14 @@ Arto runs as one process. A newly launched process:
 Protocol (JSON Lines):
 
 ```json
-{"type":"open","files":["/path/to/file.md"],"directory":null,"behavior":"last_focused"}
-{"type":"open","files":[],"directory":"/path/to/dir","behavior":"new_window"}
-{"type":"reopen","behavior":"last_focused"}
+{"type":"open","files":["/path/to/file.md"],"directory":null,"behavior":"last_focused","behind":false}
+{"type":"open","files":[],"directory":"/path/to/dir","behavior":"new_window","behind":true}
+{"type":"reopen","behavior":"last_focused","behind":false}
 ```
+
+`behind` (from `arto --behind`) tells the primary to apply the request
+without activating itself or moving the focus; it defaults to `false` when
+a message omits it.
 
 The older `file` and `directory` messages are still accepted from a
 not-yet-upgraded secondary instance.

--- a/crates/arto-ipc/src/lib.rs
+++ b/crates/arto-ipc/src/lib.rs
@@ -28,13 +28,14 @@
 //! by the secondary instance and read by the primary:
 //!
 //! ```json
-//! {"type":"open","files":["/path/to/file.md"],"directory":null,"behavior":"last_focused"}
-//! {"type":"open","files":[],"directory":"/path/to/dir","behavior":"new_window"}
-//! {"type":"reopen","behavior":"last_focused"}
+//! {"type":"open","files":["/path/to/file.md"],"directory":null,"behavior":"last_focused","behind":false}
+//! {"type":"open","files":[],"directory":"/path/to/dir","behavior":"new_window","behind":true}
+//! {"type":"reopen","behavior":"last_focused","behind":false}
 //! ```
 //!
 //! The older `file` and `directory` messages are still accepted so a
-//! freshly upgraded primary understands a not-yet-upgraded secondary.
+//! freshly upgraded primary understands a not-yet-upgraded secondary, and
+//! `behind` defaults to `false` when a message omits it.
 //!
 //! # Socket location
 //!

--- a/crates/arto-ipc/src/protocol.rs
+++ b/crates/arto-ipc/src/protocol.rs
@@ -11,6 +11,10 @@ pub struct OpenRequest {
     /// Which window should receive the request; `None` leaves the choice
     /// to the running instance's configuration.
     pub behavior: Option<FileOpenBehavior>,
+    /// Leave the frontmost app frontmost: apply the request without
+    /// activating Arto or moving the keyboard focus.
+    #[serde(default)]
+    pub behind: bool,
 }
 
 /// A request in the form the running instance handles: the wire messages,
@@ -21,7 +25,10 @@ pub enum OpenEvent {
     Open(OpenRequest),
     /// Bring the app forward without opening anything (app icon clicked,
     /// or a launch with no paths).
-    Reopen { behavior: Option<FileOpenBehavior> },
+    Reopen {
+        behavior: Option<FileOpenBehavior>,
+        behind: bool,
+    },
 }
 
 /// One line of the JSON Lines protocol.
@@ -44,11 +51,15 @@ pub enum IpcMessage {
         files: Vec<PathBuf>,
         directory: Option<PathBuf>,
         behavior: Option<FileOpenBehavior>,
+        #[serde(default)]
+        behind: bool,
     },
     /// Reopen/activate the application (no paths provided).
     Reopen {
         #[serde(default)]
         behavior: Option<FileOpenBehavior>,
+        #[serde(default)]
+        behind: bool,
     },
 }
 
@@ -60,22 +71,26 @@ impl IpcMessage {
                 files: vec![path],
                 directory: None,
                 behavior: None,
+                behind: false,
             }),
             IpcMessage::Directory { path } => OpenEvent::Open(OpenRequest {
                 files: Vec::new(),
                 directory: Some(path),
                 behavior: None,
+                behind: false,
             }),
             IpcMessage::Open {
                 files,
                 directory,
                 behavior,
+                behind,
             } => OpenEvent::Open(OpenRequest {
                 files,
                 directory,
                 behavior,
+                behind,
             }),
-            IpcMessage::Reopen { behavior } => OpenEvent::Reopen { behavior },
+            IpcMessage::Reopen { behavior, behind } => OpenEvent::Reopen { behavior, behind },
         }
     }
 }
@@ -87,8 +102,9 @@ impl From<OpenEvent> for IpcMessage {
                 files: request.files,
                 directory: request.directory,
                 behavior: request.behavior,
+                behind: request.behind,
             },
-            OpenEvent::Reopen { behavior } => IpcMessage::Reopen { behavior },
+            OpenEvent::Reopen { behavior, behind } => IpcMessage::Reopen { behavior, behind },
         }
     }
 }
@@ -128,11 +144,12 @@ mod tests {
             files: vec![PathBuf::from("/path/to/file.md")],
             directory: Some(PathBuf::from("/path/to/dir")),
             behavior: Some(FileOpenBehavior::LastFocused),
+            behind: false,
         };
         let json = serde_json::to_string(&msg).unwrap();
         assert_eq!(
             json,
-            r#"{"type":"open","files":["/path/to/file.md"],"directory":"/path/to/dir","behavior":"last_focused"}"#
+            r#"{"type":"open","files":["/path/to/file.md"],"directory":"/path/to/dir","behavior":"last_focused","behind":false}"#
         );
     }
 
@@ -140,14 +157,18 @@ mod tests {
     fn reopen_serializes_with_type_tag() {
         let msg = IpcMessage::Reopen {
             behavior: Some(FileOpenBehavior::LastFocused),
+            behind: false,
         };
         let json = serde_json::to_string(&msg).unwrap();
-        assert_eq!(json, r#"{"type":"reopen","behavior":"last_focused"}"#);
+        assert_eq!(
+            json,
+            r#"{"type":"reopen","behavior":"last_focused","behind":false}"#
+        );
     }
 
     #[test]
     fn open_deserializes() {
-        let json = r#"{"type":"open","files":["/path/to/file.md"],"directory":"/path/to/dir","behavior":"last_focused"}"#;
+        let json = r#"{"type":"open","files":["/path/to/file.md"],"directory":"/path/to/dir","behavior":"last_focused","behind":true}"#;
         let msg: IpcMessage = serde_json::from_str(json).unwrap();
         assert_eq!(
             msg,
@@ -155,6 +176,24 @@ mod tests {
                 files: vec![PathBuf::from("/path/to/file.md")],
                 directory: Some(PathBuf::from("/path/to/dir")),
                 behavior: Some(FileOpenBehavior::LastFocused),
+                behind: true,
+            }
+        );
+    }
+
+    #[test]
+    fn open_without_behind_opens_in_front() {
+        let open: IpcMessage = serde_json::from_str(
+            r#"{"type":"open","files":["/a.md"],"directory":null,"behavior":null}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            open,
+            IpcMessage::Open {
+                files: vec![PathBuf::from("/a.md")],
+                directory: None,
+                behavior: None,
+                behind: false,
             }
         );
     }
@@ -166,12 +205,19 @@ mod tests {
         assert_eq!(
             msg,
             IpcMessage::Reopen {
-                behavior: Some(FileOpenBehavior::LastFocused)
+                behavior: Some(FileOpenBehavior::LastFocused),
+                behind: false,
             }
         );
 
         let legacy: IpcMessage = serde_json::from_str(r#"{"type":"reopen"}"#).unwrap();
-        assert_eq!(legacy, IpcMessage::Reopen { behavior: None });
+        assert_eq!(
+            legacy,
+            IpcMessage::Reopen {
+                behavior: None,
+                behind: false,
+            }
+        );
     }
 
     #[test]
@@ -206,6 +252,7 @@ mod tests {
                 files: vec![PathBuf::from("/tmp/a.md")],
                 directory: None,
                 behavior: None,
+                behind: false,
             })
         );
         assert_eq!(
@@ -217,6 +264,7 @@ mod tests {
                 files: Vec::new(),
                 directory: Some(PathBuf::from("/tmp/docs")),
                 behavior: None,
+                behind: false,
             })
         );
         assert_eq!(
@@ -224,21 +272,25 @@ mod tests {
                 files: vec![PathBuf::from("/test.md")],
                 directory: Some(PathBuf::from("/test/dir")),
                 behavior: Some(FileOpenBehavior::CurrentScreen),
+                behind: true,
             }
             .into_open_event(),
             OpenEvent::Open(OpenRequest {
                 files: vec![PathBuf::from("/test.md")],
                 directory: Some(PathBuf::from("/test/dir")),
                 behavior: Some(FileOpenBehavior::CurrentScreen),
+                behind: true,
             })
         );
         assert_eq!(
             IpcMessage::Reopen {
-                behavior: Some(FileOpenBehavior::LastFocused)
+                behavior: Some(FileOpenBehavior::LastFocused),
+                behind: true,
             }
             .into_open_event(),
             OpenEvent::Reopen {
-                behavior: Some(FileOpenBehavior::LastFocused)
+                behavior: Some(FileOpenBehavior::LastFocused),
+                behind: true,
             }
         );
     }
@@ -250,8 +302,22 @@ mod tests {
                 files: vec![PathBuf::from("/a.md")],
                 directory: Some(PathBuf::from("/dir")),
                 behavior: Some(FileOpenBehavior::NewWindow),
+                behind: false,
             }),
-            OpenEvent::Reopen { behavior: None },
+            OpenEvent::Open(OpenRequest {
+                files: vec![PathBuf::from("/a.md")],
+                directory: None,
+                behavior: None,
+                behind: true,
+            }),
+            OpenEvent::Reopen {
+                behavior: None,
+                behind: false,
+            },
+            OpenEvent::Reopen {
+                behavior: None,
+                behind: true,
+            },
         ];
         for event in events {
             let json = serde_json::to_string(&IpcMessage::from(event.clone())).unwrap();
@@ -263,9 +329,9 @@ mod tests {
     #[test]
     fn json_lines_parse_one_message_per_line() {
         let input = indoc! {r#"
-            {"type":"open","files":["/file1.md"],"directory":null,"behavior":"last_focused"}
-            {"type":"open","files":[],"directory":"/dir","behavior":"new_window"}
-            {"type":"reopen","behavior":"current_screen"}
+            {"type":"open","files":["/file1.md"],"directory":null,"behavior":"last_focused","behind":false}
+            {"type":"open","files":[],"directory":"/dir","behavior":"new_window","behind":true}
+            {"type":"reopen","behavior":"current_screen","behind":false}
         "#};
 
         let messages: Vec<IpcMessage> = input
@@ -281,14 +347,17 @@ mod tests {
                     files: vec![PathBuf::from("/file1.md")],
                     directory: None,
                     behavior: Some(FileOpenBehavior::LastFocused),
+                    behind: false,
                 },
                 IpcMessage::Open {
                     files: Vec::new(),
                     directory: Some(PathBuf::from("/dir")),
                     behavior: Some(FileOpenBehavior::NewWindow),
+                    behind: true,
                 },
                 IpcMessage::Reopen {
                     behavior: Some(FileOpenBehavior::CurrentScreen),
+                    behind: false,
                 },
             ]
         );

--- a/crates/arto/src/cli.rs
+++ b/crates/arto/src/cli.rs
@@ -25,4 +25,6 @@ pub struct CliInvocation {
     pub paths: Vec<PathBuf>,
     pub directory: Option<PathBuf>,
     pub open_mode: CliOpenMode,
+    /// Open without activating Arto, leaving the keyboard focus where it is.
+    pub behind: bool,
 }

--- a/crates/arto/src/ipc.rs
+++ b/crates/arto/src/ipc.rs
@@ -226,9 +226,9 @@ fn handle_event_on_main_thread(
             tracing::debug!(?request, "Processing open request event");
             open_request_with_behavior(desktop, request);
         }
-        OpenEvent::Reopen { behavior } => {
-            tracing::debug!(?behavior, "Processing reopen event");
-            reopen_with_behavior(desktop, behavior);
+        OpenEvent::Reopen { behavior, behind } => {
+            tracing::debug!(?behavior, behind, "Processing reopen event");
+            reopen_with_behavior(desktop, behavior, behind);
         }
     }
 }
@@ -244,13 +244,16 @@ fn open_request_with_behavior(
     if let Some(window_id) = select_target_window_with_behavior(behavior) {
         if let Some(mut state) = crate::window::main::get_window_state(window_id) {
             apply_open_request_to_state(&mut state, &request);
-            let _ = crate::window::main::focus_window(window_id);
+            if !request.behind {
+                let _ = crate::window::main::focus_window(window_id);
+            }
             return;
         }
     }
 
     let params = crate::window::CreateMainWindowConfigParams {
         directory: request.directory,
+        focused: !request.behind,
         ..Default::default()
     };
 
@@ -279,7 +282,16 @@ fn apply_open_request_to_state(state: &mut crate::state::AppState, request: &Ope
 fn reopen_with_behavior(
     desktop: &std::rc::Rc<dioxus::desktop::DesktopService>,
     behavior: Option<crate::config::FileOpenBehavior>,
+    behind: bool,
 ) {
+    // A reopen asks for the app to come forward, which is the one thing
+    // `--behind` refuses to do: every window, visible or hidden, is left
+    // exactly as it is. Events are only dispatched once a window exists, so
+    // there is never one to create here either.
+    if behind {
+        return;
+    }
+
     let target_window = match behavior {
         Some(behavior) => select_target_window_with_behavior(behavior),
         None => select_target_window(),
@@ -324,13 +336,18 @@ mod tests {
             files: vec![PathBuf::from("/first.md")],
             directory: None,
             behavior: None,
+            behind: false,
         }));
         push_event(OpenEvent::Open(OpenRequest {
             files: Vec::new(),
             directory: Some(PathBuf::from("/second")),
             behavior: None,
+            behind: false,
         }));
-        push_event(OpenEvent::Reopen { behavior: None });
+        push_event(OpenEvent::Reopen {
+            behavior: None,
+            behind: false,
+        });
 
         // try_pop_first_event returns FIFO order
         let first = try_pop_first_event();
@@ -350,7 +367,10 @@ mod tests {
         ));
         assert!(matches!(
             &remaining[1],
-            OpenEvent::Reopen { behavior: None }
+            OpenEvent::Reopen {
+                behavior: None,
+                behind: false
+            }
         ));
 
         // Queue is empty after drain

--- a/crates/arto/src/ipc/request.rs
+++ b/crates/arto/src/ipc/request.rs
@@ -16,6 +16,7 @@ pub fn open_event_for_invocation(invocation: &CliInvocation) -> OpenEvent {
         Some(request) => OpenEvent::Open(request),
         None => OpenEvent::Reopen {
             behavior: invocation.open_mode.to_file_open_behavior(),
+            behind: invocation.behind,
         },
     }
 }
@@ -54,23 +55,27 @@ pub fn build_open_request(invocation: &CliInvocation) -> Option<OpenRequest> {
         files,
         directory,
         behavior: invocation.open_mode.to_file_open_behavior(),
+        behind: invocation.behind,
     })
 }
 
 /// Validate and categorize a path from non-CLI sources (e.g., Finder).
 ///
-/// Finder events do not override `fileOpen`, so behavior is `None`.
+/// Finder events do not override `fileOpen`, so behavior is `None`. Opening
+/// from Finder is a request to read the file now, so the window comes forward.
 pub fn validate_path(path: impl AsRef<Path>) -> Option<OpenEvent> {
     match classify_path(path.as_ref()) {
         Some(PathKind::File(canonical)) => Some(OpenEvent::Open(OpenRequest {
             files: vec![canonical],
             directory: None,
             behavior: None,
+            behind: false,
         })),
         Some(PathKind::Directory(canonical)) => Some(OpenEvent::Open(OpenRequest {
             files: Vec::new(),
             directory: Some(canonical),
             behavior: None,
+            behind: false,
         })),
         None => {
             tracing::warn!(
@@ -114,6 +119,7 @@ mod tests {
             paths: vec![directory.clone(), file.clone()],
             directory: None,
             open_mode: CliOpenMode::LastFocused,
+            behind: false,
         };
 
         let request = build_open_request(&invocation).unwrap();
@@ -134,6 +140,7 @@ mod tests {
             paths: vec![positional_directory.clone()],
             directory: Some(option_directory.clone()),
             open_mode: CliOpenMode::LastFocused,
+            behind: false,
         };
 
         let request = build_open_request(&invocation).unwrap();
@@ -154,10 +161,46 @@ mod tests {
             paths: vec![file],
             directory: None,
             open_mode: CliOpenMode::CurrentScreen,
+            behind: false,
         };
 
         let request = build_open_request(&invocation).unwrap();
         assert_eq!(request.behavior, Some(FileOpenBehavior::CurrentScreen));
+    }
+
+    #[test]
+    fn build_open_request_carries_behind() {
+        let temp = tempfile::tempdir().unwrap();
+        let file = temp.path().join("README.md");
+        std::fs::write(&file, "# test").unwrap();
+
+        let invocation = CliInvocation {
+            paths: vec![file],
+            directory: None,
+            open_mode: CliOpenMode::Config,
+            behind: true,
+        };
+
+        let request = build_open_request(&invocation).unwrap();
+        assert!(request.behind);
+    }
+
+    #[test]
+    fn open_event_for_invocation_carries_behind_into_reopen() {
+        let invocation = CliInvocation {
+            paths: Vec::new(),
+            directory: None,
+            open_mode: CliOpenMode::Config,
+            behind: true,
+        };
+
+        assert_eq!(
+            open_event_for_invocation(&invocation),
+            OpenEvent::Reopen {
+                behavior: None,
+                behind: true,
+            }
+        );
     }
 
     #[test]
@@ -170,6 +213,7 @@ mod tests {
             paths: vec![file],
             directory: None,
             open_mode: CliOpenMode::Config,
+            behind: false,
         };
 
         let request = build_open_request(&invocation).unwrap();
@@ -182,12 +226,14 @@ mod tests {
             paths: Vec::new(),
             directory: None,
             open_mode: CliOpenMode::NewWindow,
+            behind: false,
         };
 
         assert_eq!(
             open_event_for_invocation(&invocation),
             OpenEvent::Reopen {
-                behavior: Some(FileOpenBehavior::NewWindow)
+                behavior: Some(FileOpenBehavior::NewWindow),
+                behind: false,
             }
         );
     }

--- a/crates/arto/src/lib.rs
+++ b/crates/arto/src/lib.rs
@@ -66,7 +66,10 @@ pub fn run(invocation: cli::CliInvocation) -> RunResult {
     // let menu = menu::build_menu();
 
     // Get window parameters for first window from preferences
-    let params = window::CreateMainWindowConfigParams::from_preferences(true);
+    let params = window::CreateMainWindowConfigParams {
+        focused: !invocation.behind,
+        ..window::CreateMainWindowConfigParams::from_preferences(true)
+    };
 
     let config = window::create_main_window_config(&params).with_custom_event_handler(
         move |event, _target| {
@@ -95,7 +98,10 @@ pub fn run(invocation: cli::CliInvocation) -> RunResult {
                 Event::Reopen { .. } => {
                     // Handle dock click / app activation
                     tracing::debug!("Event::Reopen received (dock click or app activation)");
-                    ipc::push_event(ipc::OpenEvent::Reopen { behavior: None });
+                    ipc::push_event(ipc::OpenEvent::Reopen {
+                        behavior: None,
+                        behind: false,
+                    });
                     ipc::process_main_thread_tasks();
                 }
                 Event::WindowEvent {
@@ -126,6 +132,21 @@ pub fn run(invocation: cli::CliInvocation) -> RunResult {
     let config = config.with_menu(crate::menu::build_menu());
     #[cfg(target_os = "windows")]
     let config = config.with_menu(None);
+
+    // Tao activates the app as soon as it finishes launching. `--behind` has
+    // to own the event loop to turn that off, so the launch leaves whatever
+    // the user was working in frontmost.
+    #[cfg(target_os = "macos")]
+    let config = if invocation.behind {
+        use dioxus::desktop::tao::event_loop::EventLoopBuilder;
+        use dioxus::desktop::tao::platform::macos::EventLoopExtMacOS;
+
+        let mut event_loop = EventLoopBuilder::with_user_event().build();
+        event_loop.set_activate_ignoring_other_apps(false);
+        config.with_event_loop(event_loop)
+    } else {
+        config
+    };
 
     // Launch MainApp (first window only)
     // MainApp pops the first CLI event from IPC queue for its initial tab.

--- a/crates/arto/src/main.rs
+++ b/crates/arto/src/main.rs
@@ -32,6 +32,7 @@ enum OpenModeArg {
         \x20 arto README.md           Open a specific file\n\
         \x20 arto --open=screen README.md\n\
         \x20 arto --open=new README.md\n\
+        \x20 arto --behind README.md  Open without taking the focus\n\
         \x20 arto --directory=. README.md\n\
         \x20 arto docs/               Open a directory in the file explorer\n\
         \x20 arto file1.md file2.md   Open multiple files in tabs\n\
@@ -47,6 +48,9 @@ struct Cli {
     /// Open target selection mode (default: use fileOpen setting from config.json)
     #[arg(long, value_enum)]
     open: Option<OpenModeArg>,
+    /// Open without activating Arto, leaving the focus where it is
+    #[arg(long)]
+    behind: bool,
     /// Root directory for the file explorer sidebar
     #[arg(long)]
     directory: Option<PathBuf>,
@@ -116,6 +120,7 @@ fn main() {
         paths: cli.paths,
         directory: cli.directory,
         open_mode,
+        behind: cli.behind,
     };
 
     if let arto::RunResult::SentToExistingInstance = arto::run(invocation) {

--- a/crates/arto/src/window/main.rs
+++ b/crates/arto/src/window/main.rs
@@ -37,7 +37,15 @@ pub fn create_main_window_config(params: &CreateMainWindowConfigParams) -> Confi
             WindowBuilder::new()
                 .with_title("Arto")
                 .with_position(params.position)
-                .with_inner_size(params.size),
+                .with_inner_size(params.size)
+                // An unfocused window is ordered in without being made key.
+                // tao applies this only to a window it creates visible, so the
+                // launch window — which dioxus builds hidden — never sees it;
+                // and it is not the last word for the others either, because
+                // dioxus shows every window again once its webview reports
+                // ready, and on macOS that show makes the window key. Keeping
+                // the app itself inactive is what holds the keyboard focus.
+                .with_focused(params.focused),
         ))
         // Dioxus/tao can lose the requested inner height on macOS during window
         // construction, so apply the same size once the native window exists.
@@ -70,6 +78,9 @@ pub struct CreateMainWindowConfigParams {
     /// Skip position shifting for overlap avoidance.
     /// Used for preview windows during drag where exact cursor-relative position is required.
     pub skip_position_shift: bool,
+    /// Take the keyboard focus once the window exists. `arto --behind` clears
+    /// it so the window can appear without interrupting what the user is doing.
+    pub focused: bool,
 }
 
 impl CreateMainWindowConfigParams {
@@ -101,6 +112,7 @@ impl CreateMainWindowConfigParams {
             size: size_pref.size,
             position: position_pref.position,
             skip_position_shift: false,
+            focused: true,
         }
     }
 }
@@ -141,6 +153,20 @@ pub fn list_visible_main_windows() -> Vec<Rc<DesktopService>> {
 }
 
 pub fn register_main_window(handle: WeakDesktopContext) {
+    // A window that never takes the focus never reports one, so seed
+    // `LAST_FOCUSED_WINDOW` with the first window that registers. Without it
+    // a window opened behind the frontmost app is invisible to
+    // `FileOpenBehavior::LastFocused` and to reopen handling, both of which
+    // would then create a duplicate window instead of reusing this one.
+    if let Some(context) = handle.upgrade() {
+        LAST_FOCUSED_WINDOW.with(|last| {
+            let mut last = last.borrow_mut();
+            if last.is_none() {
+                *last = Some(context.window.id());
+            }
+        });
+    }
+
     MAIN_WINDOWS.with(|windows| {
         let mut windows = windows.borrow_mut();
         windows.retain(|w| w.upgrade().is_some());

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -28,7 +28,25 @@ the request to the existing process rather than starting a second one.
 | *(none)* | Reuses the last focused visible window. Without arguments, shows or focuses an existing window, or opens one if there is none. |
 | `--open=screen` | Opens on — or reuses — a window on the screen the cursor is on. |
 | `--open=new` | Always opens a new window. |
+| `--behind` | Opens without activating Arto, leaving the keyboard focus where it is. |
 | `--directory=DIR` | Sets the file explorer's root for that invocation. A positional directory (`arto docs/`) does the same. |
+
+`--behind` is for the hand-offs you did not stop to make — an editor or a
+script putting a file in front of you while you keep typing:
+
+```sh
+arto --behind README.md
+```
+
+A window that is already open takes the file where it stands, without being
+raised; a window that has to be created appears without Arto becoming the
+active application. What the flag protects is the application you are working
+in — when Arto is already the active application, a window it creates does
+take the focus from the Arto window you were reading. Keeping the application
+inactive is enforced on macOS; elsewhere a launch may still come forward.
+
+Without any paths, `arto --behind` does nothing when Arto is already running:
+bringing the app forward is exactly what the flag declines to do.
 
 ## Rendering a standalone page
 


### PR DESCRIPTION
## Summary

- Adds `arto --behind`: applies an open request without activating Arto or moving the keyboard focus.
- The single-instance protocol carries a `behind` field, defaulted on both sides so a message from either side of an upgrade still parses.
- A window that already exists takes the file where it stands; a window that has to be created is ordered in without becoming key; a reopen (`arto --behind` with no paths) leaves every window alone, since bringing the app forward is exactly what the flag declines to do.
- Window creation gained a `focused` parameter, and `LAST_FOCUSED_WINDOW` is now seeded when a window registers — an unfocused window never reports a focus event, so without that seeding every later open would miss it and pile up duplicate windows.

## Why

Handing a file to Arto is normally a request to read it now, so activating and taking the focus is the right default and stays the default. It is wrong for the hand-offs the user did not stop to make — an editor or a script showing a document while they keep typing — and there was no way to ask for that: every path opened through the CLI raised a window and moved the focus.

On the name: it says what happens rather than what is suppressed. `--background` was rejected because it reads as "run without showing a window", and `--no-focus` / `--no-activate` were rejected for being negative forms.

## Known limitation

`with_focused(false)` reaches tao only for windows created after start-up, and even there it is not the last word: dioxus-desktop 0.7.10 shows every window again once its webview reports ready (`App::handle_initialize_msg`), and on macOS that show is `makeKeyAndOrderFront:`. So when Arto is *already the frontmost application*, a window created by `--behind --open=new` still takes the focus from the Arto window you were reading. What holds the focus against *another* application — the case the flag exists for — is `set_activate_ignoring_other_apps(false)`, which is macOS-only. This wants an upstream issue against dioxus-desktop rather than a timing-dependent local workaround; the comment in `create_main_window_config` records the real mechanism and its limit.

## Test Plan

- [ ] `just fmt check test`
- [ ] Arto running behind the editor: `arto --behind README.md` opens the file in the existing window without raising it or moving the focus
- [ ] `arto --behind --open=new notes.md` from another app: the window appears, the focus stays put
- [ ] Cold start (Arto not running): `arto --behind README.md` launches without stealing the focus
- [ ] `arto --behind` with no paths does nothing while Arto is running
- [ ] Repeated `arto --behind` opens reuse the same window instead of piling up new ones
- [ ] Plain `arto README.md`, Finder double-click and dock click all still come forward and take the focus

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014dn1KXjcjdHFY63Wx8CCZk

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/arto-app/codesmith/Arto/pr/262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791400639&installation_model_id=435827&pr_number=262&repository=arto-app%2FArto&return_to=https%3A%2F%2Fgithub.com%2Farto-app%2FArto%2Fpull%2F262&signature=ef964a3c47602ec6e17d69d829f71935a337c7631376b5fc74e9bc854fa345f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->