### PR TITLE
feat(layout): give way to the document

### DIFF
--- a/.claude/rules/ui-design.md
+++ b/.claude/rules/ui-design.md
@@ -43,6 +43,13 @@ Arto uses a comprehensive design token system defined in `variables.css` for con
 --opacity-muted: 0.5;       /* Default icons, placeholders */
 --opacity-secondary: 0.6;   /* Secondary text */
 --opacity-hover: 0.8;       /* Hover state for icons */
+
+/* Quiet controls (see "Quiet controls" below) */
+--opacity-rest: 0.3;        /* A chrome control at rest */
+--opacity-woken: 0.72;      /* Its band has the pointer in it */
+--opacity-active: 0.65;     /* Selected or on, at rest */
+--hit-size: 30px;           /* Target size, independent of the glyph */
+--transition-quiet: 0.18s;
 ```
 
 **Z-Index Semantic Scale:**
@@ -91,7 +98,57 @@ wrong in every theme but the one it was taken from.
 - Use `transparent` backgrounds where possible
 - Use thin borders (`1px`) instead of thick (`2px`)
 - Prefer `font-weight: 400-500` over bold for navigation
-- Icon opacity: `var(--opacity-muted)` default, `var(--opacity-hover)` on hover/active
+
+### Quiet controls
+
+Chrome controls separate what is drawn from what can be hit, so a band of them
+reads as a few faint marks while staying as easy to click as a toolbar:
+
+- 16px glyph, `stroke-width: 1.5`, inside a `var(--hit-size)` (30px) target.
+- Nothing painted at rest: no border, no surface. A surface appears only under
+  the pointer, and only on the one control being pointed at.
+- `--opacity-rest` at rest, `--opacity-woken` when the pointer enters the band
+  (`.header:hover .nav-button`, not each button on its own), `1` under the
+  pointer. Waking the whole band means a control is already legible by the time
+  it is aimed at.
+- State is a step along that same scale — `--opacity-active` — not a colour and
+  not a filled chip.
+- A control that cannot act is not drawn. `disabled` styling leaves something
+  in the eye that offers nothing; render the button conditionally instead.
+
+### Giving way to the document
+
+When the window cannot hold everything, the document wins. There is one
+setting — `sidebar.minContentWidth` (640px by default, 360–900) — and every
+threshold is that number plus the width of whatever is still drawn beside the
+page. Things give way from the outside in:
+
+| Order | What folds | Threshold | Default |
+| --- | --- | --- | --- |
+| 1 | Margin trace (138px) | min + rail + panel + trace + gutter | below 1068px |
+| 2 | Panel (its current width) | min + rail + panel + gutter | below 930px |
+| 3 | Contents gutter (24px) | min + rail + gutter | below 704px |
+| 4 | Rail (40px) | min + rail | below 680px |
+
+`crate::hooks::layout_budget::budget` is the whole rule, and it is pure — the
+table above is its test. `AppState::visible_chrome` collects the window's own
+numbers for it, measuring width *after zoom* because magnifying the page is
+the same as narrowing the window.
+
+What comes back is state, never settings: widening the window restores the
+panel exactly as configured. The one thing width never overrides is a panel
+the reader folded with Cmd+B, because that was intent.
+
+Nothing folds without something behind it. The panel is the clearest case:
+`AppState::show_panel` pins it beside the document when the width allows and
+peeks it over the document when it does not, so Cmd+B and the rail still open
+something at any width — and the pinned choice itself is left untouched, which
+is what lets widening restore it. The contents gutter has the same
+arrangement: `contents.toggle` opens the same headings as an overlay.
+
+The header's right takes none of the document's width, so it never folds into
+an overflow menu; the breadcrumb's trail truncates from the left instead
+(`arto / … / README.md`) and absorbs the shrink.
 
 ### Visual Consistency
 
@@ -114,8 +171,8 @@ a settings tab sitting open for days, so it gets a window that closes instead.
   rather than duplicated, closed with its parent.
 - The window holds no `AppState`. What the "Current Settings" section reports
   comes over as a `PreferencesSnapshot` taken when it opens, and what it
-  changes goes back through the `SET_*_ZOOM_IN_WINDOW` events, targeted at the
-  window that opened it.
+  changes goes back through `events::SET_SIDEBAR_ZOOM_IN_WINDOW`, targeted at
+  the window that opened it.
 - `AppState::open_preferences()` is still the single entry point, so the menu
   item and the keybinding stay unchanged.
 
@@ -251,9 +308,9 @@ When content should fit without scrolling:
 }
 ```
 
-## Menu Integration with Tab Content
+## Menu Integration with the Preferences Window
 
-**Opening a specific tab when menu item is clicked:**
+**Opening a specific section when a menu item is clicked:**
 
 1. Create a static function to set the tab state before opening:
    ```rust
@@ -286,40 +343,25 @@ When content should fit without scrolling:
 
 **Unified context menu behavior across components:**
 
-Arto implements context menus in three areas:
-1. **Tab context menu** - Right-click on tab items
-2. **Sidebar tree context menu** - Right-click on files/directories
-3. **Content context menu** - Right-click in markdown viewer (future)
+Arto implements context menus in two areas:
+1. **Sidebar tree context menu** - Right-click on files/directories
+2. **Content context menu** - Right-click in markdown viewer
 
 ### Common Patterns
 
-**1. Window targeting with submenus:**
+**1. Hoisting the menu out of what it acts on:**
 ```rust
-// Refresh window list on menu open
-let handle_context_menu = move |evt: Event<MouseData>| {
-    let windows = crate::window::main::list_visible_main_windows();
-    let current_id = window().id();
-    other_windows.set(
-        windows
-            .iter()
-            .filter(|w| w.window.id() != current_id)
-            .map(|w| (w.window.id(), w.window.title()))
-            .collect(),
-    );
-    show_context_menu.set(true);
-};
-
-// Handler uses fire-and-forget transfer + auto-focus
-let handle_move_to_window = move |target_id: WindowId| {
-    crate::events::TRANSFER_TAB_TO_WINDOW.send((target_id, None, tab));
-    crate::window::main::focus_window(target_id);
-    show_context_menu.set(false);
-};
+// The row only records what was asked for; the menu itself is rendered once
+// at the app-container root by `SidebarContextMenuHost`, so a watcher-driven
+// remount of the tree cannot unmount an open menu.
+state.sidebar_context_menu.set(Some(SidebarContextMenuData::new(
+    cursor, viewport, path, kind, closable,
+)));
 ```
 
 **2. Submenu hover behavior:**
 ```rust
-// Track submenu state to show/hide "Open in Window" options
+// A flyout opens while the pointer rests on its parent item
 let mut show_submenu = use_signal(|| false);
 
 div {
@@ -327,21 +369,18 @@ div {
     onmouseenter: move |_| show_submenu.set(true),
     onmouseleave: move |_| show_submenu.set(false),
 
-    span { "Open in Window" }
+    span { "Copy As" }
     span { class: "submenu-arrow", "›" }
 
     if *show_submenu.read() {
-        div {
-            class: "context-submenu",
-            // Window list...
-        }
+        div { class: "context-submenu", /* items */ }
     }
 }
 ```
 
 **3. Backdrop for outside-click closing:**
 ```rust
-// Invisible backdrop catches clicks outside menu
+// Invisible backdrop catches clicks outside the menu
 div {
     class: "context-menu-backdrop",
     onclick: move |_| on_close.call(()),
@@ -353,7 +392,6 @@ div {
 **Stop propagation to prevent conflicts:**
 - Context menu clicks should `evt.stop_propagation()` to prevent parent handlers
 - Sidebar tree clicks use split areas with `stop_propagation()` on chevron
-- Tab context menu should not interfere with drag events
 
 ### Menu Positioning
 
@@ -375,5 +413,5 @@ div {
 }
 ```
 
-**Auto-focus target window after operations:**
-All "Open in Window" / "Move to Window" operations should call `crate::window::main::focus_window(target_id)` after sending the event, providing immediate visual feedback to the user.
+**Auto-focus a window an action reached across:**
+An action that acts on another window calls `crate::window::main::focus_window(target_id)` after sending its event, so the window it acted on is the one in front.

--- a/crates/arto-config/src/lib.rs
+++ b/crates/arto-config/src/lib.rs
@@ -74,6 +74,14 @@ mod tests {
     }
 
     #[test]
+    fn the_old_name_for_always_still_parses() {
+        // `hidden_when_full_width` named a choice that is now simply what
+        // happens: a document at full width has no margin for the trace.
+        let parsed: RecentTrace = serde_json::from_str(r#""hidden_when_full_width""#).unwrap();
+        assert_eq!(parsed, RecentTrace::Always);
+    }
+
+    #[test]
     fn test_config_default() {
         let config = Config::default();
 
@@ -92,6 +100,9 @@ mod tests {
 
         // Sidebar defaults
         assert!(!config.sidebar.default_pinned); // Default is false (unpinned, overlay on hover)
+        assert_eq!(config.sidebar.min_content_width, 640.0);
+        assert_eq!(config.sidebar.recent_trace, RecentTrace::HiddenWhenSidebar);
+        assert_eq!(config.sidebar.recent_trace_count, 6);
         assert_eq!(config.sidebar.default_width, 280.0);
         assert!(!config.sidebar.default_show_all_files);
         assert_eq!(config.sidebar.default_zoom_level, 1.0);
@@ -168,6 +179,9 @@ mod tests {
                 default_width: 320.0,
                 default_show_all_files: true,
                 default_zoom_level: 1.2,
+                min_content_width: 800.0,
+                recent_trace: RecentTrace::Always,
+                recent_trace_count: 4,
                 on_open: OpenFromPanel::ClosePanel,
                 on_startup: StartupBehavior::LastClosed,
                 on_new_window: NewWindowBehavior::LastFocused,
@@ -232,6 +246,9 @@ mod tests {
         assert!(!parsed.sidebar.default_pinned);
         assert_eq!(parsed.sidebar.default_width, 320.0);
         assert_eq!(parsed.sidebar.default_zoom_level, 1.2);
+        assert_eq!(parsed.sidebar.min_content_width, 800.0);
+        assert_eq!(parsed.sidebar.recent_trace, RecentTrace::Always);
+        assert_eq!(parsed.sidebar.recent_trace_count, 4);
         assert_eq!(parsed.window_position.default_position.x.value, 10.0);
         assert_eq!(
             parsed.window_position.default_position.x.unit,
@@ -268,6 +285,9 @@ mod tests {
 
         // Sidebar zoom and layout defaults
         assert_eq!(parsed.sidebar.default_zoom_level, 1.0);
+        assert_eq!(parsed.sidebar.min_content_width, 640.0);
+        assert_eq!(parsed.sidebar.recent_trace, RecentTrace::HiddenWhenSidebar);
+        assert_eq!(parsed.sidebar.recent_trace_count, 6);
         assert_eq!(parsed.file_open, FileOpenBehavior::LastFocused);
     }
 

--- a/crates/arto-config/src/sidebar_config.rs
+++ b/crates/arto-config/src/sidebar_config.rs
@@ -5,12 +5,57 @@ use serde::{Deserialize, Serialize};
 /// Default sidebar width in pixels
 pub const DEFAULT_SIDEBAR_WIDTH: f64 = 280.0;
 
+/// Default width the document is not narrowed below while anything else can
+/// give way instead.
+pub const DEFAULT_MIN_CONTENT_WIDTH: f64 = 640.0;
+
+/// The narrowest and widest the minimum content width may be set to.
+pub const MIN_CONTENT_WIDTH_RANGE: std::ops::RangeInclusive<f64> = 360.0..=900.0;
+
+/// How many documents the margin trace names by default.
+pub const DEFAULT_RECENT_TRACE_COUNT: usize = 6;
+
 fn default_sidebar_width() -> f64 {
     DEFAULT_SIDEBAR_WIDTH
 }
 
+fn default_min_content_width() -> f64 {
+    DEFAULT_MIN_CONTENT_WIDTH
+}
+
+fn default_recent_trace_count() -> usize {
+    DEFAULT_RECENT_TRACE_COUNT
+}
+
 fn default_sidebar_zoom_level() -> f64 {
     DEFAULT_ZOOM_LEVEL
+}
+
+/// When the margin trace — the documents read before this one, left at the
+/// edge of the page — is drawn.
+///
+/// It is the one window on the history nobody asks for, which is why it is
+/// the one that can be turned off. Whatever is chosen here, the trace is
+/// drawn only where there is a margin to draw it in: a window too narrow to
+/// keep the document readable hides it, and so does a document set to the
+/// full width, which leaves no margin at all. That is state, not a change to
+/// this setting.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RecentTrace {
+    /// Never drawn.
+    Never,
+    /// Hidden while the panel is out, since it already lists documents.
+    #[default]
+    HiddenWhenSidebar,
+    /// Always drawn, where there is a margin for it.
+    ///
+    /// `hidden_when_full_width` is the old name of this: it named a choice
+    /// that is now simply what happens, since a document at full width has no
+    /// margin for the trace to be in. A configuration that still says it
+    /// keeps working and means this.
+    #[serde(alias = "hidden_when_full_width")]
+    Always,
 }
 
 /// What the panel does once a document has been opened from one of its rows.
@@ -44,6 +89,19 @@ pub struct SidebarConfig {
     /// Default zoom level for sidebar content
     #[serde(default = "default_sidebar_zoom_level")]
     pub default_zoom_level: f64,
+    /// The width the document keeps while anything else can give way instead.
+    ///
+    /// Every threshold in the layout is this number plus the width of what
+    /// is still drawn beside the document, so raising it folds the trace,
+    /// the panel, the gutter and the rail at correspondingly wider windows.
+    #[serde(default = "default_min_content_width")]
+    pub min_content_width: f64,
+    /// When the margin trace is drawn.
+    #[serde(default)]
+    pub recent_trace: RecentTrace,
+    /// How many documents the margin trace names.
+    #[serde(default = "default_recent_trace_count")]
+    pub recent_trace_count: usize,
     /// What the panel does once a document has been opened from it.
     #[serde(default)]
     pub on_open: OpenFromPanel,
@@ -60,6 +118,9 @@ impl Default for SidebarConfig {
             default_width: default_sidebar_width(),
             default_show_all_files: false,
             default_zoom_level: default_sidebar_zoom_level(),
+            min_content_width: default_min_content_width(),
+            recent_trace: RecentTrace::default(),
+            recent_trace_count: default_recent_trace_count(),
             on_open: OpenFromPanel::default(),
             on_startup: StartupBehavior::Default,
             on_new_window: NewWindowBehavior::Default,

--- a/crates/arto/src/components/app.rs
+++ b/crates/arto/src/components/app.rs
@@ -29,7 +29,7 @@ use crate::theme::Theme;
 use drag_drop_overlay::DragDropOverlay;
 use drop_handlers::handle_dropped_files;
 use keybinding_engine::setup_keybinding_engine;
-use listeners::setup_preferences_listeners;
+use listeners::setup_window_listeners;
 use shortcut_overlay::{
     build_shortcut_help_items, close_shortcut_overlay, split_shortcut_help_columns,
     ShortcutHelpOverlay, ShortcutOverlayVisibility,
@@ -180,7 +180,7 @@ pub fn App(
         }
     });
 
-    setup_preferences_listeners(state);
+    setup_window_listeners(state);
 
     // Keep the window title on the document being read
     use_effect(move || {
@@ -210,14 +210,12 @@ pub fn App(
     // Hover state for overlay sidebars is stored in AppState
     // so that dispatcher.rs (keybinding focus actions) can access it.
     let mut left_hover_active = state.left_hover_active;
-    // Generation counters for auto-hide timer cancellation
+    // Generation counter for auto-hide timer cancellation
     let mut left_hide_gen = use_signal(|| 0u32);
     // Track whether mouse is physically inside the overlay wrapper.
     // Used by on_resize_change to decide whether to start a hide timer:
     // if mouse is inside, onmouseleave will handle hiding naturally.
     let mut left_mouse_inside = use_signal(|| false);
-
-    let left_pinned = state.sidebar.read().pinned;
 
     /// Grace before a peeking panel retracts.
     ///
@@ -257,6 +255,14 @@ pub fn App(
             retract_after_grace(left_hide_gen, left_hover_active);
         }
     });
+
+    // The width has the last word on what is drawn beside the document. The
+    // panel's own choice is untouched by it, so widening the window brings a
+    // panel back exactly as it was left; a panel folded with Cmd+B stays
+    // folded, because that was intent rather than a consequence of width.
+    let chrome = use_memo(move || state.visible_chrome());
+    let rail_visible = use_memo(move || chrome().rail);
+    let left_pinned = state.sidebar.read().pinned && chrome().panel;
 
     let focused_panel = *state.focused_panel.read();
     let focused_context = focused_panel.key_context();
@@ -309,22 +315,25 @@ pub fn App(
                 });
             },
 
-            // The rail switches the panel's faces and, because it is visible
+            // The rail is here whenever the window can spare 40px for it. It
+            // is what switches the panel's faces and, because it is visible
             // and exists for the purpose, it is also what the pointer can
             // safely aim at to bring the panel back.
-            crate::components::sidebar::rail::Rail {
-                on_peek: move |face| {
-                    // Resting on a glyph brings that face over the document. A
-                    // panel that is being held stays as it was: what is held
-                    // was chosen, and a pointer passing over the rail is not a
-                    // choice — it would rewrite the reader's own with nothing
-                    // but a hover.
-                    if !left_pinned {
-                        state.sidebar.write().face = face;
-                        left_hover_active.set(true);
-                        left_hide_gen.set(left_hide_gen() + 1);
-                    }
-                },
+            if rail_visible() {
+                crate::components::sidebar::rail::Rail {
+                    on_peek: move |face| {
+                        // Resting on a glyph brings that face over the
+                        // document. A panel that is being held stays as it
+                        // was: what is held was chosen, and a pointer passing
+                        // over the rail is not a choice — it would rewrite the
+                        // reader's own with nothing but a hover.
+                        if !left_pinned {
+                            state.sidebar.write().face = face;
+                            left_hover_active.set(true);
+                            left_hide_gen.set(left_hide_gen() + 1);
+                        }
+                    },
+                }
             }
 
             // Left sidebar: pinned → flex layout, unpinned → overlay with animation
@@ -347,7 +356,7 @@ pub fn App(
                     // Stand beside the rail rather than over it: the marks
                     // that peeked the panel out are the ones that switch its
                     // faces and send it back, so they have to stay visible.
-                    class: "beside-rail",
+                    class: if rail_visible() { "beside-rail" },
                     class: if left_hover_active() { "visible" },
                     onmouseenter: move |_| {
                         left_mouse_inside.set(true);

--- a/crates/arto/src/components/app/listeners.rs
+++ b/crates/arto/src/components/app/listeners.rs
@@ -6,17 +6,25 @@ use crate::events::SET_SIDEBAR_ZOOM_IN_WINDOW;
 use crate::pinned_search::{PinnedSearch, PINNED_SEARCHES, PINNED_SEARCHES_CHANGED};
 use crate::state::AppState;
 
-/// Subscribe this window to what the preferences window changes about it.
-///
-/// The "Current Settings" sliders act on the window that opened preferences.
-/// That window is no longer the one drawing them — preferences has a window of
-/// its own and no `AppState` — so the value arrives as an event addressed to
-/// this window.
-pub(super) fn setup_preferences_listeners(mut state: AppState) {
+/// Subscribe this window to what other windows change about it.
+pub(super) fn setup_window_listeners(mut state: AppState) {
     let current_window_id = window().id();
+
+    // A saved preference has to reach the windows already open. The
+    // configuration is not a signal, so this is what makes anything derived
+    // from it — the layout thresholds, the margin trace — redraw.
+    use_future(move || async move {
+        let mut rx = crate::config::CONFIG_CHANGED_BROADCAST.subscribe();
+        while rx.recv().await.is_ok() {
+            let next = state.config_revision.read().wrapping_add(1);
+            state.config_revision.set(next);
+        }
+    });
 
     setup_pinned_highlights();
 
+    // The panel zoom slider in the preferences window, which acts on the
+    // window that opened it rather than on every window.
     use_future(move || async move {
         let mut rx = SET_SIDEBAR_ZOOM_IN_WINDOW.subscribe();
         while let Ok((target_window_id, zoom)) = rx.recv().await {

--- a/crates/arto/src/components/content.rs
+++ b/crates/arto/src/components/content.rs
@@ -5,6 +5,7 @@ mod file_viewer;
 mod gutter;
 mod preferences_view;
 mod search_handler;
+mod trace;
 mod welcome_view;
 
 use dioxus::prelude::*;
@@ -48,9 +49,28 @@ pub fn Content() -> Element {
 
     let headings = state.headings;
 
+    // The trace answers to the setting first and to the width last; the
+    // gutter only to the width. Both come from `AppState`, so narrowing the
+    // window folds them and widening brings them back as configured.
+    let trace_visible = use_memo(move || state.trace_visible());
+    let gutter_visible = use_memo(move || state.visible_chrome().gutter);
+    let trace_count = use_memo(move || state.trace_count());
+
+    // With nothing to read, the whole area is the welcome page — the trace and
+    // the gutter have nothing to say beside it.
+    let showing_welcome = use_memo(move || state.document.read().is_empty());
+
     rsx! {
         div {
             class: "content-area",
+
+        // The documents read before this one, at the edge of the page. Always
+        // mounted, so that it can be *seen* to arrive and leave: a column that
+        // is only rendered while it applies has no way to fade.
+        trace::MarginTrace {
+            count: trace_count(),
+            visible: trace_visible() && !showing_welcome(),
+        }
 
         div {
             class: "content",
@@ -81,7 +101,9 @@ pub fn Content() -> Element {
         // The contents live beside the document rather than in a panel of
         // their own: always there, 24px wide, and impossible to open by
         // accident because there is nothing to open.
-        ContentsGutter { headings: headings() }
+        if gutter_visible() && !showing_welcome() {
+            ContentsGutter { headings: headings() }
+        }
         }
     }
 }

--- a/crates/arto/src/components/content/preferences_view/tabs/sidebar_tab.rs
+++ b/crates/arto/src/components/content/preferences_view/tabs/sidebar_tab.rs
@@ -1,7 +1,7 @@
 use super::super::form_controls::{OptionCardItem, OptionCards, SliderInput};
 use crate::config::{
-    normalize_sidebar_zoom, Config, NewWindowBehavior, OpenFromPanel, StartupBehavior,
-    MAX_SIDEBAR_ZOOM, MIN_SIDEBAR_ZOOM, ZOOM_STEP,
+    normalize_sidebar_zoom, Config, NewWindowBehavior, OpenFromPanel, RecentTrace, StartupBehavior,
+    MAX_SIDEBAR_ZOOM, MIN_CONTENT_WIDTH_RANGE, MIN_SIDEBAR_ZOOM, ZOOM_STEP,
 };
 use crate::events::SET_SIDEBAR_ZOOM_IN_WINDOW;
 use dioxus::desktop::tao::window::WindowId;
@@ -41,7 +41,8 @@ pub fn SidebarTab(
                     decimals: 1,
                     on_change: move |new_zoom| {
                         // Normalize to 0.1 step and clamp to valid range
-                        let _ = SET_SIDEBAR_ZOOM_IN_WINDOW.send((window_id, normalize_sidebar_zoom(new_zoom)));
+                        let _ = SET_SIDEBAR_ZOOM_IN_WINDOW
+                            .send((window_id, normalize_sidebar_zoom(new_zoom)));
                     },
                     default_value: Some(sidebar_cfg.default_zoom_level),
                 }
@@ -149,6 +150,91 @@ pub fn SidebarTab(
                     selected: sidebar_cfg.default_show_all_files,
                     on_change: move |new_state| {
                         config.write().sidebar.default_show_all_files = new_state;
+                        has_changes.set(true);
+                    },
+                }
+            }
+
+            h3 { class: "preference-section-title", "Reading Width" }
+
+            div {
+                class: "preference-item",
+                div {
+                    class: "preference-item-header",
+                    label { "Minimum Content Width" }
+                    p {
+                        class: "preference-description",
+                        "The width the document keeps while anything else can give way instead. Everything around the page folds at this number plus its own width, from the outside in: the margin trace, then the panel, then the contents gutter, then the rail. Raise it and a wide window folds them sooner."
+                    }
+                }
+                SliderInput {
+                    value: sidebar_cfg.min_content_width,
+                    min: *MIN_CONTENT_WIDTH_RANGE.start(),
+                    max: *MIN_CONTENT_WIDTH_RANGE.end(),
+                    step: 10.0,
+                    unit: "px".to_string(),
+                    on_change: move |new_width| {
+                        config.write().sidebar.min_content_width = new_width;
+                        has_changes.set(true);
+                    },
+                }
+            }
+
+            div {
+                class: "preference-item",
+                div {
+                    class: "preference-item-header",
+                    label { "Margin Trace" }
+                    p {
+                        class: "preference-description",
+                        "The documents read before this one, left at the edge of the page. It is the one window on the history nobody asks for, so it is the one you can turn off. A window too narrow to keep the document readable hides it whatever is chosen here."
+                    }
+                }
+                OptionCards {
+                    name: "sidebar-recent-trace".to_string(),
+                    options: vec![
+                        OptionCardItem {
+                            icon: None,
+                            value: RecentTrace::Never,
+                            title: "Never".to_string(),
+                            description: Some("Keep the margin empty".to_string()),
+                        },
+                        OptionCardItem {
+                            icon: None,
+                            value: RecentTrace::HiddenWhenSidebar,
+                            title: "Not with the panel".to_string(),
+                            description: Some("Hidden while the panel is out".to_string()),
+                        },
+                        OptionCardItem {
+                            icon: None,
+                            value: RecentTrace::Always,
+                            title: "Always".to_string(),
+                            description: Some("Drawn whenever it fits".to_string()),
+                        },
+                    ],
+                    selected: sidebar_cfg.recent_trace,
+                    on_change: move |new_trace| {
+                        config.write().sidebar.recent_trace = new_trace;
+                        has_changes.set(true);
+                    },
+                }
+            }
+
+            div {
+                class: "preference-item",
+                div {
+                    class: "preference-item-header",
+                    label { "Documents in the Trace" }
+                    p { class: "preference-description", "How many documents the margin trace names." }
+                }
+                SliderInput {
+                    value: sidebar_cfg.recent_trace_count as f64,
+                    min: 1.0,
+                    max: 12.0,
+                    step: 1.0,
+                    unit: String::new(),
+                    on_change: move |new_count: f64| {
+                        config.write().sidebar.recent_trace_count = new_count.max(1.0) as usize;
                         has_changes.set(true);
                     },
                 }

--- a/crates/arto/src/components/content/trace.rs
+++ b/crates/arto/src/components/content/trace.rs
@@ -1,0 +1,76 @@
+use dioxus::prelude::*;
+
+use crate::components::document_name::DocumentName;
+use crate::state::AppState;
+use crate::visits::{Visit, VISITS, VISITS_CHANGED};
+
+/// The documents read just before this one, left in the margin.
+///
+/// The other three windows on the history are asked for; this one is simply
+/// there, at the edge of the page, the way a bookmark ribbon is. It costs a
+/// column of margin the document was not using and answers "what was I
+/// reading before" without a keystroke.
+///
+/// It is the one window a reader can turn off, because it is the one that is
+/// never asked for — the choice is `sidebar.recentTrace` and the widths it
+/// yields to are Phase 5's; until then it appears when the panel is not out,
+/// which is the default that setting names.
+#[component]
+pub fn MarginTrace(count: usize, visible: bool) -> Element {
+    let mut state = use_context::<AppState>();
+    let mut revision = use_signal(|| 0u32);
+
+    use_future(move || async move {
+        let mut rx = VISITS_CHANGED.subscribe();
+        while rx.recv().await.is_ok() {
+            *revision.write() += 1;
+        }
+    });
+
+    // Read so a recorded visit redraws the trace; the numbers say nothing.
+    // Two of them: the broadcast carries what other windows did, and the
+    // window's own signal carries what this one did, in the same frame.
+    let _ = revision();
+    let _ = state.visits_revision.read();
+
+    let current = state.current_file();
+    let rows: Vec<Visit> = {
+        let visits = VISITS.read();
+        visits
+            .items
+            .iter()
+            // What is on screen is not a trace of where the reader has been.
+            .filter(|visit| current.as_deref() != Some(visit.path.as_path()))
+            .take(count)
+            .cloned()
+            .collect()
+    };
+
+    if rows.is_empty() {
+        return rsx! {};
+    }
+
+    rsx! {
+        div {
+            class: "margin-trace",
+            class: if !visible { "away" },
+            "aria-label": "Recently read",
+            "aria-hidden": if visible { "false" } else { "true" },
+
+            div { class: "margin-trace-label", "Recent" }
+
+            for visit in rows {
+                button {
+                    key: "{visit.path.display()}",
+                    class: "margin-trace-row",
+                    title: "{visit.path.display()}",
+                    onclick: {
+                        let path = visit.path.clone();
+                        move |_| state.open_file(&path)
+                    },
+                    DocumentName { path: visit.path.clone() }
+                }
+            }
+        }
+    }
+}

--- a/crates/arto/src/components/sidebar/rail.rs
+++ b/crates/arto/src/components/sidebar/rail.rs
@@ -32,7 +32,7 @@ pub fn Rail(on_peek: EventHandler<Face>) -> Element {
     // most needs to see, because it decides whether moving the pointer away
     // takes the panel with it.
     let showing = state.panel_is_showing();
-    let held = state.sidebar.read().pinned;
+    let held = state.sidebar.read().pinned && state.visible_chrome().panel;
 
     rsx! {
         div {
@@ -99,7 +99,7 @@ pub fn Rail(on_peek: EventHandler<Face>) -> Element {
 /// "already open" would close what the pointer had just asked for — and take
 /// two more clicks to bring it back.
 fn press(mut state: AppState, face: Face) {
-    let held = state.sidebar.read().pinned;
+    let held = state.sidebar.read().pinned && state.visible_chrome().panel;
     if held && state.sidebar.read().face == face {
         state.hide_panel();
     } else {

--- a/crates/arto/src/hooks.rs
+++ b/crates/arto/src/hooks.rs
@@ -1,3 +1,4 @@
+pub mod layout_budget;
 pub mod viewer_window;
 
 pub use viewer_window::*;

--- a/crates/arto/src/hooks/layout_budget.rs
+++ b/crates/arto/src/hooks/layout_budget.rs
@@ -1,0 +1,161 @@
+//! What fits beside the document at a given width.
+//!
+//! Every element around the page has a width, and at some point their sum
+//! leaves the document too narrow to read. Rather than five thresholds to
+//! keep in step, there is one number — the document's minimum width — and
+//! everything else is that number plus the width of whatever is still out.
+//!
+//! The order things give way in is fixed: the margin trace first (the
+//! history has three other windows), then the panel (the rail can still peek
+//! it back), then the contents gutter (Cmd+J still opens it), then the rail.
+//! The document itself never gives way; below the last threshold it simply
+//! follows the window, because the minimum is a target and not a floor.
+//!
+//! What comes out is state, never settings. Narrowing a window hides the
+//! panel; widening it brings the panel back exactly as it was configured.
+//! The one exception lives in the caller: a panel the reader folded with
+//! Cmd+B stays folded, because that was a statement of intent rather than a
+//! consequence of the width.
+
+/// The rail's width. Always the last thing to go.
+pub const RAIL_WIDTH: f64 = 40.0;
+
+/// The contents gutter's width.
+pub const GUTTER_WIDTH: f64 = 24.0;
+
+/// The margin trace's width.
+pub const TRACE_WIDTH: f64 = 138.0;
+
+/// What may be drawn beside the document at this width.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Visible {
+    pub trace: bool,
+    pub panel: bool,
+    pub gutter: bool,
+    pub rail: bool,
+}
+
+/// Give way from the outside in until the document keeps `min_content`.
+///
+/// `effective_width` is the window's content width after zoom — magnifying
+/// the page is the same as narrowing the window, so the same rule covers
+/// both. `panel_w` is the panel's current width, so widening the panel
+/// raises the width at which it folds.
+pub fn budget(effective_width: f64, min_content: f64, panel_w: f64) -> Visible {
+    let rail = effective_width >= min_content + RAIL_WIDTH;
+    let gutter = rail && effective_width >= min_content + RAIL_WIDTH + GUTTER_WIDTH;
+    let panel = gutter && effective_width >= min_content + RAIL_WIDTH + panel_w + GUTTER_WIDTH;
+    let trace =
+        panel && effective_width >= min_content + RAIL_WIDTH + panel_w + TRACE_WIDTH + GUTTER_WIDTH;
+
+    Visible {
+        trace,
+        panel,
+        gutter,
+        rail,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The panel width the specification's threshold table assumes.
+    const PANEL: f64 = 226.0;
+
+    fn at(width: f64, min_content: f64) -> Visible {
+        budget(width, min_content, PANEL)
+    }
+
+    #[test]
+    fn a_wide_window_shows_everything() {
+        let visible = at(1600.0, 640.0);
+        assert_eq!(
+            visible,
+            Visible {
+                trace: true,
+                panel: true,
+                gutter: true,
+                rail: true
+            }
+        );
+    }
+
+    // The specification's table, from both sides of every threshold:
+    // 1068 / 930 / 704 / 680 for a 640px document.
+
+    #[test]
+    fn the_trace_goes_first() {
+        assert!(at(1068.0, 640.0).trace);
+        assert!(!at(1067.0, 640.0).trace);
+        assert!(at(1067.0, 640.0).panel);
+    }
+
+    #[test]
+    fn then_the_panel() {
+        assert!(at(930.0, 640.0).panel);
+        assert!(!at(929.0, 640.0).panel);
+        assert!(at(929.0, 640.0).gutter);
+    }
+
+    #[test]
+    fn then_the_gutter() {
+        assert!(at(704.0, 640.0).gutter);
+        assert!(!at(703.0, 640.0).gutter);
+        assert!(at(703.0, 640.0).rail);
+    }
+
+    #[test]
+    fn and_the_rail_last() {
+        assert!(at(680.0, 640.0).rail);
+        assert!(!at(679.0, 640.0).rail);
+    }
+
+    #[test]
+    fn nothing_is_left_below_the_last_threshold() {
+        let visible = at(400.0, 640.0);
+        assert_eq!(
+            visible,
+            Visible {
+                trace: false,
+                panel: false,
+                gutter: false,
+                rail: false
+            }
+        );
+    }
+
+    // The same table with the setting raised: 1228 / 1090 / 864 / 840.
+
+    #[test]
+    fn a_wider_document_folds_things_sooner() {
+        assert!(at(1228.0, 800.0).trace);
+        assert!(!at(1227.0, 800.0).trace);
+        assert!(at(1090.0, 800.0).panel);
+        assert!(!at(1089.0, 800.0).panel);
+        assert!(at(864.0, 800.0).gutter);
+        assert!(!at(863.0, 800.0).gutter);
+        assert!(at(840.0, 800.0).rail);
+        assert!(!at(839.0, 800.0).rail);
+    }
+
+    #[test]
+    fn a_wider_panel_folds_at_a_wider_window() {
+        // The panel's own width is part of its threshold, so dragging it
+        // wider moves the point at which it gives way.
+        assert!(budget(930.0, 640.0, 226.0).panel);
+        assert!(!budget(930.0, 640.0, 280.0).panel);
+        assert!(budget(984.0, 640.0, 280.0).panel);
+    }
+
+    #[test]
+    fn the_order_never_inverts() {
+        // Whatever the width, nothing outer survives something inner going.
+        for width in (300..1600).step_by(7) {
+            let visible = budget(width as f64, 640.0, PANEL);
+            assert!(!visible.trace || visible.panel);
+            assert!(!visible.panel || visible.gutter);
+            assert!(!visible.gutter || visible.rail);
+        }
+    }
+}

--- a/crates/arto/src/state/app_state.rs
+++ b/crates/arto/src/state/app_state.rs
@@ -11,6 +11,7 @@ use crate::theme::Theme;
 
 mod document;
 mod focused_panel;
+mod layout;
 mod sidebar;
 pub(crate) mod sidebar_cursor;
 
@@ -98,6 +99,11 @@ pub struct AppState {
     pub reload_trigger: Signal<usize>,
     /// Which panel currently has keyboard focus (for context-aware keybindings).
     pub focused_panel: Signal<FocusedPanel>,
+    /// Bumped when the configuration changes, because the configuration is
+    /// not a signal and nothing subscribes to it. Anything derived from it
+    /// reads this instead, which is what makes a saved preference redraw the
+    /// window that is looking at it.
+    pub config_revision: Signal<u32>,
     /// Whether the command palette is open.
     pub palette_open: Signal<bool>,
     /// What is typed into the palette, and which row the keys act on.
@@ -161,6 +167,7 @@ impl AppState {
             current_scroll_anchor: Signal::new(ScrollAnchor::TOP),
             reload_trigger: Signal::new(0),
             focused_panel: Signal::new(FocusedPanel::Content),
+            config_revision: Signal::new(0),
             palette_open: Signal::new(false),
             palette_query: Signal::new(String::new()),
             palette_cursor: Signal::new(None),

--- a/crates/arto/src/state/app_state/layout.rs
+++ b/crates/arto/src/state/app_state/layout.rs
@@ -1,0 +1,54 @@
+//! What the window is wide enough to draw beside the document.
+//!
+//! The rule and its thresholds live in [`crate::hooks::layout_budget`], which
+//! is pure and tested against the specification's table. This is where the
+//! window's own numbers are collected and handed to it.
+
+use dioxus::prelude::*;
+
+use crate::config::{RecentTrace, CONFIG};
+use crate::hooks::layout_budget::{budget, Visible};
+use crate::state::AppState;
+
+impl AppState {
+    /// How many documents the margin trace names.
+    pub fn trace_count(&self) -> usize {
+        let _ = self.config_revision.read();
+        CONFIG.read().sidebar.recent_trace_count
+    }
+
+    /// What fits beside the document right now.
+    ///
+    /// The width is measured after zoom, because magnifying the page is the
+    /// same as narrowing the window.
+    pub fn visible_chrome(&self) -> Visible {
+        // Subscribes whoever is reading to configuration changes; the value
+        // itself says nothing.
+        let _ = self.config_revision.read();
+        let zoom = *self.zoom_level.read();
+        let width = self.size.read().width as f64;
+        let effective_width = if zoom > 0.0 { width / zoom } else { width };
+        let (min_content, panel_width) = {
+            let config = CONFIG.read();
+            (config.sidebar.min_content_width, self.sidebar.read().width)
+        };
+        budget(effective_width, min_content, panel_width)
+    }
+
+    /// Whether the margin trace is drawn.
+    ///
+    /// The setting decides first and the margin has the last word. There has
+    /// to be one: a window too narrow to keep the document readable has none
+    /// to spare, and a document set to the full width has none at all — the
+    /// trace would be drawn over the first inch of every line. Neither is a
+    /// change to what was chosen, so both are undone by undoing them.
+    pub fn trace_visible(&self) -> bool {
+        let _ = self.config_revision.read();
+        let chosen = match CONFIG.read().sidebar.recent_trace {
+            RecentTrace::Never => false,
+            RecentTrace::HiddenWhenSidebar => !self.sidebar.read().pinned,
+            RecentTrace::Always => true,
+        };
+        chosen && !*self.content_full_width.read() && self.visible_chrome().trace
+    }
+}

--- a/crates/arto/src/state/app_state/sidebar.rs
+++ b/crates/arto/src/state/app_state/sidebar.rs
@@ -159,10 +159,29 @@ impl AppState {
     /// Whether the panel is on screen, pinned beside the document or peeking
     /// over it.
     pub fn panel_is_showing(&self) -> bool {
-        self.sidebar.read().pinned || *self.left_hover_active.read()
+        (self.sidebar.read().pinned && self.visible_chrome().panel)
+            || *self.left_hover_active.read()
+    }
+
+    /// Open a document the reader picked out of the panel.
+    ///
+    /// Not quite the same act as opening a document: the panel is the other
+    /// half of it. Some readers work down the list, opening one document after
+    /// another; others go to it for one thing and want the page to themselves
+    /// once they have it. `sidebar.onOpen` says which.
+    pub fn open_from_panel(&mut self, path: impl AsRef<std::path::Path>) {
+        self.open_file(path.as_ref());
+        if crate::config::CONFIG.read().sidebar.on_open == crate::config::OpenFromPanel::ClosePanel
+        {
+            self.hide_panel();
+        }
     }
 
     /// Put the panel away, however it is showing.
+    ///
+    /// A keyboard cursor inside it goes with it: leaving the focus on rows
+    /// that are no longer drawn would send the next keystroke somewhere the
+    /// reader cannot see.
     pub fn hide_panel(&mut self) {
         self.sidebar.write().pinned = false;
         self.focus_content();
@@ -179,10 +198,19 @@ impl AppState {
         self.left_hover_active.set(false);
     }
 
-    /// Bring the panel out.
+    /// Bring the panel out, in whichever way the width allows.
+    ///
+    /// A window wide enough holds it beside the document; a narrower one
+    /// shows it over the document instead, so Cmd+B still opens something
+    /// when the layout has folded the panel away. The pinned choice is left
+    /// alone in that case, so widening the window restores it as configured.
     pub fn show_panel(&mut self) {
-        self.sidebar.write().pinned = true;
-        self.left_hover_active.set(false);
+        if self.visible_chrome().panel {
+            self.sidebar.write().pinned = true;
+            self.left_hover_active.set(false);
+        } else {
+            self.left_hover_active.set(true);
+        }
     }
 
     /// Toggle the panel, whichever way it is currently showing.
@@ -223,20 +251,6 @@ impl AppState {
     pub fn step_face(&mut self, forward: bool) {
         let next = self.sidebar.peek().face.step(forward);
         self.focus_face(next);
-    }
-
-    /// Open a document the reader picked out of the panel.
-    ///
-    /// Not quite the same act as opening a document: the panel is the other
-    /// half of it. Some readers work down the list, opening one document after
-    /// another; others go to it for one thing and want the page to themselves
-    /// once they have it. `sidebar.onOpen` says which.
-    pub fn open_from_panel(&mut self, path: impl AsRef<Path>) {
-        self.open_file(path.as_ref());
-        if crate::config::CONFIG.read().sidebar.on_open == crate::config::OpenFromPanel::ClosePanel
-        {
-            self.hide_panel();
-        }
     }
 
     /// Take in the current bookmarked directories as the tree's places.
@@ -391,8 +405,10 @@ mod tests {
         assert!(!sidebar.is_expanded(Group::Bookmark, both, both));
     }
 
-    /// The pinned flag on its own, which is what `AppState::toggle_sidebar`
-    /// writes.
+    /// The pinned flag on its own, which is what `AppState::show_panel` and
+    /// `AppState::hide_panel` write. Whether a pinned panel is actually drawn
+    /// also depends on the width, and that rule is tested in
+    /// `crate::hooks::layout_budget`.
     fn apply_toggle(sidebar: &mut Sidebar) {
         sidebar.pinned = !sidebar.pinned;
     }

--- a/frontend/src/reading-position.ts
+++ b/frontend/src/reading-position.ts
@@ -1,11 +1,40 @@
 /**
  * Where the reader is in the document, for the chrome that answers to it: the
- * contents gutter's current tick and the marks a search left on it.
+ * contents gutter's current tick, the marks a search left on it, and the
+ * margin trace's place beside the page.
  *
  * All of it is the same question asked in different words — where in this
  * document are we, and what is around us — so it shares one passive scroll
  * listener and one frame's worth of work.
  */
+
+/**
+ * How much of the column the margin trace has to centre itself against.
+ *
+ * The trace is set level with the middle of what is being read, and what is
+ * being read is the document — until the document is taller than the window,
+ * when it is the window. So: the smaller of the two.
+ */
+const TRACE_EXTENT = "--trace-extent";
+
+/**
+ * How far the margin trace has to move to reach the document.
+ *
+ * The trace is laid out at the left edge of the content area, but the column
+ * it annotates is centred in what is left of the window, so at a wide window
+ * the two are half a screen apart. This closes that: the names sit in the
+ * document's own margin, which is the only place a marginal note means
+ * anything.
+ */
+const TRACE_OFFSET = "--trace-offset";
+
+/**
+ * How much air is left between the trace and the text it annotates.
+ *
+ * Kept here rather than as padding on the column, so that widening the gap
+ * moves the whole column instead of eating the room its names are set in.
+ */
+const TRACE_GAP = 56;
 
 /** The attribute that marks the heading the reader is inside. */
 const CURRENT = "data-current";
@@ -117,6 +146,33 @@ function scroller(): HTMLElement | null {
   return document.querySelector(".content");
 }
 
+/**
+ * The page whose height everything here is measured against.
+ *
+ * It does not arrive at its full height: code blocks are highlighted,
+ * diagrams and formulae are drawn, images load, and each of those makes the
+ * page taller after it was last measured. A scroll does not necessarily
+ * follow — the reader may still be looking at the first screen — so nothing
+ * else would ask for the measurement again, and the trace would sit level
+ * with the middle of a document that no longer exists.
+ */
+let measured: HTMLElement | null = null;
+let growth: ResizeObserver | null = null;
+
+function watchBody(body: HTMLElement | null): void {
+  if (body === measured) {
+    return;
+  }
+  growth ??= new ResizeObserver(() => refreshReadingPosition());
+  if (measured) {
+    growth.unobserve(measured);
+  }
+  measured = body;
+  if (body) {
+    growth.observe(body);
+  }
+}
+
 function update(): void {
   scheduled = false;
 
@@ -130,7 +186,28 @@ function update(): void {
     listening = content;
   }
 
+  const area = content.closest<HTMLElement>(".content-area");
   const body = content.querySelector<HTMLElement>(".markdown-body");
+  watchBody(body);
+  if (area) {
+    const document_ = body?.getBoundingClientRect().height ?? content.clientHeight;
+    const window_ = content.clientHeight;
+    area.style.setProperty(TRACE_EXTENT, `${Math.round(Math.min(document_, window_))}px`);
+
+    // Layout coordinates for the trace, so that the offset already applied to
+    // it does not feed back into the next measurement.
+    const trace = area.querySelector<HTMLElement>(".margin-trace");
+    if (trace && body) {
+      const traceRight = trace.offsetLeft + trace.offsetWidth;
+      const bodyLeft = body.getBoundingClientRect().left - area.getBoundingClientRect().left;
+      const offset = Math.max(0, Math.round(bodyLeft - traceRight - TRACE_GAP));
+      area.style.setProperty(TRACE_OFFSET, `${offset}px`);
+      // Until this has run once, the column is still at the window's edge
+      // rather than beside the text; drawn there and then moved, it reads as
+      // the page settling into place after the reader is already looking.
+      area.dataset.traceReady = "";
+    }
+  }
 
   // The ticks and the names they stand for are two views of one list, so the
   // current heading is marked on both.

--- a/frontend/style/components/content.css
+++ b/frontend/style/components/content.css
@@ -1,7 +1,9 @@
 @import url("./content/frontmatter.css");
 @import url("./content/markdown-alert.css");
 @import url("./content/markdown-viewer.css");
+@import url("./content/highlights.css");
 @import url("./content/welcome.css");
+@import url("./content/margin-trace.css");
 
 .content {
   flex: 1;

--- a/frontend/style/components/content/margin-trace.css
+++ b/frontend/style/components/content/margin-trace.css
@@ -1,0 +1,120 @@
+/* =================================
+   Margin trace
+   =================================
+
+   The documents read before this one, left at the edge of the page. It is
+   the one window on the history that is never asked for, so it stays at
+   rest-ink until the pointer is in its column, and it yields its space
+   before anything else does.
+
+   It sits level with the middle of the page and is set against the document
+   rather than against the window: right-aligned, so the names line up along
+   the page's own edge and the margin falls on the window's side. */
+
+.margin-trace {
+  /* Out of the flow, in the margin the page is not using. The page is centred
+     in the whole of what is left of the window and the trace takes what that
+     leaves over — not the other way round, which set the page off centre by
+     half a column and moved it every time the trace came and went.
+     The layout budget still reserves this width: it is what decides whether
+     there is a margin wide enough to put the trace in at all. */
+  position: absolute;
+  left: 0;
+  /* The whole of the reading area, which is what the band leaves of the
+     window. So centring in it is centring in the window — which is what the
+     trace does before anything has been measured, and what it goes on doing
+     for a document taller than the window. */
+  top: 0;
+  bottom: 0;
+  /* The layout budget reserves this much beside the document, so the box keeps
+     to it — but the names are not cut to fit. They are right-aligned, so what
+     does not fit grows leftwards into the window's own margin, which is empty
+     and has nothing to be pushed out of. */
+  width: 138px;
+  overflow: visible;
+  /* Level with the middle of what is being read: the page when the page is
+     shorter than the window, the window when it is not. A shorter page is the
+     only case that needs measuring, and `reading-position.ts` measures it,
+     because nothing in CSS can see how tall a sibling's contents are; without
+     it the box is the reading area itself. */
+  height: var(--trace-extent, auto);
+  /* Moved up against the document rather than left at the window's edge: a
+     note in the margin belongs beside the text it is a note on. The distance
+     is measured in `reading-position.ts`, because the column it has to reach
+     is centred in whatever is left of the window. */
+  transform: translateX(var(--trace-offset, 0px));
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-end;
+  text-align: right;
+  gap: 7px;
+  box-sizing: border-box;
+  /* The trace fades, and only fades. Neither `width` nor `transform` is in
+     this list. The width is the document's margin, which the document has to
+     have back the moment the trace is gone. The transform is where the column
+     it annotates happens to be, and that is measured after the page has been
+     laid out — animated, it made the trace slide across the window on its way
+     in, from wherever the column had been when it was last hidden. */
+  transition: opacity var(--transition-normal) ease;
+}
+
+/* Not drawn until it has been measured — see `reading-position.ts`. It fades
+   in where it belongs instead of appearing where it does not and walking. */
+.content-area:not([data-trace-ready]) .margin-trace {
+  opacity: 0;
+  transition: none;
+}
+
+/* Out of the way, and seen to go: it fades, rather than closing like a door.
+   It can simply fade now that it holds no width of the page's — nothing moves
+   when it goes. */
+.margin-trace.away {
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* Smaller and fainter than the names it heads, and lettered rather than set:
+   it is the one word here that is not a document. */
+.margin-trace-label {
+  margin-bottom: 2px;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  opacity: var(--opacity-muted);
+}
+
+.margin-trace-row {
+  padding: 0;
+  border: none;
+  background: transparent;
+  /* The document's own ink at rest ink: a name here is a document, and the
+     column is faint because of the density, not because of the colour. */
+  color: var(--text-color);
+  font-family: inherit;
+  /* Smaller than anything in the document, because it is beside one. */
+  font-size: 10.5px;
+  text-align: right;
+  white-space: nowrap;
+  cursor: pointer;
+  opacity: var(--opacity-rest);
+  transition: opacity var(--transition-quiet) ease;
+}
+
+/* The whole column wakes together, so a name is legible by the time it is
+   aimed at — but only part of the way, or the one under the pointer would
+   have nowhere left to go. */
+.margin-trace:hover .margin-trace-row {
+  opacity: 0.45;
+}
+
+/* The one being pointed at, said the way everything else here is said: in
+   density. A line under it would be a second device for a difference the ink
+   already carries. */
+.margin-trace:hover .margin-trace-row:hover,
+.margin-trace-row:hover {
+  opacity: 1;
+}

--- a/frontend/style/variables.css
+++ b/frontend/style/variables.css
@@ -57,7 +57,8 @@
     ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
     monospace;
 
-  /* The rail's width. */
+  /* The rail's width. The layout budget measures the same band in Rust
+     (`hooks::layout_budget::RAIL_WIDTH`); keep the two in step. */
   --rail-width: 40px;
 
   /* The peeking panel's shadow. The offset and the negative spread keep it


### PR DESCRIPTION
## Summary

- One setting — `sidebar.minContentWidth` — and everything beside the page gives way from the outside in.
- `hooks::layout_budget` is the whole rule, and it is pure, so the table of thresholds is its test.
- Width changes state, never settings: widening restores the panel as configured.
- Adds the margin trace: the documents read before this one, in the margin the page is not using.

## Why

Everything beside the page kept its width whatever the window's was, so a narrow window was a column of chrome with a sliver of document in it — and the reader's only recourse was to put things away by hand and fetch them back afterwards.

There is one number now — `sidebar.minContentWidth`, 640px by default — and every threshold is that number plus the width of whatever is still drawn beside the page. Things give way from the outside in: the margin trace, then the panel, then the contents gutter, then the rail. `hooks::layout_budget` is the whole rule and it is pure, so the table of thresholds is its test.

What comes back is state, never settings: widening the window restores the panel exactly as it was configured, and a panel folded with Cmd+B stays folded because that was intent rather than a consequence of width. Nothing folds without something behind it either — at a width with no room to stand the panel beside the page, Cmd+B and the rail peek it over the page instead.

The trace is what the width buys: the documents read before this one, in the margin the page is not using, set against the column rather than the window so it reads as a note beside the text. It fades rather than closing, because a column shutting like a door draws more attention leaving than it ever does sitting there.

## Test Plan

- [ ] Narrowing the window folds the trace, then the panel, then the gutter, then the rail
- [ ] Widening restores the panel exactly as it was configured; a panel folded with `Cmd+B` stays folded
- [ ] `Cmd+B` and the rail still open the panel at any width
- [ ] `just fmt check test`

## Stack

These land in order; each is based on the one above it.

1. #265 — chore(dev): sign the bundle `dx serve` builds on macOS
2. #266 — feat(preferences): a window, not a tab
3. #267 — feat(window): one document to a window
4. #268 — feat(panel): several roots, and the folders you keep
5. #269 — feat(panel): one panel, three faces, and the history among them
6. #270 — feat(contents): the contents live beside the page
7. #271 — feat(header): the document's name is the way back, and one glyph opens the app
8. #272 — feat(search): find in the header, and the marks stay in the contents
9. #273 — feat(welcome): a window with nothing open says what there is to read
10. #274 — feat(layout): give way to the document 👈 **this one**
11. #275 — feat(keys): every list and every field answers to bindings
12. #276 — feat(recent): remember where a document was left, and open it there
13. #277 — feat(menu): give every menu row its icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01731Zfkg9P6V4Lm7buLEN53
