### PR TITLE
feat(header): the document's name is the way back, and one glyph opens the app

### DIFF
--- a/.claude/rules/menu.md
+++ b/.claude/rules/menu.md
@@ -30,17 +30,18 @@ The closure parameter is already a `&MenuEvent`, so it is passed as is:
 
 ```rust
 // main_app.rs
-#[cfg(not(target_os = "windows"))]
+#[cfg(target_os = "macos")]
 use_muda_event_handler(move |event| {
     crate::menu::handle_menu_event_global(event);
 });
 
 // app.rs
-#[cfg(not(target_os = "windows"))]
+#[cfg(target_os = "macos")]
 use_muda_event_handler(move |event| {
     menu::handle_menu_event_with_state(event, &mut state);
 });
 ```
 
-Both return `bool` (handled or not). On Windows the native menu is built
-differently; check the `cfg` guards before touching registration.
+Both return `bool` (handled or not). The native menu bar is macOS only —
+everywhere else the same commands hang off the glyph at the head of the
+header — so check the `cfg` guards before touching registration.

--- a/crates/arto-keybindings/src/engine.rs
+++ b/crates/arto-keybindings/src/engine.rs
@@ -140,7 +140,7 @@ impl KeybindingEngine {
     }
 
     /// Build an engine with the menu-shortcut folding decision forced, so tests
-    /// can exercise both the native-menu (macOS/Linux) and folded (Windows)
+    /// can exercise both the native-menu (macOS) and folded (everywhere else)
     /// branches regardless of the host platform.
     #[cfg(test)]
     fn new_with_menu_folding(bindings: &BindingSet, fold_menu_shortcuts: bool) -> Self {
@@ -307,9 +307,10 @@ mod tests {
     fn menu_shortcut_reachable_only_when_folded() {
         // The menu-shortcut folding decision, tested on both branches from any
         // host. Cmd+o (file.open) is a menu shortcut in the default preset.
-        // - Native-menu platforms (macOS/Linux): the OS dispatches it, so the
-        //   engine must NOT resolve it.
-        // - Windows: no native menu, so it is folded into the engine and matches.
+        // - macOS: the native menu bar carries the accelerator and the OS
+        //   dispatches it, so the engine must NOT resolve it.
+        // - Everywhere else: the menu is drawn in the header and has no
+        //   accelerator table, so it is folded into the engine and matches.
         // Using `chord("Cmd+o")` keeps the probe in the host's own parse space,
         // so it lines up with the folded binding regardless of platform.
         let config = default_bindings();

--- a/crates/arto-keybindings/src/resolve.rs
+++ b/crates/arto-keybindings/src/resolve.rs
@@ -47,11 +47,13 @@ impl BindingSet {
     /// Resolve every entry, returning the usable bindings and the entries
     /// that had to be skipped, in one pass.
     ///
-    /// Platforms with a native menu (macOS/Linux) let the OS dispatch menu
-    /// shortcuts, so they are excluded. Windows has no native menu, so the
-    /// engine must own them or they would have no dispatch path at all.
+    /// macOS has a native menu bar, which sits above the window rather than
+    /// inside it, and lets the OS dispatch menu shortcuts — so they are
+    /// excluded there. Everywhere else the menu is drawn in the header and
+    /// there is no accelerator table behind it, so the engine must own the
+    /// menu shortcuts or they would have no dispatch path at all.
     pub fn resolve(self) -> (Vec<ResolvedBinding>, Vec<BindingError>) {
-        self.resolve_with(cfg!(target_os = "windows"))
+        self.resolve_with(cfg!(not(target_os = "macos")))
     }
 
     /// Flatten into resolved bindings for engine consumption, dropping the

--- a/crates/arto/src/components.rs
+++ b/crates/arto/src/components.rs
@@ -1,4 +1,5 @@
 pub mod app;
+pub mod app_menu;
 pub mod bookmark_button;
 pub mod content;
 pub mod context_menu;
@@ -14,5 +15,3 @@ pub mod preferences_window;
 pub mod search_bar;
 pub mod sidebar;
 pub mod theme_selector;
-#[cfg(target_os = "windows")]
-pub mod win_hamburger;

--- a/crates/arto/src/components/app.rs
+++ b/crates/arto/src/components/app.rs
@@ -6,7 +6,7 @@ mod shortcut_overlay;
 
 use dioxus::desktop::tao::dpi::{LogicalPosition, LogicalSize};
 use dioxus::desktop::tao::event::{Event as TaoEvent, WindowEvent};
-#[cfg(not(target_os = "windows"))]
+#[cfg(target_os = "macos")]
 use dioxus::desktop::use_muda_event_handler;
 use dioxus::desktop::{use_wry_event_handler, window};
 use dioxus::document;
@@ -22,7 +22,7 @@ use super::search_bar::SearchBar;
 use super::sidebar::file_explorer::SidebarContextMenuHost;
 use super::sidebar::Sidebar;
 use crate::assets::main_script_url;
-#[cfg(not(target_os = "windows"))]
+#[cfg(target_os = "macos")]
 use crate::menu;
 use crate::state::{AppState, Document, PersistedState};
 use crate::theme::Theme;
@@ -53,6 +53,10 @@ pub fn App(
     zoom_level: f64,
 ) -> Element {
     // Initialize application state with the provided document
+    // Taken mutably only by the native menu handler, which is built on macOS
+    // alone — the other platforms draw their menu in the header, so nothing
+    // there needs `mut`.
+    #[cfg_attr(not(target_os = "macos"), allow(unused_mut))]
     let mut state = use_context_provider(|| {
         let mut app_state = AppState::new(theme);
         // A duplicated window arrives with the place its original had reached
@@ -134,7 +138,7 @@ pub fn App(
     setup_keybinding_engine(state, shortcut_overlay_visibility);
 
     // Handle menu events (only state-dependent events, not global ones)
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(target_os = "macos")]
     use_muda_event_handler(move |event| {
         // Only handle state-dependent events
         menu::handle_menu_event_with_state(event, &mut state);

--- a/crates/arto/src/components/app/keybinding_engine.rs
+++ b/crates/arto/src/components/app/keybinding_engine.rs
@@ -37,7 +37,7 @@ const JS_KEYBOARD_READY_MAX_RETRIES: u32 = if cfg!(target_os = "windows") { 200 
 /// skips them (the OS menu dispatches those; forwarding would double-fire).
 ///
 /// Must be called within the Dioxus runtime (component task / spawn).
-#[cfg(not(target_os = "windows"))]
+#[cfg(target_os = "macos")]
 fn push_menu_accelerators_to_js() {
     use crate::config::CONFIG;
 
@@ -57,9 +57,10 @@ fn push_menu_accelerators_to_js() {
     ));
 }
 
-/// Windows has no native menu, so menu shortcuts are dispatched by the engine
-/// (see `BindingSet::into_resolved_bindings`) — there is nothing to skip.
-#[cfg(target_os = "windows")]
+/// Off macOS there is no native menu — the same commands hang off the glyph in
+/// the header and are dispatched by the engine (see
+/// `BindingSet::into_resolved_bindings`), so there is nothing to skip.
+#[cfg(not(target_os = "macos"))]
 fn push_menu_accelerators_to_js() {}
 
 /// Tell the JS interceptor which primary-modifier + single-letter chords the

--- a/crates/arto/src/components/app_menu.rs
+++ b/crates/arto/src/components/app_menu.rs
@@ -1,5 +1,3 @@
-#![cfg(target_os = "windows")]
-
 use crate::components::context_menu::{ContextMenuItem, ContextMenuSeparator, ContextMenuSubmenu};
 use crate::components::icon::IconName;
 use crate::state::AppState;
@@ -7,7 +5,7 @@ use crate::utils::task::spawn_detached;
 use dioxus::prelude::*;
 
 #[component]
-pub fn WindowsMenu(on_close: EventHandler<()>) -> Element {
+pub fn AppMenu(on_close: EventHandler<()>) -> Element {
     let mut state = use_context::<AppState>();
 
     // Helper to get keyboard shortcut hints
@@ -16,6 +14,10 @@ pub fn WindowsMenu(on_close: EventHandler<()>) -> Element {
     // Get information on the currently open file (for invalidation determination)
     let current_file = state.current_file();
     let has_file = current_file.is_some();
+
+    let history = state.document().history;
+    let can_go_back = history.can_go_back();
+    let can_go_forward = history.can_go_forward();
 
     let close = move || on_close.call(());
 
@@ -30,11 +32,11 @@ pub fn WindowsMenu(on_close: EventHandler<()>) -> Element {
         // Menu body
         div {
             class: "context-menu",
-            style: "position: absolute; left: 12px; top: 40px; z-index: 999;",
+            style: "position: absolute; left: 12px; top: var(--header-height); z-index: 999;",
             onclick: move |evt| evt.stop_propagation(),
 
             // === Arto (App) ===
-            ContextMenuItem { label: "About Arto", shortcut: shortcut("app.about"), on_click: move |_| {
+            ContextMenuItem { label: "About Arto", shortcut: shortcut("app.about"), icon: Some(IconName::InfoCircle), on_click: move |_| {
                 crate::components::content::set_preferences_tab_to_about();
                 state.open_preferences();
                 close();
@@ -83,7 +85,7 @@ pub fn WindowsMenu(on_close: EventHandler<()>) -> Element {
                     close();
                 } } }
                 ContextMenuSeparator {}
-                ContextMenuItem { label: "Close Window", shortcut: shortcut("window.close"), on_click: move |_| {
+                ContextMenuItem { label: "Close Window", shortcut: shortcut("window.close"), icon: Some(IconName::Close), on_click: move |_| {
                     dioxus::desktop::window().close();
                 } }
                 ContextMenuSeparator {}
@@ -99,11 +101,11 @@ pub fn WindowsMenu(on_close: EventHandler<()>) -> Element {
                     state.open_search_with_text(None);
                     close();
                 } }
-                ContextMenuItem { label: "Find Next", shortcut: shortcut("search.next"), on_click: move |_| {
+                ContextMenuItem { label: "Find Next", shortcut: shortcut("search.next"), icon: Some(IconName::ChevronDown), on_click: move |_| {
                     spawn_detached(async move { let _ = document::eval("window.Arto.search.navigate('next')").await; });
                     close();
                 } }
-                ContextMenuItem { label: "Find Previous", shortcut: shortcut("search.prev"), on_click: move |_| {
+                ContextMenuItem { label: "Find Previous", shortcut: shortcut("search.prev"), icon: Some(IconName::ChevronUp), on_click: move |_| {
                     spawn_detached(async move { let _ = document::eval("window.Arto.search.navigate('prev')").await; });
                     close();
                 } }
@@ -120,7 +122,7 @@ pub fn WindowsMenu(on_close: EventHandler<()>) -> Element {
                     state.zoom_reset();
                     close();
                 } }
-                ContextMenuItem { label: "Zoom In", shortcut: shortcut("zoom.in"), icon: Some(IconName::Add), on_click: move |_| {
+                ContextMenuItem { label: "Zoom In", shortcut: shortcut("zoom.in"), on_click: move |_| {
                     state.zoom_in();
                     close();
                 } }
@@ -131,24 +133,34 @@ pub fn WindowsMenu(on_close: EventHandler<()>) -> Element {
             }
 
             // === History ===
-            ContextMenuSubmenu { label: "History",
-                ContextMenuItem { label: "Go Back", shortcut: shortcut("history.back"), icon: Some(IconName::ChevronLeft), on_click: move |_| {
-                    state.save_scroll_and_go_back();
-                    close();
-                } }
-                ContextMenuItem { label: "Go Forward", shortcut: shortcut("history.forward"), icon: Some(IconName::ChevronRight), on_click: move |_| {
-                    state.save_scroll_and_go_forward();
-                    close();
-                } }
+            // Only where there is a history to move through: the header no
+            // longer carries back and forward, so this is where they are, and
+            // an item that cannot act reads as the feature being broken
+            // rather than as the reader being at the start.
+            if can_go_back || can_go_forward {
+                ContextMenuSubmenu { label: "History",
+                    if can_go_back {
+                        ContextMenuItem { label: "Go Back", shortcut: shortcut("history.back"), icon: Some(IconName::ChevronLeft), on_click: move |_| {
+                            state.save_scroll_and_go_back();
+                            close();
+                        } }
+                    }
+                    if can_go_forward {
+                        ContextMenuItem { label: "Go Forward", shortcut: shortcut("history.forward"), icon: Some(IconName::ChevronRight), on_click: move |_| {
+                            state.save_scroll_and_go_forward();
+                            close();
+                        } }
+                    }
+                }
             }
 
             // === Window ===
             ContextMenuSubmenu { label: "Window",
-                ContextMenuItem { label: "Close All Child Windows", shortcut: shortcut("window.close_all_child_windows"), on_click: move |_| {
+                ContextMenuItem { label: "Close All Child Windows", shortcut: shortcut("window.close_all_child_windows"), icon: Some(IconName::Close), on_click: move |_| {
                     crate::window::close_child_windows_for_last_focused();
                     close();
                 } }
-                ContextMenuItem { label: "Close All Windows", shortcut: shortcut("window.close_all_windows"), on_click: move |_| {
+                ContextMenuItem { label: "Close All Windows", shortcut: shortcut("window.close_all_windows"), icon: Some(IconName::Close), on_click: move |_| {
                     crate::window::close_all_main_windows();
                     close();
                 } }
@@ -165,7 +177,7 @@ pub fn WindowsMenu(on_close: EventHandler<()>) -> Element {
             ContextMenuSeparator {}
 
             // === Quit ===
-            ContextMenuItem { label: "Quit", icon: Some(IconName::Close), on_click: move |_| {
+            ContextMenuItem { label: "Quit", on_click: move |_| {
                 crate::window::shutdown_all_windows();
             } }
         }

--- a/crates/arto/src/components/content/preferences_view/tabs/keybindings_tab.rs
+++ b/crates/arto/src/components/content/preferences_view/tabs/keybindings_tab.rs
@@ -13,9 +13,11 @@ use crate::keybindings::{KeyChord, ShortcutSequence};
 
 /// Which shortcut table a section edits.
 ///
-/// Menu shortcuts become native OS menu accelerators (single chord, shown in the
-/// menu bar); engine bindings are handled in-window and support chord sequences
-/// and per-context behavior.
+/// Menu shortcuts are single chords, the ones a menu item can carry. On macOS
+/// they become native accelerators and the OS dispatches them; everywhere else
+/// the engine does, since the menu is drawn in the header and has no
+/// accelerator table behind it. Engine bindings are always handled in-window
+/// and support chord sequences and per-context behavior.
 #[derive(Clone, Copy, PartialEq)]
 enum BindingScope {
     Menu,

--- a/crates/arto/src/components/context_menu.rs
+++ b/crates/arto/src/components/context_menu.rs
@@ -2,8 +2,8 @@
 //!
 //! Each menu owns its own contents, but they all render the same
 //! item/separator/submenu markup and clamp themselves into the viewport the
-//! same way. Consumers include the tab bar, the sidebar file tree, the markdown
-//! content area, and the Windows hamburger menu — the last of which is
+//! same way. Consumers include the sidebar file tree, the markdown
+//! content area, and the app menu in the header — the last of which is
 //! `cfg`-gated, so a grep or build on another platform will not surface it.
 //! Check it too before assuming a menu change is complete.
 

--- a/crates/arto/src/components/header.rs
+++ b/crates/arto/src/components/header.rs
@@ -1,12 +1,13 @@
+mod breadcrumb_menu;
+
 use dioxus::prelude::*;
 
+use crate::components::app_menu::AppMenu;
 use crate::components::bookmark_button::BookmarkButton;
+use crate::components::header::breadcrumb_menu::Breadcrumb;
 use crate::components::icon::{Icon, IconName};
 use crate::components::theme_selector::ThemeSelector;
 use crate::state::AppState;
-
-#[cfg(target_os = "windows")]
-use crate::components::win_hamburger::WindowsMenu;
 
 #[component]
 pub fn Header() -> Element {
@@ -15,27 +16,12 @@ pub fn Header() -> Element {
     let mut is_menu_open = use_signal(|| false);
 
     let document = state.document();
-    let file_path = document.file();
-    let file = file_path
-        .as_ref()
-        .map(|f| {
-            f.file_name()
-                .unwrap_or(f.as_os_str())
-                .to_string_lossy()
-                .to_string()
-        })
-        .unwrap_or_else(|| "No file opened".to_string());
-
-    let can_go_back = document.history.can_go_back();
-    let can_go_forward = document.history.can_go_forward();
-
-    let on_back = move |_| {
-        state.save_scroll_and_go_back();
-    };
-
-    let on_forward = move |_| {
-        state.save_scroll_and_go_forward();
-    };
+    let file_path = document.file().map(|file| file.to_path_buf());
+    let file = document.display_name();
+    // Both of the right-hand controls act on a document: one searches it, the
+    // other decides how wide it is set. With no document they can do neither,
+    // and a control that cannot act is not drawn.
+    let reading = !document.is_empty();
 
     let is_reloading = use_signal(|| false);
     let mut is_reloading_write = is_reloading;
@@ -56,67 +42,38 @@ pub fn Header() -> Element {
     // Copy feedback state
     let mut is_copied = use_signal(|| false);
 
-    let menu_overlay = {
-        #[cfg(target_os = "windows")]
-        {
-            if *is_menu_open.read() {
-                rsx! {
-                    WindowsMenu {
-                        on_close: move |_| is_menu_open.set(false),
-                    }
-                }
-            } else {
-                rsx! {}
-            }
-        }
-        #[cfg(not(target_os = "windows"))]
-        {
-            rsx! {}
-        }
-    };
-
     rsx! {
         div {
             class: "header",
-            style: "position: relative;",
 
             // File name display (left side) with navigation buttons
             div {
                 class: "header-left",
 
-                    // Hamburger Menu Button
-                    if cfg!(target_os = "windows") {
-                        button {
-                            class: "nav-button hamburger-button",
-                            class: if *is_menu_open.read() { "active" },
-                            title: "Menu",
-                            onclick: move |_| is_menu_open.toggle(),
-                            Icon { name: IconName::Menu2 }
-                        }
-                    }
-
-
-                // Back button
+                // Everything the app can do, in the window it applies to.
+                // macOS has a menu bar of its own, but it belongs to whichever
+                // window is frontmost and sits at the top of the screen rather
+                // than at the top of the window, so this one is drawn there
+                // too.
                 button {
-                    class: "nav-button",
-                    disabled: !can_go_back,
-                    onclick: on_back,
-                    Icon { name: IconName::ChevronLeft }
+                    class: "nav-button app-menu-button",
+                    class: if *is_menu_open.read() { "active" },
+                    // No `title`: the menu opens directly under this glyph,
+                    // and the tooltip would land on its first item. Taking the
+                    // attribute away once the menu is open is too late —
+                    // WebKit reads it when the pointer arrives and shows it a
+                    // moment later, and by then the pointer has not moved, so
+                    // the text it already read is what appears. A control that
+                    // opens a panel under itself gets no tooltip at all; the
+                    // panel says what the tooltip would.
+                    "aria-label": "Menu",
+                    onclick: move |_| is_menu_open.toggle(),
+                    Icon { name: IconName::Menu2 }
                 }
 
-                // Forward button
-                button {
-                    class: "nav-button",
-                    disabled: !can_go_forward,
-                    onclick: on_forward,
-                    Icon { name: IconName::ChevronRight }
-                }
-
-                // File name
-                span {
-                    class: "file-name",
-                    "{file}"
-                }
+                // The name of what is being read is also the way back to
+                // what was read before it.
+                Breadcrumb { label: file }
 
                 div {
                     class: "file-action-buttons",
@@ -144,7 +101,6 @@ pub fn Header() -> Element {
                             },
                             Icon {
                                 name: if *is_copied.read() { IconName::Check } else { IconName::Copy },
-                                size: 14,
                             }
                         }
 
@@ -154,7 +110,7 @@ pub fn Header() -> Element {
                             class: if *is_reloading.read() { "reloading" },
                             onclick: on_reload,
                             title: "Reload file",
-                            Icon { name: IconName::Refresh, size: 14 }
+                            Icon { name: IconName::Refresh }
                         }
                     }
                 }
@@ -164,25 +120,15 @@ pub fn Header() -> Element {
             div {
                 class: "header-right",
 
+                if reading {
                 // Search button
                 button {
                     class: "nav-button search-button",
                     class: if *state.search_open.read() { "active" },
                     title: "Search in page",
-                    onclick: move |_| {
-                        let was_closed = !*state.search_open.read();
-                        state.toggle_search();
-                        if was_closed {
-                            // Focus the search input after opening
-                            spawn(async {
-                                let _ = document::eval(
-                                    "document.querySelector('.search-input')?.focus()",
-                                )
-                                .await;
-                            });
-                        }
-                    },
-                    Icon { name: IconName::Search, size: 20 }
+                    // The field focuses itself as it mounts.
+                    onclick: move |_| state.toggle_search(),
+                    Icon { name: IconName::Search }
                 }
 
                 // Full-width content toggle
@@ -193,15 +139,19 @@ pub fn Header() -> Element {
                     onclick: move |_| state.toggle_content_full_width(),
                     Icon {
                         name: if *state.content_full_width.read() { IconName::ViewportNarrow } else { IconName::ViewportWide },
-                        size: 20,
                     }
+                }
                 }
 
                 // Theme selector
                 ThemeSelector { current_theme: state.current_theme }
             }
 
-            {menu_overlay}
+            if *is_menu_open.read() {
+                AppMenu {
+                    on_close: move |_| is_menu_open.set(false),
+                }
+            }
 
         }
     }

--- a/crates/arto/src/components/header/breadcrumb_menu.rs
+++ b/crates/arto/src/components/header/breadcrumb_menu.rs
@@ -1,0 +1,197 @@
+use std::path::Path;
+
+use dioxus::prelude::*;
+
+use crate::components::document_name::DocumentName;
+use crate::components::icon::{Icon, IconName};
+use crate::state::{AppState, Face};
+use crate::visits::{Visit, VISITS, VISITS_CHANGED};
+
+/// How many documents the breadcrumb drops.
+///
+/// Enough to cover a morning's reading; the last row goes to the face that
+/// holds the rest, so this list never has to grow into a browser.
+const MAX_ROWS: usize = 12;
+
+/// The name of what is being read, and the way back to what was read before.
+///
+/// The header used to state the file name and stop there. The name is also
+/// the natural place to ask "what else have I had open", so it became the
+/// control that answers: clicking it drops the recent documents, and the last
+/// row opens the panel's Recent face with all of them.
+#[component]
+pub fn Breadcrumb(label: String) -> Element {
+    let mut state = use_context::<AppState>();
+    let mut is_open = use_signal(|| false);
+    let mut revision = use_signal(|| 0u32);
+
+    use_future(move || async move {
+        let mut rx = VISITS_CHANGED.subscribe();
+        while rx.recv().await.is_ok() {
+            *revision.write() += 1;
+        }
+    });
+
+    // Read so a recorded visit redraws the list; the numbers say nothing.
+    let _ = revision();
+    let _ = state.visits_revision.read();
+
+    let now = chrono::Local::now();
+    let current = state.current_file();
+    // The folders between the root the document was reached through and the
+    // document itself. It truncates from the left, so what survives at any
+    // width is the part nearest the name.
+    let prefix = current
+        .as_deref()
+        .and_then(|file| {
+            let sidebar = state.sidebar.read();
+            let root = sidebar.roots.covering(file)?;
+            let parent = file.parent()?;
+            Some(trail(root, parent))
+        })
+        .unwrap_or_default();
+    let rows: Vec<Visit> = {
+        let visits = VISITS.read();
+        visits
+            .items
+            .iter()
+            // What is on screen is not somewhere to go back to.
+            .filter(|visit| current.as_deref() != Some(visit.path.as_path()))
+            .take(MAX_ROWS)
+            .cloned()
+            .collect()
+    };
+
+    rsx! {
+        div {
+            class: "breadcrumb",
+
+            button {
+                class: "breadcrumb-label",
+                class: if is_open() { "open" },
+                // No `title`: it would land on the list this opens. See the
+                // app menu's glyph in `components::header`.
+                "aria-label": "Recently read",
+                onclick: move |_| is_open.toggle(),
+                if !prefix.is_empty() {
+                    span { class: "breadcrumb-prefix", "{prefix}" }
+                }
+                span { class: "file-name", "{label}" }
+                Icon { name: IconName::ChevronDown, size: 12 }
+            }
+
+            if is_open() {
+                // Catches the click that closes the menu, so the rows below
+                // do not have to guess where the pointer went.
+                div {
+                    class: "breadcrumb-backdrop",
+                    onclick: move |_| is_open.set(false),
+                }
+
+                div {
+                    class: "breadcrumb-menu",
+
+                    if rows.is_empty() {
+                        div { class: "breadcrumb-empty", "Nothing else read yet" }
+                    }
+
+                    // Grouped by day, like every other window on this history:
+                    // "before this one" is a question about time, and the
+                    // heading is what makes the clock beside each row mean
+                    // something.
+                    for (bucket, entries) in crate::visits::group(&rows, now) {
+                        div { class: "breadcrumb-group", "{bucket.heading()}" }
+                        for visit in entries {
+                            div {
+                                key: "{visit.path.display()}",
+                                class: "breadcrumb-row",
+                                title: "{visit.path.display()}",
+                                onclick: {
+                                    let path = visit.path.clone();
+                                    move |_| {
+                                        state.open_file(&path);
+                                        is_open.set(false);
+                                    }
+                                },
+                                Icon { name: IconName::File, size: 14 }
+                                span {
+                                    class: "breadcrumb-row-name",
+                                    DocumentName { path: visit.path.clone() }
+                                }
+                                span {
+                                    class: "breadcrumb-row-when",
+                                    "{crate::visits::short_when(visit.at, now)}"
+                                }
+                            }
+                        }
+                    }
+
+                    div {
+                        class: "breadcrumb-row breadcrumb-row-all",
+                        onclick: move |_| {
+                            state.show_face(Face::Recent);
+                            is_open.set(false);
+                        },
+                        Icon { name: IconName::History, size: 14 }
+                        span { class: "breadcrumb-row-name", "All history…" }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// The folders from `root` down to `parent`, as `arto / docs /`.
+///
+/// The root's own name leads, because knowing which of several roots the
+/// document came from is the question the trail actually answers.
+fn trail(root: &Path, parent: &Path) -> String {
+    let root_name = root
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| root.to_string_lossy().into_owned());
+
+    let mut names = vec![root_name];
+    if let Ok(rest) = parent.strip_prefix(root) {
+        names.extend(
+            rest.components()
+                .map(|part| part.as_os_str().to_string_lossy().into_owned()),
+        );
+    }
+
+    // The trailing separator ends the string with neutral characters, and the
+    // element they land in is `direction: rtl` so that it truncates from the
+    // left. Bidi resolves trailing neutrals to the paragraph's direction,
+    // which put the separator at the visual *start* — "/ demo README.md". A
+    // left-to-right mark closes the run with a strong character, so the whole
+    // trail is one LTR run and reads in the order it was written.
+    format!("{} / \u{200e}", names.join(" / "))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn the_trail_starts_at_the_root_it_came_from() {
+        let root = PathBuf::from("/home/reader/arto");
+        let parent = PathBuf::from("/home/reader/arto/docs/design");
+        assert_eq!(trail(&root, &parent), "arto / docs / design / \u{200e}");
+    }
+
+    #[test]
+    fn a_document_in_the_root_names_only_the_root() {
+        let root = PathBuf::from("/home/reader/arto");
+        assert_eq!(trail(&root, &root), "arto / \u{200e}");
+    }
+
+    #[test]
+    fn a_parent_outside_the_root_still_names_the_root() {
+        // `covering` only hands over a root the file is under, so this is a
+        // defensive case rather than one the app reaches.
+        let root = PathBuf::from("/home/reader/arto");
+        let parent = PathBuf::from("/elsewhere");
+        assert_eq!(trail(&root, &parent), "arto / \u{200e}");
+    }
+}

--- a/crates/arto/src/components/main_app.rs
+++ b/crates/arto/src/components/main_app.rs
@@ -1,7 +1,7 @@
 use crate::ipc::OpenEvent;
 use crate::state::{Document, PersistedState};
 use crate::window::settings;
-#[cfg(not(target_os = "windows"))]
+#[cfg(target_os = "macos")]
 use dioxus::desktop::use_muda_event_handler;
 use dioxus::desktop::window;
 #[cfg(target_os = "macos")]
@@ -47,14 +47,14 @@ pub fn MainApp() -> Element {
     });
 
     // Set up global menu event handling
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(target_os = "macos")]
     use_muda_event_handler(move |event| {
         crate::menu::handle_menu_event_global(event);
     });
 
     // Keep native menu accelerators in sync with the keybinding config.
     // Runs on the main thread (required for muda menu mutation).
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(target_os = "macos")]
     use_future(move || async move {
         let mut rx = crate::config::CONFIG_CHANGED_BROADCAST.subscribe();
         while rx.recv().await.is_ok() {

--- a/crates/arto/src/components/theme_selector.rs
+++ b/crates/arto/src/components/theme_selector.rs
@@ -96,15 +96,21 @@ pub fn ThemeSelector(current_theme: Signal<Theme>) -> Element {
                 class: "theme-selector-main",
                 "aria-expanded": if is_expanded() { "true" } else { "false" },
                 "aria-haspopup": "menu",
-                title: current_title,
+                // No `title`: it would land on the list this opens. See the
+                // app menu's glyph in `components::header`.
+                "aria-label": current_title,
                 onmousedown: move |evt| {
                     evt.stop_propagation();
                 },
+                // The glyph says which theme is on, and pressing it names all
+                // three. Stepping to the next one instead made the control
+                // answer a question nobody asked — "what is after this?" —
+                // and put the theme two presses away from the one wanted.
                 onclick: move |evt| {
                     evt.stop_propagation();
                     is_expanded.set(!is_expanded());
                 },
-                Icon { name: current_icon, size: 18 }
+                Icon { name: current_icon }
             }
 
             // Dropdown menu (remaining 2 themes)
@@ -130,7 +136,7 @@ pub fn ThemeSelector(current_theme: Signal<Theme>) -> Element {
                             current_theme.set(theme);
                             is_expanded.set(false);
                         },
-                        Icon { name: icon, size: 18 }
+                        Icon { name: icon }
                     }
                 }
             }

--- a/crates/arto/src/hooks/viewer_window.rs
+++ b/crates/arto/src/hooks/viewer_window.rs
@@ -1,4 +1,4 @@
-#[cfg(not(target_os = "windows"))]
+#[cfg(target_os = "macos")]
 use dioxus::desktop::use_muda_event_handler;
 /// Common hooks for specialized viewer windows (Mermaid, Math, Image).
 /// Provides reusable functionality for window lifecycle and zoom synchronization.
@@ -27,7 +27,7 @@ fn is_close_shortcut(key: &str, meta_key: bool, ctrl_key: bool, alt_key: bool) -
 /// Handle Cmd+W and Cmd+Shift+W to close the viewer window.
 /// Call this in viewer window components to enable standard window close shortcuts.
 pub fn use_window_close_handler() {
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(target_os = "macos")]
     use_muda_event_handler(move |event| {
         if !window().is_focused() {
             return;

--- a/crates/arto/src/keybindings.rs
+++ b/crates/arto/src/keybindings.rs
@@ -43,9 +43,8 @@ pub fn shortcut_hint_for_action(action: &str, context: Option<KeyContext>) -> Op
 
 /// Return a formatted shortcut hint from global (and menu) keybindings.
 ///
-/// Only referenced by the Windows in-app menu (`win_hamburger`); platforms with
-/// a native menu (macOS/Linux) derive accelerators from `menu_shortcuts`.
-#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+/// This is the hint for an action reached by name rather than by key — from
+/// the in-app menu — so it asks for no context.
 pub fn shortcut_hint_for_global_action(action: &str) -> Option<String> {
     shortcut_hint_for_action(action, None)
 }

--- a/crates/arto/src/lib.rs
+++ b/crates/arto/src/lib.rs
@@ -11,7 +11,7 @@ mod hooks;
 pub mod ipc;
 mod keybindings;
 mod markdown;
-#[cfg(not(target_os = "windows"))]
+#[cfg(target_os = "macos")]
 mod menu;
 mod pinned_search;
 mod roots;
@@ -125,9 +125,13 @@ pub fn run(invocation: cli::CliInvocation) -> RunResult {
             }
         },
     );
-    #[cfg(not(target_os = "windows"))]
+    // Only macOS gets a native menu, because only there does it live outside
+    // the window. On Windows and Linux the same items hang off one glyph in
+    // the header instead, so nothing takes a strip of the window to say what
+    // the app is called.
+    #[cfg(target_os = "macos")]
     let config = config.with_menu(crate::menu::build_menu());
-    #[cfg(target_os = "windows")]
+    #[cfg(not(target_os = "macos"))]
     let config = config.with_menu(None);
 
     // Tao activates the app as soon as it finishes launching. `--behind` has

--- a/crates/arto/src/menu.rs
+++ b/crates/arto/src/menu.rs
@@ -1,3 +1,8 @@
+//! The native menu bar, which only macOS has.
+//!
+//! Windows and Linux draw the same items in the header instead
+//! (`components::app_menu`), so nothing here is compiled for them.
+
 use dioxus_desktop::muda::accelerator::Accelerator;
 use dioxus_desktop::muda::{Menu, MenuEvent, MenuItem, PredefinedMenuItem, Submenu};
 use dioxus_desktop::window;

--- a/crates/arto/src/roots.rs
+++ b/crates/arto/src/roots.rs
@@ -88,6 +88,11 @@ impl Roots {
         &self.temps
     }
 
+    /// Every root, places first, in the order the tree draws them.
+    pub fn all(&self) -> impl Iterator<Item = &PathBuf> {
+        self.places.iter().chain(self.temps.iter())
+    }
+
     /// Replace the places.
     ///
     /// The window's own folder is left alone, even when a place now covers it.
@@ -103,6 +108,15 @@ impl Roots {
         let mut seen = std::collections::HashSet::new();
         places.retain(|place| seen.insert(place.clone()));
         self.places = places;
+    }
+
+    /// The deepest root covering `target`, if any.
+    ///
+    /// Deepest rather than first: with both a repository and one of its
+    /// subdirectories open, a document inside the subdirectory belongs to the
+    /// narrower of the two.
+    pub fn covering(&self, target: &Path) -> Option<&PathBuf> {
+        deepest(self.all(), target)
     }
 
     /// The window's own folder, if it holds `target`.

--- a/crates/arto/src/state/app_state/document.rs
+++ b/crates/arto/src/state/app_state/document.rs
@@ -70,6 +70,25 @@ impl Document {
         }
     }
 
+    /// Whether there is no document to show.
+    pub fn is_empty(&self) -> bool {
+        matches!(
+            self.content,
+            DocumentContent::None | DocumentContent::Inline(_) | DocumentContent::FileError(_, _)
+        )
+    }
+
+    /// The name to put in the header and the window title.
+    pub fn display_name(&self) -> String {
+        match &self.content {
+            DocumentContent::File(path) | DocumentContent::FileError(path, _) => path
+                .file_name()
+                .map(|name| name.to_string_lossy().into_owned())
+                .unwrap_or_else(|| "Unnamed".to_string()),
+            DocumentContent::Inline(_) | DocumentContent::None => "Welcome".to_string(),
+        }
+    }
+
     /// Follow a link to another file, remembering where it came from.
     pub fn navigate_to(&mut self, file: impl Into<PathBuf>) {
         let file = file.into();
@@ -97,6 +116,34 @@ mod tests {
         assert_eq!(document.content, DocumentContent::File(path.clone()));
         assert_eq!(document.file(), Some(path.as_path()));
         assert_eq!(document.history.current_path(), Some(path.as_path()));
+    }
+
+    #[test]
+    fn the_name_is_the_file_name_whatever_is_in_it() {
+        assert_eq!(Document::new("/path/to/README").display_name(), "README");
+        assert_eq!(
+            Document::new("/path/to/日本語ファイル.md").display_name(),
+            "日本語ファイル.md"
+        );
+        assert_eq!(
+            Document::new("/path/to/.hidden.md").display_name(),
+            ".hidden.md"
+        );
+    }
+
+    #[test]
+    fn a_path_with_no_name_is_unnamed() {
+        let document = Document {
+            content: DocumentContent::File(PathBuf::from("/")),
+            ..Default::default()
+        };
+        assert_eq!(document.display_name(), "Unnamed");
+    }
+
+    #[test]
+    fn a_window_with_nothing_open_is_empty() {
+        assert!(Document::default().is_empty());
+        assert!(!Document::new("/test/file.md").is_empty());
     }
 
     #[test]

--- a/crates/arto/src/visits.rs
+++ b/crates/arto/src/visits.rs
@@ -3,7 +3,8 @@
 //! A reader loses nothing by closing a document, so "open" was never a state
 //! worth keeping — the only thing that turns out to matter is what was read
 //! and how recently. That is this list, and it is the one behind every way
-//! the interface offers to go back, starting with the panel's history face.
+//! the interface offers to go back: the list dropped from the breadcrumb and
+//! the panel's history face.
 //!
 //! Grouping coarsens with age. The last few days are worth separating by day;
 //! a year ago, the month is as fine as anyone needs, and a year before that,

--- a/crates/arto/src/window.rs
+++ b/crates/arto/src/window.rs
@@ -52,7 +52,7 @@ pub use child::{
     close_child_windows_for_last_focused, close_child_windows_for_parent,
     open_or_focus_image_window, open_or_focus_math_window, open_or_focus_mermaid_window,
 };
-#[cfg(not(target_os = "windows"))]
+#[cfg(target_os = "macos")]
 pub use main::has_any_main_windows;
 pub use main::{
     close_all_main_windows, create_main_window_config, create_main_window_sync,

--- a/frontend/src/context-menu-handler.test.ts
+++ b/frontend/src/context-menu-handler.test.ts
@@ -174,9 +174,13 @@ describe("extractTableDelimited", () => {
 
 describe("setup", () => {
   test("preserves relative href for normal links", () => {
+    // The page as the app draws it: the viewer holds the body, and its own
+    // padding is the margin a right-click can also land in.
     document.body.innerHTML = `
-      <div class="markdown-body">
-        <p><a href="./guide/page.md">Guide</a></p>
+      <div class="markdown-viewer">
+        <div class="markdown-body">
+          <p><a href="./guide/page.md">Guide</a></p>
+        </div>
       </div>
     `;
     document.caretRangeFromPoint = () => null;
@@ -210,5 +214,27 @@ describe("setup", () => {
     expect(captured).toMatchObject({
       context: { type: "link", href: "./guide/page.md" },
     });
+  });
+
+  test("a right-click in the margin is a right-click on the page", () => {
+    document.body.innerHTML = `
+      <div class="markdown-viewer">
+        <div class="markdown-body"><p>Something to read</p></div>
+      </div>
+    `;
+    document.caretRangeFromPoint = () => null;
+
+    let captured: unknown = null;
+    setup((data) => {
+      captured = data;
+    });
+
+    document
+      .querySelector(".markdown-viewer")
+      ?.dispatchEvent(
+        new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 4, clientY: 4 }),
+      );
+
+    expect(captured).not.toBeNull();
   });
 });

--- a/frontend/src/context-menu-handler.ts
+++ b/frontend/src/context-menu-handler.ts
@@ -479,6 +479,8 @@ function adjustMenuPosition(menu: HTMLElement): void {
 // Initialize the position adjuster
 setupMenuPositionAdjuster();
 let clearCursorOnClickInitialized = false;
+let pressWatchInitialized = false;
+let selectionWasTheReaders = false;
 
 /**
  * Setup context menu event listener on the markdown viewer
@@ -498,25 +500,65 @@ export function setup(sendToRust: (data: ContextMenuData) => void): void {
     clearCursorOnClickInitialized = true;
   }
 
+  // Whether the selection standing when the menu opens is one the reader
+  // made. WebKit selects the word under the pointer as part of the
+  // right-click itself, so by the time the menu is being built there is
+  // always "a selection" — and the menu would offer to copy a word nobody
+  // asked for. What was true a moment *before* the press is the answer, so
+  // it is taken then.
+  if (!pressWatchInitialized) {
+    document.addEventListener(
+      "mousedown",
+      (event) => {
+        if (event.button !== 2) {
+          return;
+        }
+        const target = event.target as HTMLElement | null;
+        const selection = window.getSelection();
+        selectionWasTheReaders = Boolean(
+          target?.closest(".markdown-viewer") &&
+          selection &&
+          !selection.isCollapsed &&
+          selection.containsNode(target, true),
+        );
+      },
+      true,
+    );
+    pressWatchInitialized = true;
+  }
+
   // Find the markdown body element
   const handler = (event: MouseEvent) => {
     const target = event.target as HTMLElement;
 
-    // Only handle right-clicks within markdown-body
-    const markdownBody = target.closest(".markdown-body");
-    if (!markdownBody) return;
+    // Anywhere in the page or the band above it. The margin is part of the
+    // document — it is where the page's own width is set from — and a
+    // right-click that lands an inch wide of a paragraph is a right-click on
+    // the page, not on nothing. The header is the same page's chrome, and it
+    // answers with the same menu rather than with one of its own.
+    const page = target.closest(".markdown-viewer, .header");
+    if (!page) return;
 
     // Prevent default browser context menu
     event.preventDefault();
 
-    // Keep content cursor aligned with the context-menu target so that
-    // context-menu actions and keyboard actions operate on the same element.
-    window.Arto?.contentCursor?.setFromContextTarget?.(target);
+    // A right-click with nothing selected is about the block it landed in, so
+    // the word the browser just selected is undone and the block is marked
+    // instead — the same block Ctrl+j would step to. With a selection the
+    // reader made, that selection is the subject and nothing is marked over
+    // it: a block highlight drawn across a few chosen words hides them.
+    if (!selectionWasTheReaders) {
+      window.getSelection()?.removeAllRanges();
+      if (target.closest(".markdown-body")) {
+        window.Arto?.contentCursor?.setFromContextTarget?.(target);
+      }
+    }
+
+    const { hasSelection, selectedText } = getTextSelection();
 
     // Detect context and send to Rust
     // Position adjustment is handled by MutationObserver after menu renders
     const { context, sourceLine: blockLine, sourceLineEnd: blockLineEnd } = detectContext(target);
-    const { hasSelection, selectedText } = getTextSelection();
     const tableData = detectTable(target);
 
     // Block elements override selection-based line detection

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,5 +1,6 @@
 import "../style/main.css";
 
+import { applyPictureTheme } from "./picture-theme";
 import { refreshReadingPosition, setupReadingPosition } from "./reading-position";
 import { setupRowHover } from "./row-hover";
 import { type Theme, currentTheme, isDarkTheme, themedElement } from "./theme";
@@ -149,9 +150,12 @@ declare global {
  */
 export function setCurrentTheme(theme: Theme): Promise<void> {
   themedElement().setAttribute("data-theme", theme);
-  // The stylesheet repaints on the attribute alone; only Mermaid has to be
-  // told, because its colours are baked into the SVG it already drew.
+  // The stylesheet repaints on the attribute alone. Mermaid has to be told,
+  // because its colours are baked into the SVG it already drew, and so do
+  // theme-aware pictures, whose media query answers for the system rather
+  // than for the theme the reader chose here.
   mermaidRenderer.setTheme(theme);
+  applyPictureTheme();
   return renderCoordinator.forceRenderMermaid();
 }
 

--- a/frontend/src/picture-theme.ts
+++ b/frontend/src/picture-theme.ts
@@ -1,0 +1,49 @@
+import { currentTheme, isDarkTheme } from "./theme";
+
+/**
+ * Theme-aware `<picture>` follows the theme Arto is painting, not the OS's.
+ *
+ * GitHub's documented shape for a light/dark image is a `<source>` carrying
+ * `media="(prefers-color-scheme: dark)"`. That query answers for the system,
+ * and Arto's theme is its own setting: a reader on a light desktop reading in
+ * `dark_dimmed` would otherwise get the light artwork on the dark page, which
+ * is the one combination the author drew two images to avoid.
+ *
+ * So the query is answered here instead. Each `prefers-color-scheme` term is
+ * swapped for one that is true or false by construction, and the original is
+ * kept on the element so the next theme can be answered from it rather than
+ * from what the last one left behind. Everything else in the media condition
+ * (a width, a resolution) is left to the browser.
+ */
+const COLOR_SCHEME = /\(\s*prefers-color-scheme\s*:\s*(dark|light)\s*\)/gi;
+
+/** True in every viewport there is. */
+const ALWAYS = "(min-width: 0px)";
+
+/** False in every viewport there is — no `<source>` will be picked over it. */
+const NEVER = "(min-width: 999999px)";
+
+const ORIGINAL_MEDIA = "artoMedia";
+
+export function applyPictureTheme(root: ParentNode = document): void {
+  const dark = isDarkTheme(currentTheme());
+
+  for (const source of root.querySelectorAll("picture source[media]")) {
+    if (!(source instanceof HTMLSourceElement)) {
+      continue;
+    }
+
+    const original = source.dataset[ORIGINAL_MEDIA] ?? source.media;
+    const resolved = original.replace(COLOR_SCHEME, (_, scheme: string) =>
+      (scheme.toLowerCase() === "dark") === dark ? ALWAYS : NEVER,
+    );
+    if (resolved === original) {
+      continue;
+    }
+
+    source.dataset[ORIGINAL_MEDIA] = original;
+    if (source.media !== resolved) {
+      source.media = resolved;
+    }
+  }
+}

--- a/frontend/src/render-coordinator.ts
+++ b/frontend/src/render-coordinator.ts
@@ -1,3 +1,4 @@
+import { applyPictureTheme } from "./picture-theme";
 import * as mathRenderer from "./math-renderer";
 import * as mermaidRenderer from "./mermaid-renderer";
 import * as syntaxHighlighter from "./syntax-highlighter";
@@ -327,6 +328,7 @@ class RenderCoordinator {
     try {
       await Promise.all(
         Array.from(markdownBodies).map(async (markdownBody) => {
+          applyPictureTheme(markdownBody);
           mathRenderer.renderMath(markdownBody);
           syntaxHighlighter.highlightCodeBlocks(markdownBody);
           await mermaidRenderer.renderDiagrams(markdownBody);

--- a/frontend/style/components/header.css
+++ b/frontend/style/components/header.css
@@ -1,79 +1,64 @@
 @import url("./header/theme-selector.css");
 
+/* The band above the document.
+   It holds its own row at the top of the window and the page begins below it,
+   on the same ground and with no line between them: the margin at the top of
+   the document is the whole of the separation, which is one device fewer for
+   the same boundary. */
 .header {
   flex-shrink: 0;
-  align-items: center;
-  background: var(--bg-color);
-  display: flex;
-  justify-content: space-between;
-  padding: 10px 20px;
-  /* Stay above search bar */
   position: relative;
   z-index: var(--z-header);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: var(--header-height);
+  box-sizing: border-box;
+  padding: 0 20px;
+  background: var(--bg-color);
 }
 
+/* No `overflow: hidden` here. The breadcrumb's menu hangs below this row,
+   and clipping the row clipped the menu away entirely — it opened into
+   nothing. What this used to guard against is handled where it belongs:
+   `min-width: 0` lets the flex items shrink, and the trail and the file name
+   each truncate themselves. */
+/* The band's text sits a size below the document's, so the name of what is
+   being read never competes with the reading. */
 .header-left {
   color: var(--text-color);
   flex: 1;
   min-width: 0;
-  overflow: hidden;
-  font-size: var(--font-size-base);
+  font-size: var(--font-size-sm);
   font-weight: 500;
   display: flex;
   align-items: center;
   gap: 8px;
-  opacity: var(--opacity-muted);
-  transition: opacity 0.4s;
 }
 
-.header:hover .header-left {
-  opacity: 0.7;
-
-  &:hover {
-    opacity: 1;
-  }
-}
-
-.header-left .left-sidebar-toggle-button,
+/* Quiet control: the glyph is small and faint, the target is not. Nothing
+   is painted at rest -- no surface, no border -- so the band reads as a few
+   marks rather than a row of buttons. */
 .header-left .nav-button {
   flex-shrink: 0;
   background: transparent;
-  border: 1px solid transparent;
+  border: none;
   border-radius: var(--radius-sm);
   color: var(--text-color);
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 4px;
-  transition: all var(--transition-normal);
-  width: 28px;
-  height: 28px;
-
-  &:hover:not(:disabled) {
-    border-color: var(--border-color);
-    background: var(--bg-secondary);
-  }
-
-  &:disabled {
-    opacity: var(--opacity-subtle);
-    cursor: not-allowed;
-  }
+  padding: 0;
+  width: var(--hit-size);
+  height: var(--hit-size);
+  opacity: var(--opacity-rest);
+  transition:
+    opacity var(--transition-quiet) ease,
+    background-color var(--transition-quiet) ease;
 
   .icon {
     color: var(--text-color);
-  }
-}
-
-.header-left .left-sidebar-toggle-button {
-  margin-right: 4px;
-
-  .icon {
-    opacity: var(--opacity-muted);
-  }
-
-  &.active .icon {
-    opacity: 1;
   }
 }
 
@@ -103,22 +88,6 @@
   opacity: 1;
 }
 
-.header .header-left .file-action-buttons .nav-button {
-  flex-shrink: 0;
-  width: 24px;
-  height: 24px;
-  padding: 3px;
-  opacity: var(--opacity-muted);
-  transition:
-    opacity var(--transition-normal),
-    color var(--transition-normal);
-}
-
-/* Show file action buttons on header hover */
-.header:hover .header-left .file-action-buttons .nav-button:hover:not(:disabled) {
-  opacity: 1;
-}
-
 /* Copy button success state - always visible when copied (higher specificity) */
 .header .header-left .file-action-buttons {
   .copy-button.copied {
@@ -145,36 +114,46 @@
 
 .header-right .nav-button {
   background: transparent;
-  border: 1px solid transparent;
+  border: none;
   border-radius: var(--radius-sm);
-  color: var(--text-secondary);
+  color: var(--text-color);
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 4px;
-  transition: all var(--transition-normal);
-  width: 28px;
-  height: 28px;
-
-  &:hover:not(:disabled) {
-    border-color: var(--border-color);
-    background: var(--bg-secondary);
-    color: var(--text-color);
-  }
-
-  &.active {
-    color: var(--text-color);
-  }
-
-  &:disabled {
-    opacity: var(--opacity-subtle);
-    cursor: not-allowed;
-  }
+  padding: 0;
+  width: var(--hit-size);
+  height: var(--hit-size);
+  opacity: var(--opacity-rest);
+  transition:
+    opacity var(--transition-quiet) ease,
+    background-color var(--transition-quiet) ease;
 
   .icon {
     color: inherit;
   }
+}
+
+/* State is a step along the same scale, not a colour and not a filled chip. */
+.header .nav-button.active {
+  opacity: var(--opacity-active);
+}
+
+/* The whole band wakes together: by the time the pointer arrives at a
+   control it is already legible, so nothing has to be hunted for. */
+.header:hover .nav-button,
+.header:hover .theme-selector-main {
+  opacity: var(--opacity-woken);
+}
+
+.header:hover .nav-button.active {
+  opacity: 1;
+}
+
+.header .nav-button:hover,
+.header .theme-selector-main:hover {
+  opacity: 1;
+  background: var(--bg-secondary);
 }
 
 /* ========================================
@@ -187,7 +166,7 @@
 }
 
 .header-left:hover .file-action-buttons .bookmark-button {
-  opacity: var(--opacity-muted);
+  opacity: var(--opacity-woken);
 }
 
 .file-action-buttons .bookmark-button:hover {
@@ -195,6 +174,165 @@
 }
 
 .file-action-buttons .bookmark-button.bookmarked {
-  opacity: var(--opacity-hover);
-  color: var(--accent-bg);
+  opacity: var(--opacity-active);
+}
+
+/* --- Breadcrumb ------------------------------------------------------ */
+
+/* The document's name is also the control that drops the recent ones.
+   Nothing is painted at rest — it reads as the title it already was — and
+   the chevron only appears once the band is awake. */
+.breadcrumb {
+  position: relative;
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.breadcrumb-label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  padding: 2px 6px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: inherit;
+  font-family: inherit;
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color var(--transition-quiet) ease;
+
+  .icon {
+    flex-shrink: 0;
+    opacity: 0;
+    transition: opacity var(--transition-quiet) ease;
+  }
+}
+
+.header:hover .breadcrumb-label .icon,
+.breadcrumb-label.open .icon {
+  opacity: var(--opacity-rest);
+}
+
+.breadcrumb-label:hover,
+.breadcrumb-label.open {
+  background: var(--bg-secondary);
+
+  .icon {
+    opacity: var(--opacity-woken);
+  }
+}
+
+.breadcrumb-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-dropdown);
+}
+
+/* It hangs from the name rather than floating near it: the top corners are
+   square because the header is what it is attached to, and the shadow falls
+   down the page it is over. No ring — something already floating needs no
+   outline. */
+.breadcrumb-menu {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: calc(var(--z-dropdown) + 1);
+  min-width: 244px;
+  max-width: 420px;
+  max-height: 60vh;
+  overflow-y: auto;
+  padding: 0 4px 6px;
+  background: var(--bg-color);
+  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
+  box-shadow: var(--shadow-drop);
+}
+
+/* The same word-on-a-hairline the panel's history uses. */
+.breadcrumb-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 10px 10px 3px;
+  font-size: var(--font-size-sm);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  opacity: var(--opacity-secondary);
+}
+
+.breadcrumb-group::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--border-color);
+}
+
+.breadcrumb-row-when {
+  flex: none;
+  margin-left: auto;
+  padding-left: 12px;
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  opacity: var(--opacity-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
+.breadcrumb-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-md);
+  font-weight: 400;
+  color: var(--text-color);
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+
+  .icon {
+    flex-shrink: 0;
+    opacity: var(--opacity-muted);
+  }
+}
+
+.breadcrumb-row:hover {
+  background: var(--bg-secondary);
+}
+
+.breadcrumb-row-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* The way out of the short list and into the whole history. */
+.breadcrumb-row-all {
+  color: var(--text-secondary);
+}
+
+.breadcrumb-empty {
+  padding: 12px 10px;
+  font-size: var(--font-size-md);
+  color: var(--text-secondary);
+  opacity: var(--opacity-secondary);
+}
+
+/* The trail from the root shortens from the left as the window narrows, so
+   what survives is always the part nearest the name. The header's right is
+   only 90px of glyphs and takes none of the document's width, so nothing
+   there has to fold into an overflow menu: this is what absorbs the shrink. */
+.breadcrumb-prefix {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  direction: rtl;
+  font-weight: 400;
+  color: var(--text-secondary);
+  opacity: var(--opacity-secondary);
 }

--- a/frontend/style/components/header/theme-selector.css
+++ b/frontend/style/components/header/theme-selector.css
@@ -7,37 +7,32 @@
   display: flex;
 }
 
-/* Main button (current theme) */
+/* Main button (current theme). Same quiet control as the rest of the band:
+   no surface or border at rest, and the header's hover rules wake it. */
 .theme-selector-main {
   appearance: none;
   background: transparent;
-  border: 1px solid transparent;
-  border-radius: var(--radius-md);
+  border: none;
+  border-radius: var(--radius-sm);
   color: var(--text-color);
   cursor: pointer;
   line-height: 1;
-  padding: 8px;
-  min-width: 36px;
-  min-height: 36px;
+  padding: 0;
+  width: var(--hit-size);
+  height: var(--hit-size);
   display: flex;
   align-items: center;
   justify-content: center;
-  opacity: var(--opacity-muted);
+  opacity: var(--opacity-rest);
   transition:
-    opacity var(--transition-normal) ease,
-    border-color var(--transition-normal) ease,
-    background-color var(--transition-normal) ease;
-}
-
-.theme-selector-main:hover {
-  opacity: 1;
-  border-color: var(--border-color);
-  background: var(--bg-secondary);
+    opacity var(--transition-quiet) ease,
+    background-color var(--transition-quiet) ease;
 }
 
 /* Expanded state - make button fully visible */
 .theme-selector-main[aria-expanded="true"] {
   opacity: 1;
+  background: var(--bg-secondary);
 }
 
 .theme-selector-main:focus-visible {
@@ -88,9 +83,9 @@
   color: var(--text-color);
   cursor: pointer;
   line-height: 1;
-  padding: 8px;
-  min-width: 36px;
-  min-height: 36px;
+  padding: 0;
+  width: var(--hit-size);
+  height: var(--hit-size);
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary

- The document's name is the control that drops the recent documents, its folder, and the whole history.
- The app's menu is one glyph at the head of the header, on every platform; macOS keeps its native menu bar as well.
- The theme control opens a menu rather than cycling, and theme-aware `<picture>` follows it.
- A right-click on the page's margin or on the header answers with the document's menu.

## Why

The header said the file name and offered a row of buttons; the way back through what had been read was two arrows that only knew this window's own trail, and the whole of the app's commands lived in a menu bar that macOS draws at the top of the *screen* — and on Windows in a hamburger that only Windows had.

So the name of what is being read is itself the control: it drops the documents read before this one, the folder the document sits in, and the way into the whole history. The trail to it truncates from the left as the window narrows, which is what absorbs the shrink so nothing on the right has to fold into an overflow menu.

The app's own menu is one glyph at the head of the header, on every platform. macOS keeps its menu bar too — it belongs to whichever window is frontmost and sits at the top of the screen rather than of the window — but the glyph is where the commands are when you are looking at the window.

The theme control opens a menu rather than cycling: three states behind one button meant pressing it to find out where you were. Pictures follow the theme it sets. GitHub's shape for a light/dark image asks the system what it prefers, which is not what Arto is painting, so the media query is answered here instead — otherwise a reader on a light desktop reading a dark theme gets the light artwork, the one pairing the author drew two images to avoid.

The band is chrome over the page rather than a surface of its own, so a right-click on it answers with the document's menu. The page's margin does too: it is where the page's width is set from, and a right-click an inch wide of a paragraph is a right-click on the page, not on nothing. With nothing selected the menu is about the block it landed in — the word WebKit selects as part of the press itself is put back, because nobody asked for it.

Everything in the band is drawn quietly: nothing painted at rest, the whole band waking together when the pointer enters it, and state said as a step of ink rather than as a colour or a filled chip.

## Test Plan

- [ ] The document's name drops the recent documents, its folder, and the way into the whole history
- [ ] The glyph at the head of the header opens the app's menu on every platform
- [ ] The theme control opens a menu
- [ ] A right-click on the page margin or on the header answers with the document's menu
- [ ] A light/dark `<picture>` follows the theme Arto is painting, not the system's
- [ ] `just fmt check test`

## Stack

These land in order; each is based on the one above it.

1. #265 — chore(dev): sign the bundle `dx serve` builds on macOS
2. #266 — feat(preferences): a window, not a tab
3. #267 — feat(window): one document to a window
4. #268 — feat(panel): several roots, and the folders you keep
5. #269 — feat(panel): one panel, three faces, and the history among them
6. #270 — feat(contents): the contents live beside the page
7. #271 — feat(header): the document's name is the way back, and one glyph opens the app 👈 **this one**
8. #272 — feat(search): find in the header, and the marks stay in the contents
9. #273 — feat(welcome): a window with nothing open says what there is to read
10. #274 — feat(layout): give way to the document
11. #275 — feat(keys): every list and every field answers to bindings
12. #276 — feat(recent): remember where a document was left, and open it there
13. #277 — feat(menu): give every menu row its icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01731Zfkg9P6V4Lm7buLEN53
