### PR TITLE
chore(dev): sign the bundle `dx serve` builds on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ package-lock.json
 
 # Build-generated version file (CI only)
 crates/arto/VERSION
+
+# Playwright MCP writes its snapshots and console logs here.
+.playwright-mcp/

--- a/justfile
+++ b/justfile
@@ -50,7 +50,16 @@ dev:
   vite_pid=$!
   trap 'kill "$vite_pid" 2>/dev/null || true' EXIT
   cd "$root/crates/arto"
-  dx serve
+  # macOS will not launch an app bundle that carries no seal of its own, so
+  # the bundle `dx` assembles has to be signed with the same ad-hoc identity
+  # the release build uses. `platform/macos/bundle/dev.entitlements` says why
+  # it grants nothing.
+  if [ "$(uname -s)" = "Darwin" ]; then
+    dx serve --codesign true --apple-team-id=- \
+      --apple-entitlements "$root/platform/macos/bundle/dev.entitlements"
+  else
+    dx serve
+  fi
 
 build: frontend::assets arto::build
 

--- a/platform/macos/bundle/dev.entitlements
+++ b/platform/macos/bundle/dev.entitlements
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  No entitlements, on purpose.
+
+  macOS will not launch an app bundle that carries no seal of its own: the
+  binary's linker signature is not a bundle signature, and the kernel answers
+  the missing `_CodeSignature` with SIGKILL before `main` runs. `dx serve`
+  therefore has to sign the bundle it assembles, and `dx` insists on an
+  entitlements file when it is asked to. The release build signs with none
+  (`crates/arto/justfile`, `_embed-quicklook`), so the development build
+  claims none either — an entitlement granted here and not there would be a
+  capability that only ever works on the machine it was built on.
+-->
+<plist version="1.0">
+  <dict/>
+</plist>


### PR DESCRIPTION
## Summary

- `just dev` signs the bundle `dx serve` assembles, ad-hoc, on macOS.
- Adds `platform/macos/bundle/dev.entitlements`, which grants nothing on purpose.
- Keeps the browser tool's scratch output (`.playwright-mcp/`) out of the tree.

## Why

Playwright MCP writes page snapshots and console logs into `.playwright-mcp/` in whatever directory it is run from. They are a debugging session's leavings, not the repository's.

macOS will not launch an app bundle that carries no seal of its own: the executable's linker signature is not a bundle signature, and the kernel answers the missing `_CodeSignature` with SIGKILL before `main` runs. The development loop therefore died on launch on any machine where Gatekeeper was doing its job.

So `dx serve` signs what it assembles, ad-hoc, the way the release build does. `dx` insists on an entitlements file whenever it signs; that file claims nothing, because an entitlement granted in development and not in the release would be a capability that only ever works on the machine it was built on.

## Test Plan

- [ ] `just dev` launches the app on macOS instead of dying at startup
- [ ] `just fmt check test`

## Stack

These land in order; each is based on the one above it.

1. #265 — chore(dev): sign the bundle `dx serve` builds on macOS 👈 **this one**
2. #266 — feat(preferences): a window, not a tab
3. #267 — feat(window): one document to a window
4. #268 — feat(panel): several roots, and the folders you keep
5. #269 — feat(panel): one panel, three faces, and the history among them
6. #270 — feat(contents): the contents live beside the page
7. #271 — feat(header): the document's name is the way back, and one glyph opens the app
8. #272 — feat(search): find in the header, and the marks stay in the contents
9. #273 — feat(welcome): a window with nothing open says what there is to read
10. #274 — feat(layout): give way to the document
11. #275 — feat(keys): every list and every field answers to bindings
12. #276 — feat(recent): remember where a document was left, and open it there
13. #277 — feat(menu): give every menu row its icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01731Zfkg9P6V4Lm7buLEN53
