### PR TITLE
feat(preferences): a window, not a tab

### DIFF
--- a/.claude/rules/ui-design.md
+++ b/.claude/rules/ui-design.md
@@ -102,18 +102,25 @@ wrong in every theme but the one it was taken from.
 - All similar buttons must have matching sizes (padding, font-size, border-radius)
 - Use `color-mix(in srgb, var(--accent-bg) 8%, transparent)` for subtle selection backgrounds
 
-## In-Page Settings (Browser-Style)
+## Preferences is its own window
 
-**Prefer in-page settings over modal dialogs for preferences.**
+**Preferences is a window, not a tab and not a modal.**
 
-Settings should integrate with the tab system rather than blocking the UI with modals.
-This follows browser conventions (Chrome's `chrome://settings`, Firefox's `about:preferences`).
+Changing a setting is a short errand; a tab is where a document lives for as
+long as it is being read. Giving the errand a document's lifetime is what left
+a settings tab sitting open for days, so it gets a window that closes instead.
 
 ### Architecture
 
-- Add a `TabContent::Preferences` variant to the content enum
-- Implement `open_preferences()` method with tab deduplication (reuse existing preferences tab)
-- Use state-based navigation instead of broadcast channels for window-specific features
+- `window::preferences::open_or_focus_preferences_window` opens it, reusing the
+  child-window machinery in `window/child.rs`: one window at a time, focused
+  rather than duplicated, closed with its parent.
+- The window holds no `AppState`. What the "Current Settings" section reports
+  comes over as a `PreferencesSnapshot` taken when it opens, and what it
+  changes goes back through the `SET_*_ZOOM_IN_WINDOW` events, targeted at the
+  window that opened it.
+- `AppState::open_preferences()` is still the single entry point, so the menu
+  item and the keybinding stay unchanged.
 
 ### Layout Structure
 

--- a/.claude/rules/windows.md
+++ b/.claude/rules/windows.md
@@ -11,8 +11,8 @@ paths: "crates/arto/src/window/**, crates/arto/src/events.rs, crates/arto/src/ma
    `WindowCloseBehaviour::WindowHides` keeps the last window alive instead of
    quitting. Further windows come from File → New Window and each owns its
    tabs and state.
-2. **Child windows** (Mermaid, math, image viewers) are owned by a main
-   window and close with it.
+2. **Child windows** (Mermaid, math, image viewers, preferences) are owned by
+   a main window and close with it.
 
 ## Creating windows
 
@@ -74,6 +74,10 @@ Windows coordinate through the broadcast channels in
   floating tab and drop indicators.
 - `OPEN_FILE_IN_WINDOW` / `OPEN_DIRECTORY_IN_WINDOW`: open a path in a
   specific window.
+- `SET_SIDEBAR_ZOOM_IN_WINDOW` / `SET_RIGHT_SIDEBAR_ZOOM_IN_WINDOW`: the
+  preferences window acting on the window that opened it. Preferences holds no
+  `AppState` of its own, so a "Current Settings" slider sends rather than
+  writes.
 
 ```rust
 // Send

--- a/crates/arto/src/components.rs
+++ b/crates/arto/src/components.rs
@@ -9,6 +9,7 @@ pub mod main_app;
 pub mod math_window;
 pub mod mermaid_window;
 pub mod pinned_chips;
+pub mod preferences_window;
 pub mod right_sidebar;
 pub mod search_bar;
 pub mod sidebar;

--- a/crates/arto/src/components/app.rs
+++ b/crates/arto/src/components/app.rs
@@ -37,7 +37,7 @@ use drag_drop_overlay::DragDropOverlay;
 use drag_handlers::{handle_drag_mouse_motion, handle_drag_mouse_release};
 use drop_handlers::handle_dropped_files;
 use keybinding_engine::setup_keybinding_engine;
-use listeners::setup_cross_window_open_listeners;
+use listeners::{setup_cross_window_open_listeners, setup_preferences_listeners};
 use shortcut_overlay::{
     build_shortcut_help_items, close_shortcut_overlay, split_shortcut_help_columns,
     ShortcutHelpOverlay, ShortcutOverlayVisibility,
@@ -277,6 +277,7 @@ pub fn App(
 
     // Listen for cross-window file/directory open events (from sidebar context menu)
     setup_cross_window_open_listeners(state);
+    setup_preferences_listeners(state);
 
     // Update window title when active tab changes
     use_effect(move || {

--- a/crates/arto/src/components/app/listeners.rs
+++ b/crates/arto/src/components/app/listeners.rs
@@ -1,7 +1,10 @@
 use dioxus::desktop::window;
 use dioxus::prelude::*;
 
-use crate::events::{OPEN_DIRECTORY_IN_WINDOW, OPEN_FILE_IN_WINDOW};
+use crate::events::{
+    OPEN_DIRECTORY_IN_WINDOW, OPEN_FILE_IN_WINDOW, SET_RIGHT_SIDEBAR_ZOOM_IN_WINDOW,
+    SET_SIDEBAR_ZOOM_IN_WINDOW,
+};
 use crate::state::AppState;
 
 /// Setup listeners for cross-window file/directory open events (from sidebar context menu)
@@ -32,6 +35,34 @@ pub(super) fn setup_cross_window_open_listeners(mut state: AppState) {
                 state.set_root_directory(path.clone());
                 // Pin the sidebar so users can see the directory tree
                 state.sidebar.write().pinned = true;
+            }
+        }
+    });
+}
+
+/// Subscribe this window to what the preferences window changes about it.
+///
+/// The "Current Settings" sliders act on the window that opened preferences.
+/// That window is no longer the one drawing them — preferences has a window of
+/// its own and no `AppState` — so the value arrives as an event addressed to
+/// this window.
+pub(super) fn setup_preferences_listeners(mut state: AppState) {
+    let current_window_id = window().id();
+
+    use_future(move || async move {
+        let mut rx = SET_SIDEBAR_ZOOM_IN_WINDOW.subscribe();
+        while let Ok((target_window_id, zoom)) = rx.recv().await {
+            if target_window_id == current_window_id {
+                state.sidebar.write().zoom_level = zoom;
+            }
+        }
+    });
+
+    use_future(move || async move {
+        let mut rx = SET_RIGHT_SIDEBAR_ZOOM_IN_WINDOW.subscribe();
+        while let Ok((target_window_id, zoom)) = rx.recv().await {
+            if target_window_id == current_window_id {
+                state.right_sidebar.write().zoom_level = zoom;
             }
         }
     });

--- a/crates/arto/src/components/content.rs
+++ b/crates/arto/src/components/content.rs
@@ -15,10 +15,9 @@ use file_error_view::FileErrorView;
 use file_viewer::FileViewer;
 use inline_viewer::InlineViewer;
 use no_file_view::NoFileView;
-use preferences_view::PreferencesView;
 
 // Re-export for menu system
-pub use preferences_view::set_preferences_tab_to_about;
+pub use preferences_view::{set_preferences_tab_to_about, PreferencesView};
 
 // Re-export context menu types for App-level rendering
 pub use context_menu::ContentContextMenu;
@@ -69,9 +68,6 @@ pub fn Content() -> Element {
                             .unwrap_or("Unknown file")
                             .to_string();
                         rsx! { FileErrorView { filename, error_message: error } }
-                    },
-                    Some(TabContent::Preferences) => {
-                        rsx! { PreferencesView {} }
                     },
                     _ => rsx! { NoFileView {} },
                 }

--- a/crates/arto/src/components/content/preferences_view/main_view.rs
+++ b/crates/arto/src/components/content/preferences_view/main_view.rs
@@ -5,7 +5,7 @@ use super::tabs::{
 };
 use crate::components::icon::{Icon, IconName};
 use crate::config::{Config, CONFIG, CONFIG_CHANGED_BROADCAST};
-use crate::state::AppState;
+use crate::window::preferences::PreferencesSnapshot;
 use dioxus::prelude::*;
 use parking_lot::RwLock;
 use std::sync::LazyLock;
@@ -43,8 +43,7 @@ enum SaveStatus {
 }
 
 #[component]
-pub fn PreferencesView() -> Element {
-    let state = use_context::<AppState>();
+pub fn PreferencesView(snapshot: PreferencesSnapshot) -> Element {
     let mut config = use_signal(Config::default);
     let mut has_changes = use_signal(|| false);
     let mut active_tab = use_signal(|| *LAST_PREFERENCES_TAB.read());
@@ -234,7 +233,7 @@ pub fn PreferencesView() -> Element {
                             DirectoryTab {
                                 config,
                                 has_changes,
-                                current_directory: state.sidebar.read().root_directory.clone(),
+                                current_directory: snapshot.directory.clone(),
                             }
                         },
                         PreferencesTab::WindowSize => rsx! {
@@ -253,14 +252,18 @@ pub fn PreferencesView() -> Element {
                             SidebarTab {
                                 config,
                                 has_changes,
-                                state,
+                                window_id: snapshot.window_id,
+                                current_width: snapshot.sidebar_width,
+                                current_zoom: snapshot.sidebar_zoom_level,
                             }
                         },
                         PreferencesTab::RightSidebar => rsx! {
                             RightSidebarTab {
                                 config,
                                 has_changes,
-                                state,
+                                window_id: snapshot.window_id,
+                                current_width: snapshot.right_sidebar_width,
+                                current_zoom: snapshot.right_sidebar_zoom_level,
                             }
                         },
                         PreferencesTab::Keybindings => rsx! {

--- a/crates/arto/src/components/content/preferences_view/tabs/right_sidebar_tab.rs
+++ b/crates/arto/src/components/content/preferences_view/tabs/right_sidebar_tab.rs
@@ -4,19 +4,21 @@ use crate::config::{
     normalize_sidebar_zoom, Config, NewWindowBehavior, StartupBehavior, MAX_SIDEBAR_ZOOM,
     MIN_SIDEBAR_ZOOM, ZOOM_STEP,
 };
-use crate::state::AppState;
+use crate::events::SET_RIGHT_SIDEBAR_ZOOM_IN_WINDOW;
+use dioxus::desktop::tao::window::WindowId;
 use dioxus::prelude::*;
 
 #[component]
 pub fn RightSidebarTab(
     config: Signal<Config>,
     has_changes: Signal<bool>,
-    mut state: AppState,
+    /// The window these "Current Settings" act on.
+    window_id: WindowId,
+    current_width: f64,
+    current_zoom: f64,
 ) -> Element {
     // Extract values upfront to avoid holding read guard across closures
     let right_sidebar_cfg = config.read().right_sidebar.clone();
-    let current_width = state.right_sidebar.read().width;
-    let current_zoom = state.right_sidebar.read().zoom_level;
 
     rsx! {
         div {
@@ -40,7 +42,7 @@ pub fn RightSidebarTab(
                     decimals: 1,
                     on_change: move |new_zoom| {
                         // Normalize to 0.1 step and clamp to valid range
-                        state.right_sidebar.write().zoom_level = normalize_sidebar_zoom(new_zoom);
+                        let _ = SET_RIGHT_SIDEBAR_ZOOM_IN_WINDOW.send((window_id, normalize_sidebar_zoom(new_zoom)));
                     },
                     default_value: Some(right_sidebar_cfg.default_zoom_level),
                 }

--- a/crates/arto/src/components/content/preferences_view/tabs/sidebar_tab.rs
+++ b/crates/arto/src/components/content/preferences_view/tabs/sidebar_tab.rs
@@ -3,19 +3,21 @@ use crate::config::{
     normalize_sidebar_zoom, Config, NewWindowBehavior, StartupBehavior, MAX_SIDEBAR_ZOOM,
     MIN_SIDEBAR_ZOOM, ZOOM_STEP,
 };
-use crate::state::AppState;
+use crate::events::SET_SIDEBAR_ZOOM_IN_WINDOW;
+use dioxus::desktop::tao::window::WindowId;
 use dioxus::prelude::*;
 
 #[component]
 pub fn SidebarTab(
     config: Signal<Config>,
     has_changes: Signal<bool>,
-    mut state: AppState,
+    /// The window these "Current Settings" act on.
+    window_id: WindowId,
+    current_width: f64,
+    current_zoom: f64,
 ) -> Element {
     // Extract values upfront to avoid holding read guard across closures
     let sidebar_cfg = config.read().sidebar.clone();
-    let current_width = state.sidebar.read().width;
-    let current_zoom = state.sidebar.read().zoom_level;
 
     rsx! {
         div {
@@ -39,7 +41,7 @@ pub fn SidebarTab(
                     decimals: 1,
                     on_change: move |new_zoom| {
                         // Normalize to 0.1 step and clamp to valid range
-                        state.sidebar.write().zoom_level = normalize_sidebar_zoom(new_zoom);
+                        let _ = SET_SIDEBAR_ZOOM_IN_WINDOW.send((window_id, normalize_sidebar_zoom(new_zoom)));
                     },
                     default_value: Some(sidebar_cfg.default_zoom_level),
                 }

--- a/crates/arto/src/components/preferences_window.rs
+++ b/crates/arto/src/components/preferences_window.rs
@@ -1,0 +1,25 @@
+use dioxus::prelude::*;
+
+use crate::components::content::PreferencesView;
+use crate::hooks::viewer_window::use_theme_dispatch;
+use crate::theme::Theme;
+use crate::window::preferences::PreferencesSnapshot;
+
+/// Root of the preferences window.
+///
+/// Thin on purpose: the page itself is [`PreferencesView`], which is the same
+/// component whichever window it is drawn in. All this adds is the window's
+/// own theme, which has to be dispatched to the document because each window
+/// paints its own `data-theme`.
+#[component]
+pub fn PreferencesWindow(snapshot: PreferencesSnapshot, theme: Theme) -> Element {
+    let current_theme = use_signal(|| theme);
+    use_theme_dispatch(current_theme);
+
+    rsx! {
+        div {
+            class: "preferences-window",
+            PreferencesView { snapshot }
+        }
+    }
+}

--- a/crates/arto/src/components/tab/calculations.rs
+++ b/crates/arto/src/components/tab/calculations.rs
@@ -301,11 +301,5 @@ mod tests {
             let content = TabContent::Inline("content".to_string());
             assert!(!is_tab_transferable(&content));
         }
-
-        #[test]
-        fn preferences_tab_is_not_transferable() {
-            let content = TabContent::Preferences;
-            assert!(!is_tab_transferable(&content));
-        }
     }
 }

--- a/crates/arto/src/components/tab/tab_bar.rs
+++ b/crates/arto/src/components/tab/tab_bar.rs
@@ -476,18 +476,12 @@ fn NewTabButton() -> Element {
 #[component]
 fn PreferencesButton() -> Element {
     let mut state = use_context::<AppState>();
-    let current_tab = state.current_tab();
-    let is_preferences_active = current_tab
-        .as_ref()
-        .is_some_and(|tab| matches!(tab.content, crate::state::TabContent::Preferences));
-
     rsx! {
         button {
             class: "tab-preferences",
-            class: if is_preferences_active { "active" },
             title: "Preferences",
             onclick: move |_| {
-                state.toggle_preferences();
+                state.open_preferences();
             },
             Icon { name: IconName::Gear, size: 16 }
         }

--- a/crates/arto/src/events.rs
+++ b/crates/arto/src/events.rs
@@ -1,6 +1,7 @@
 //! Event propagation system for multi-window coordination.
 //!
 //! This module provides broadcast channels for cross-window communication:
+//! - Preferences acting on the window that opened it
 //! - Tab transfers (drag-and-drop, context menu "Move to Window")
 //! - Drag state updates (visual feedback across windows)
 //! - Cross-window file/directory opening (context menu "Open in Window")
@@ -9,6 +10,23 @@ use crate::state::Tab;
 use dioxus::desktop::tao::window::WindowId;
 use std::path::PathBuf;
 use tokio::sync::broadcast;
+
+// ============================================================================
+// Preferences Window Events
+// ============================================================================
+
+/// Apply a zoom level to one window's sidebar, from the preferences window.
+///
+/// The "Current Settings" sliders act on the window that opened preferences.
+/// Preferences is its own window now and holds no `AppState`, so the value
+/// travels as an event to that window rather than being written directly.
+pub static SET_SIDEBAR_ZOOM_IN_WINDOW: std::sync::LazyLock<broadcast::Sender<(WindowId, f64)>> =
+    std::sync::LazyLock::new(|| broadcast::channel(10).0);
+
+/// The same, for the right sidebar.
+pub static SET_RIGHT_SIDEBAR_ZOOM_IN_WINDOW: std::sync::LazyLock<
+    broadcast::Sender<(WindowId, f64)>,
+> = std::sync::LazyLock::new(|| broadcast::channel(10).0);
 
 // ============================================================================
 // Tab Transfer Events (for Drag-and-Drop and Context Menu)

--- a/crates/arto/src/state/app_state/tabs/content.rs
+++ b/crates/arto/src/state/app_state/tabs/content.rs
@@ -12,8 +12,6 @@ pub enum TabContent {
     Inline(String),
     /// File that cannot be opened (binary or error)
     FileError(PathBuf, String),
-    /// Preferences page (browser-style settings)
-    Preferences,
 }
 
 #[cfg(test)]
@@ -29,6 +27,6 @@ mod tests {
     fn test_tab_content_equality() {
         let path = PathBuf::from("/test/file.md");
         assert_eq!(TabContent::File(path.clone()), TabContent::File(path));
-        assert_ne!(TabContent::None, TabContent::Preferences);
+        assert_ne!(TabContent::None, TabContent::Inline(String::new()));
     }
 }

--- a/crates/arto/src/state/app_state/tabs/crud.rs
+++ b/crates/arto/src/state/app_state/tabs/crud.rs
@@ -14,7 +14,6 @@
 //! - The Tab/TabContent module tests cover the underlying data structures
 //!   (see `tabs/tab.rs` and `tabs/content.rs` for unit tests)
 
-use super::content::TabContent;
 use super::tab::Tab;
 use crate::state::AppState;
 use dioxus::prelude::*;
@@ -56,19 +55,13 @@ impl AppState {
     /// Returns `true` if the tab was closed successfully.
     /// Returns `false` if the index was out of bounds.
     ///
-    /// Note: When the last tab is closed, this method also closes the window
-    /// (unless it was a Preferences tab). The caller cannot distinguish between
-    /// "tab closed" and "window closed" from the return value alone.
+    /// Note: When the last tab is closed, this method also closes the window.
+    /// The caller cannot distinguish between "tab closed" and "window closed"
+    /// from the return value alone.
     pub fn close_tab(&mut self, index: usize) -> bool {
-        let tab = self.take_tab(index);
-        if let Some(tab) = tab {
+        if self.take_tab(index).is_some() {
             if self.tabs.read().is_empty() {
-                if tab.content == TabContent::Preferences {
-                    // Replace with an empty tab instead of closing the window
-                    self.add_empty_tab(true);
-                } else {
-                    dioxus::desktop::window().close();
-                }
+                dioxus::desktop::window().close();
             }
             true
         } else {

--- a/crates/arto/src/state/app_state/tabs/file_ops.rs
+++ b/crates/arto/src/state/app_state/tabs/file_ops.rs
@@ -1,8 +1,5 @@
 //! AppState extension methods for file operations in tabs.
 
-use super::content::TabContent;
-use super::tab::Tab;
-use crate::history::HistoryManager;
 use crate::state::AppState;
 use dioxus::prelude::*;
 use std::path::{Path, PathBuf};
@@ -35,68 +32,35 @@ impl AppState {
         });
     }
 
-    /// Open preferences in a tab. Reuses existing preferences tab if found.
-    /// Unpins both sidebars so preferences gets the full window.
+    /// Open the preferences window, or focus it if it is already open.
+    ///
+    /// Preferences used to be a tab, which gave a short errand the lifetime of
+    /// a document and left it sitting open. It is a window now; what the
+    /// "Current Settings" section needs from this window is handed over as a
+    /// snapshot, since the preferences window has no `AppState` of its own.
     pub fn open_preferences(&mut self) {
-        // Unpin both sidebars and close overlays (preferences is a full-screen settings page)
-        self.sidebar.write().pinned = false;
-        self.right_sidebar.write().pinned = false;
-        self.left_hover_active.set(false);
-        self.right_hover_active.set(false);
-
-        // Check if preferences tab already exists
-        let tabs = self.tabs.read();
-        if let Some(index) = tabs
-            .iter()
-            .position(|tab| matches!(tab.content, TabContent::Preferences))
-        {
-            drop(tabs);
-            self.switch_to_tab(index);
-            return;
-        }
-        drop(tabs);
-
-        // Check if current tab is empty (None, Inline, or FileError) - reuse it
-        if self.is_current_tab_no_file() {
-            self.update_current_tab(|tab| {
-                tab.content = TabContent::Preferences;
-            });
-        } else {
-            // Create new tab with preferences
-            let mut tabs = self.tabs.write();
-            tabs.push(Tab {
-                content: TabContent::Preferences,
-                history: HistoryManager::new(),
-                pinned: false,
-            });
-            let new_index = tabs.len() - 1;
-            drop(tabs);
-            self.active_tab.set(new_index);
-        }
-    }
-
-    /// Toggle preferences tab. Opens if not present, closes if currently active.
-    pub fn toggle_preferences(&mut self) {
-        // Check if preferences tab already exists
-        let tabs = self.tabs.read();
-        let preferences_index = tabs
-            .iter()
-            .position(|tab| matches!(tab.content, TabContent::Preferences));
-        drop(tabs);
-
-        if let Some(index) = preferences_index {
-            // Preferences tab exists - check if it's the active tab
-            let active_index = *self.active_tab.read();
-            if active_index == index {
-                // Close the preferences tab
-                self.close_tab(index);
-            } else {
-                // Switch to the preferences tab
-                self.switch_to_tab(index);
-            }
-        } else {
-            // No preferences tab - open new one
-            self.open_preferences();
-        }
+        let (sidebar_width, sidebar_zoom_level, directory) = {
+            let sidebar = self.sidebar.read();
+            (
+                sidebar.width,
+                sidebar.zoom_level,
+                sidebar.root_directory.clone(),
+            )
+        };
+        let (right_sidebar_width, right_sidebar_zoom_level) = {
+            let right = self.right_sidebar.read();
+            (right.width, right.zoom_level)
+        };
+        crate::window::preferences::open_or_focus_preferences_window(
+            crate::window::preferences::PreferencesSnapshot {
+                window_id: dioxus::desktop::window().id(),
+                sidebar_width,
+                sidebar_zoom_level,
+                right_sidebar_width,
+                right_sidebar_zoom_level,
+                directory,
+            },
+            *self.current_theme.read(),
+        );
     }
 }

--- a/crates/arto/src/state/app_state/tabs/tab.rs
+++ b/crates/arto/src/state/app_state/tabs/tab.rs
@@ -56,7 +56,6 @@ impl Tab {
                 .map(|name| name.to_string_lossy().into_owned())
                 .unwrap_or_else(|| "Unnamed".to_string()),
             TabContent::Inline(_) => "Welcome".to_string(),
-            TabContent::Preferences => "Preferences".to_string(),
             TabContent::None => "New Tab".to_string(),
         }
     }
@@ -118,12 +117,6 @@ mod tests {
             ..Default::default()
         };
         assert!(!tab.is_no_file());
-
-        let tab = Tab {
-            content: TabContent::Preferences,
-            ..Default::default()
-        };
-        assert!(!tab.is_no_file());
     }
 
     #[test]
@@ -151,9 +144,6 @@ mod tests {
         assert_eq!(tab.file(), None);
 
         tab.content = TabContent::Inline("test".to_string());
-        assert_eq!(tab.file(), None);
-
-        tab.content = TabContent::Preferences;
         assert_eq!(tab.file(), None);
     }
 
@@ -187,15 +177,6 @@ mod tests {
     fn test_display_name_inline() {
         let tab = Tab::with_inline_content("# Welcome to Arto");
         assert_eq!(tab.display_name(), "Welcome");
-    }
-
-    #[test]
-    fn test_display_name_preferences() {
-        let tab = Tab {
-            content: TabContent::Preferences,
-            ..Default::default()
-        };
-        assert_eq!(tab.display_name(), "Preferences");
     }
 
     // === Edge case tests ===

--- a/crates/arto/src/utils/window_title.rs
+++ b/crates/arto/src/utils/window_title.rs
@@ -13,7 +13,6 @@ pub fn generate_window_title(tab_content: &TabContent) -> String {
     match tab_content {
         TabContent::File(path) => format!("Arto - {}", extract_filename(path)),
         TabContent::Inline(_) => "Arto - Welcome".to_string(),
-        TabContent::Preferences => "Arto - Preferences".to_string(),
         TabContent::FileError(path, _) => format!("Arto - {} (Error)", extract_filename(path)),
         TabContent::None => "Arto".to_string(),
     }

--- a/crates/arto/src/window.rs
+++ b/crates/arto/src/window.rs
@@ -3,6 +3,7 @@ pub mod icon;
 pub mod index;
 pub mod main;
 pub mod metrics;
+pub mod preferences;
 pub mod preview;
 pub mod settings;
 mod types;

--- a/crates/arto/src/window/child.rs
+++ b/crates/arto/src/window/child.rs
@@ -110,7 +110,7 @@ pub fn close_all_child_windows() {
 
 /// Try to focus an existing child window, or mark it as pending for creation.
 /// Returns `true` if a new window needs to be created.
-fn try_focus_or_mark_pending(child_id: &str, parent_id: WindowId) -> bool {
+pub(super) fn try_focus_or_mark_pending(child_id: &str, parent_id: WindowId) -> bool {
     CHILD_WINDOWS.with(|windows| {
         let mut windows = windows.borrow_mut();
         windows.retain(|_, state| match state {
@@ -133,7 +133,7 @@ fn try_focus_or_mark_pending(child_id: &str, parent_id: WindowId) -> bool {
 }
 
 /// Register a newly created child window, or close it if the pending state was removed.
-async fn create_and_register_child_window(
+pub(super) async fn create_and_register_child_window(
     child_id: String,
     dom: VirtualDom,
     config: Config,

--- a/crates/arto/src/window/index.rs
+++ b/crates/arto/src/window/index.rs
@@ -53,6 +53,10 @@ pub(crate) fn build_image_window_index(theme: Theme) -> String {
     build_viewer_window_index("Image Viewer", "image-window-body", theme)
 }
 
+pub(crate) fn build_preferences_window_index(theme: Theme) -> String {
+    build_viewer_window_index("Preferences", "preferences-window-body", theme)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -68,6 +72,7 @@ mod tests {
             build_mermaid_window_index(Theme::Light),
             build_math_window_index(Theme::Light),
             build_image_window_index(Theme::Light),
+            build_preferences_window_index(Theme::Light),
         ] {
             assert!(
                 index.contains("id=\"tabler-"),

--- a/crates/arto/src/window/preferences.rs
+++ b/crates/arto/src/window/preferences.rs
@@ -1,0 +1,74 @@
+//! The preferences window.
+//!
+//! Preferences are a short errand — change a thing, close it again — while a
+//! tab is where a document lives for as long as you are reading it. Giving
+//! the errand a document's lifetime is what left a settings tab sitting open
+//! for days, so it gets a window of its own instead: opened from the menu or
+//! `⌘,`, focused if already open, and gone when closed.
+//!
+//! The window carries no `AppState`. What the "Current Settings" sliders need
+//! from the window that opened them travels here as a [`PreferencesSnapshot`],
+//! taken at open time; what they change travels back as an event
+//! ([`crate::events::SET_SIDEBAR_ZOOM_IN_WINDOW`]).
+
+use dioxus::desktop::tao::dpi::LogicalSize;
+use dioxus::desktop::tao::window::WindowId;
+use dioxus::desktop::{window, Config, WindowBuilder};
+use dioxus::prelude::*;
+use std::path::PathBuf;
+
+use crate::assets::{main_stylesheet_head, with_asset_protocol};
+use crate::components::preferences_window::{PreferencesWindow, PreferencesWindowProps};
+use crate::theme::Theme;
+
+use super::child::{create_and_register_child_window, try_focus_or_mark_pending};
+use super::index::build_preferences_window_index;
+
+/// There is only ever one preferences window, so it needs no generated key.
+const PREFERENCES_CHILD_ID: &str = "preferences";
+
+const PREFERENCES_WIDTH: f64 = 880.0;
+const PREFERENCES_HEIGHT: f64 = 640.0;
+
+/// What the preferences window knows about the window that opened it.
+///
+/// Only the values the "Current Settings" section reports back — everything
+/// else it edits is the configuration, which it reads for itself.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PreferencesSnapshot {
+    /// The window these settings act on, so changes can be sent back to it.
+    pub window_id: WindowId,
+    pub sidebar_width: f64,
+    pub sidebar_zoom_level: f64,
+    pub right_sidebar_width: f64,
+    pub right_sidebar_zoom_level: f64,
+    pub directory: Option<PathBuf>,
+}
+
+/// Open the preferences window, or focus it if it is already open.
+pub fn open_or_focus_preferences_window(snapshot: PreferencesSnapshot, theme: Theme) {
+    let parent_id = window().id();
+
+    if try_focus_or_mark_pending(PREFERENCES_CHILD_ID, parent_id) {
+        let dom = VirtualDom::new_with_props(
+            PreferencesWindow,
+            PreferencesWindowProps { snapshot, theme },
+        );
+        let config = with_asset_protocol(Config::new())
+            .with_menu(None)
+            .with_window(super::icon::apply_app_icon(
+                WindowBuilder::new()
+                    .with_title("Preferences")
+                    .with_inner_size(LogicalSize::new(PREFERENCES_WIDTH, PREFERENCES_HEIGHT)),
+            ))
+            .with_custom_head(main_stylesheet_head())
+            .with_custom_index(build_preferences_window_index(theme));
+
+        dioxus_core::spawn(create_and_register_child_window(
+            PREFERENCES_CHILD_ID.to_string(),
+            dom,
+            config,
+            parent_id,
+        ));
+    }
+}

--- a/frontend/style/components/preferences.css
+++ b/frontend/style/components/preferences.css
@@ -2,6 +2,21 @@
    Full-Page Preferences Layout
    ================================= */
 
+/* Preferences is its own window: the page owns the whole viewport, the way
+   the other standalone windows do. */
+.preferences-window-body {
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  height: 100vh;
+}
+
+.preferences-window {
+  height: 100vh;
+  background: var(--bg-color);
+  color: var(--text-color);
+}
+
 .preferences-page {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary

- Preferences becomes a child window instead of a tab.
- It holds no `AppState`: what it reports comes over as a snapshot, what it changes goes back as an event.
- `AppState::open_preferences` stays the single entry point, so the menu item and the keybinding are unchanged.

## Why

Changing a setting is a short errand; a tab is where a document lives for as long as it is being read. Giving the errand a document's lifetime is what left a settings tab sitting open for days behind the thing it was supposed to be configuring — and what made every tab operation carry a special case for the one tab that is not a document.

So preferences opens the way the other standalone pages already do: a child window of the one that asked for it, focused rather than duplicated if it is already up, closed with its parent. It holds no `AppState` — what the "Current Settings" sliders report is handed over as a snapshot when the window opens, and what they change travels back as an event addressed to the window that opened them. `AppState::open_preferences` is still the single entry point, so the menu item and the keybinding are unchanged.

## Test Plan

- [ ] `Cmd+,` and the menu item open one preferences window; asking again focuses it rather than opening a second
- [ ] Closing the window that opened it closes preferences with it
- [ ] The "Current Settings" sliders change the window that opened preferences
- [ ] `just fmt check test`

## Stack

These land in order; each is based on the one above it.

1. #265 — chore(dev): sign the bundle `dx serve` builds on macOS
2. #266 — feat(preferences): a window, not a tab 👈 **this one**
3. #267 — feat(window): one document to a window
4. #268 — feat(panel): several roots, and the folders you keep
5. #269 — feat(panel): one panel, three faces, and the history among them
6. #270 — feat(contents): the contents live beside the page
7. #271 — feat(header): the document's name is the way back, and one glyph opens the app
8. #272 — feat(search): find in the header, and the marks stay in the contents
9. #273 — feat(welcome): a window with nothing open says what there is to read
10. #274 — feat(layout): give way to the document
11. #275 — feat(keys): every list and every field answers to bindings
12. #276 — feat(recent): remember where a document was left, and open it there
13. #277 — feat(menu): give every menu row its icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01731Zfkg9P6V4Lm7buLEN53
