### PR TITLE
feat(keys): every list and every field answers to bindings

### DIFF
--- a/crates/arto-config/src/lib.rs
+++ b/crates/arto-config/src/lib.rs
@@ -69,7 +69,6 @@ mod tests {
         assert!(set.global.is_empty());
         assert!(set.content.is_empty());
         assert!(set.sidebar.is_empty());
-        assert!(set.quick_access.is_empty());
         assert!(set.search.is_empty());
     }
 

--- a/crates/arto-keybindings/src/action.rs
+++ b/crates/arto-keybindings/src/action.rs
@@ -51,19 +51,12 @@ pub enum Action {
     CopyImageAsMarkdown,
     CopyLinkPath,
 
-    // Palette — the history, two keystrokes away, and moving through it
-    PaletteOpen,
-    PaletteNext,
-    PalettePrev,
-    PaletteConfirm,
-    PaletteClose,
-
     // Window (7)
     WindowNew,
-    /// A copy of this window: the document, and the place in it the reader had
-    /// reached.
+    /// A copy of this window: its temporary roots, its document and the place
+    /// in it the reader had reached.
     WindowDuplicate,
-    /// Put the document down; the window keeps everything else.
+    /// Put the document down; the welcome page takes its place.
     WindowNewDocument,
     WindowClose,
     WindowCloseAllChildWindows,
@@ -73,8 +66,8 @@ pub enum Action {
     // Reload (1)
     WindowReload,
 
-    // Focus — keyboard-only. One per face: asking for a list is asking for
-    // that list, not for whichever the panel happened to be showing.
+    // Focus — keyboard-only. One per face of the panel, so that a reader can
+    // reach the list they want rather than the one the panel happens to be on.
     FocusPlaces,
     FocusStarred,
     FocusRecent,
@@ -98,7 +91,21 @@ pub enum Action {
     AppGoToHomepage,
     HelpShowKeyboardShortcuts,
 
-    // Sidebar (1)
+    // Palette — the history, two keystrokes away, and moving through it
+    PaletteOpen,
+    PaletteNext,
+    PalettePrev,
+    PaletteConfirm,
+    PaletteClose,
+
+    // Contents — the gutter's list, and the keyboard's way through it
+    ContentsToggle,
+    ContentsNext,
+    ContentsPrev,
+    ContentsConfirm,
+    ContentsClose,
+
+    // Sidebar — the panel and which of its faces is showing
     SidebarToggleShowAllFiles,
     SidebarFacePlaces,
     SidebarFaceRecent,
@@ -125,7 +132,7 @@ pub enum Action {
     ContentPrevHeading,
     ContentOpenViewer,
 
-    // Directory — sidebar navigation (3) — keyboard-only
+    // Directory — sidebar navigation (1) — keyboard-only
     DirectoryParent,
 
     // Cancel (1) — keyboard-only
@@ -184,16 +191,6 @@ pub const ACTION_GROUPS: &[(&str, &[Action])] = &[
         ],
     ),
     (
-        "Palette",
-        &[
-            Action::PaletteOpen,
-            Action::PaletteNext,
-            Action::PalettePrev,
-            Action::PaletteConfirm,
-            Action::PaletteClose,
-        ],
-    ),
-    (
         "Window",
         &[
             Action::WindowNew,
@@ -240,6 +237,26 @@ pub const ACTION_GROUPS: &[(&str, &[Action])] = &[
         ],
     ),
     (
+        "Palette",
+        &[
+            Action::PaletteOpen,
+            Action::PaletteNext,
+            Action::PalettePrev,
+            Action::PaletteConfirm,
+            Action::PaletteClose,
+        ],
+    ),
+    (
+        "Contents",
+        &[
+            Action::ContentsToggle,
+            Action::ContentsNext,
+            Action::ContentsPrev,
+            Action::ContentsConfirm,
+            Action::ContentsClose,
+        ],
+    ),
+    (
         "Sidebar",
         &[
             Action::SidebarToggleShowAllFiles,
@@ -282,12 +299,6 @@ pub const ACTION_GROUPS: &[(&str, &[Action])] = &[
     ("Cancel", &[Action::Cancel]),
 ];
 
-/// Actions that have a corresponding menu item and can therefore be bound as a
-/// native menu shortcut.
-///
-/// Kept in sync with the desktop app's menu module, which maps menu items to
-/// these actions and has a drift-guard test asserting every menu item's
-/// action appears here.
 impl Action {
     /// The name this action answers to when it is typed rather than pressed.
     ///
@@ -343,6 +354,7 @@ impl Action {
             Self::AppGoToHomepage => "Go to Homepage",
 
             // Contents
+            Self::ContentsToggle => "Contents",
 
             // Sidebar
             Self::SidebarToggleShowAllFiles => "Show All Files",
@@ -363,6 +375,12 @@ impl Action {
     }
 }
 
+/// Every action that answers to a name, in the order the palette lists them.
+///
+/// The order is the enum's own, which groups related commands together; the
+/// palette does not re-sort, so a query that leaves several commands standing
+/// shows them in a stable order rather than one that moves as the list is
+/// narrowed.
 pub const COMMAND_ACTIONS: &[Action] = &[
     Action::HistoryBack,
     Action::HistoryForward,
@@ -390,6 +408,7 @@ pub const COMMAND_ACTIONS: &[Action] = &[
     Action::AppAbout,
     Action::AppQuit,
     Action::AppGoToHomepage,
+    Action::ContentsToggle,
     Action::SidebarToggleShowAllFiles,
     Action::SidebarFacePlaces,
     Action::SidebarFaceRecent,
@@ -401,7 +420,12 @@ pub const COMMAND_ACTIONS: &[Action] = &[
     Action::ThemeSetAuto,
 ];
 
-/// Actions that are menu items.
+/// Actions that have a corresponding menu item and can therefore be bound as a
+/// native menu shortcut.
+///
+/// Kept in sync with the desktop app's menu module, which maps menu items to
+/// these actions and has a drift-guard test asserting every menu item's
+/// action appears here.
 pub const MENU_ACTIONS: &[Action] = &[
     Action::WindowNew,
     Action::WindowDuplicate,
@@ -507,11 +531,6 @@ action_strings! {
     CopyImagePath => "clipboard.copy_image_path",
     CopyImageAsMarkdown => "clipboard.copy_image_as_markdown",
     CopyLinkPath => "clipboard.copy_link_path",
-    PaletteOpen => "palette.open",
-    PaletteNext => "palette.next",
-    PalettePrev => "palette.prev",
-    PaletteConfirm => "palette.confirm",
-    PaletteClose => "palette.close",
     WindowNew => "window.new",
     WindowDuplicate => "window.duplicate",
     WindowNewDocument => "window.new_document",
@@ -538,6 +557,16 @@ action_strings! {
     AppQuit => "app.quit",
     AppGoToHomepage => "app.go_to_homepage",
     HelpShowKeyboardShortcuts => "help.show_keyboard_shortcuts",
+    PaletteOpen => "palette.open",
+    PaletteNext => "palette.next",
+    PalettePrev => "palette.prev",
+    PaletteConfirm => "palette.confirm",
+    PaletteClose => "palette.close",
+    ContentsToggle => "contents.toggle",
+    ContentsNext => "contents.next",
+    ContentsPrev => "contents.prev",
+    ContentsConfirm => "contents.confirm",
+    ContentsClose => "contents.close",
     SidebarToggleShowAllFiles => "sidebar.toggle_show_all_files",
     SidebarFacePlaces => "sidebar.face_places",
     SidebarFaceRecent => "sidebar.face_recent",
@@ -575,7 +604,7 @@ mod tests {
 
     #[test]
     fn all_actions_count() {
-        assert_eq!(all_actions().len(), 84);
+        assert_eq!(all_actions().len(), 89);
     }
 
     #[test]
@@ -628,6 +657,41 @@ mod tests {
         assert!("unknown.action".parse::<Action>().is_err());
         assert!("".parse::<Action>().is_err());
         assert!("scroll".parse::<Action>().is_err());
+    }
+
+    #[test]
+    fn every_named_command_is_listed() {
+        for action in all_actions() {
+            let listed = COMMAND_ACTIONS.contains(&action);
+            assert_eq!(
+                action.command_label().is_some(),
+                listed,
+                "{action} is named but not listed in COMMAND_ACTIONS, or the other way round"
+            );
+        }
+    }
+
+    #[test]
+    fn motions_have_no_name() {
+        for action in [
+            Action::ScrollDown,
+            Action::CursorDown,
+            Action::ContentNext,
+            Action::FocusContent,
+            Action::PaletteOpen,
+            Action::Cancel,
+        ] {
+            assert_eq!(action.command_label(), None, "{action} should be unnamed");
+        }
+    }
+
+    #[test]
+    fn no_duplicate_command_labels() {
+        let mut seen = std::collections::HashSet::new();
+        for action in COMMAND_ACTIONS {
+            let label = action.command_label().expect("listed command has a label");
+            assert!(seen.insert(label), "duplicate command label: {label:?}");
+        }
     }
 
     #[test]

--- a/crates/arto-keybindings/src/bindings.rs
+++ b/crates/arto-keybindings/src/bindings.rs
@@ -1,3 +1,4 @@
+use crate::context::KeyContext;
 use serde::{Deserialize, Serialize};
 
 /// Per-context keybinding definition stored in `mappings.json`.
@@ -26,11 +27,41 @@ pub struct BindingSet {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub sidebar: Vec<KeyAction>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub quick_access: Vec<KeyAction>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub search: Vec<KeyAction>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub palette: Vec<KeyAction>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub contents: Vec<KeyAction>,
+}
+
+impl BindingSet {
+    /// The bindings a context owns.
+    ///
+    /// The one place that says which field belongs to which context. Every
+    /// caller that has to answer that question — resolving for the engine,
+    /// finding the shortcut to print beside a menu item, listing a context in
+    /// the preferences — asks here, so a new context cannot be wired into
+    /// some of them and forgotten in the rest.
+    pub fn of(&self, context: KeyContext) -> &Vec<KeyAction> {
+        match context {
+            KeyContext::Content => &self.content,
+            KeyContext::Sidebar => &self.sidebar,
+            KeyContext::Search => &self.search,
+            KeyContext::Palette => &self.palette,
+            KeyContext::Contents => &self.contents,
+        }
+    }
+
+    /// The same, to be edited.
+    pub fn of_mut(&mut self, context: KeyContext) -> &mut Vec<KeyAction> {
+        match context {
+            KeyContext::Content => &mut self.content,
+            KeyContext::Sidebar => &mut self.sidebar,
+            KeyContext::Search => &mut self.search,
+            KeyContext::Palette => &mut self.palette,
+            KeyContext::Contents => &mut self.contents,
+        }
+    }
 }
 
 /// A single key → action mapping.
@@ -51,7 +82,6 @@ mod tests {
         assert!(set.global.is_empty());
         assert!(set.content.is_empty());
         assert!(set.sidebar.is_empty());
-        assert!(set.quick_access.is_empty());
         assert!(set.search.is_empty());
     }
 
@@ -80,7 +110,6 @@ mod tests {
         assert!(set.global.is_empty());
         assert!(set.content.is_empty());
         assert!(set.sidebar.is_empty());
-        assert!(set.quick_access.is_empty());
         assert!(set.search.is_empty());
     }
 
@@ -94,7 +123,7 @@ mod tests {
     #[test]
     fn structured_json() {
         let json = r#"{
-            "global": [{"key": "x", "action": "tab.close"}],
+            "global": [{"key": "x", "action": "file.open"}],
             "sidebar": [{"key": "o", "action": "cursor.enter"}]
         }"#;
         let set: BindingSet = serde_json::from_str(json).unwrap();

--- a/crates/arto-keybindings/src/codes.rs
+++ b/crates/arto-keybindings/src/codes.rs
@@ -351,7 +351,7 @@ mod tests {
             global: vec![
                 KeyAction {
                     key: "Ctrl+Shift+x".to_string(),
-                    action: "tab.close".to_string(),
+                    action: "file.open".to_string(),
                 },
                 KeyAction {
                     key: "Ctrl+Alt+v".to_string(),

--- a/crates/arto-keybindings/src/context.rs
+++ b/crates/arto-keybindings/src/context.rs
@@ -11,13 +11,46 @@ use std::str::FromStr;
 #[serde(rename_all = "snake_case")]
 pub enum KeyContext {
     Content,
+    /// The panel, whichever of its faces is showing. There used to be one of
+    /// these per face; the keys that walk a list of documents are the same
+    /// keys whether the list is a tree, a history or a set of stars, and
+    /// having to bind them three times was three chances to bind them
+    /// differently.
     Sidebar,
-    QuickAccess,
     Search,
     Palette,
+    /// The contents, while they are open by name rather than under the
+    /// pointer. A list of headings answers the same keys the panel's lists do.
+    Contents,
 }
 
 impl KeyContext {
+    /// Every context, in the order they are listed to the reader.
+    ///
+    /// What walks this rather than spelling the contexts out: resolving a
+    /// binding set for the engine, and the preferences' own list of sections.
+    /// A context added to the enum is therefore added to both.
+    pub const ALL: [Self; 5] = [
+        Self::Content,
+        Self::Sidebar,
+        Self::Search,
+        Self::Palette,
+        Self::Contents,
+    ];
+
+    /// The name this context is listed under.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Content => "Content",
+            // The panel is what the reader sees; `sidebar` is the name the
+            // configuration has always used for it.
+            Self::Sidebar => "Panel",
+            Self::Search => "Search",
+            Self::Palette => "Palette",
+            Self::Contents => "Contents",
+        }
+    }
+
     /// Whether this context is a field being typed into.
     ///
     /// What is typed there is text, not shortcuts, so a bare key belongs to
@@ -26,7 +59,7 @@ impl KeyContext {
     /// with a modifier is nobody's idea of typing, so those still fall through
     /// to the global set, and Cmd+W closes the window from inside a search.
     pub fn owns_input(&self) -> bool {
-        matches!(self, Self::Palette)
+        matches!(self, Self::Search | Self::Palette)
     }
 }
 
@@ -46,9 +79,9 @@ impl fmt::Display for KeyContext {
         match self {
             Self::Content => f.write_str("content"),
             Self::Sidebar => f.write_str("sidebar"),
-            Self::QuickAccess => f.write_str("quick_access"),
             Self::Search => f.write_str("search"),
             Self::Palette => f.write_str("palette"),
+            Self::Contents => f.write_str("contents"),
         }
     }
 }
@@ -60,9 +93,9 @@ impl FromStr for KeyContext {
         match s {
             "content" => Ok(Self::Content),
             "sidebar" => Ok(Self::Sidebar),
-            "quick_access" => Ok(Self::QuickAccess),
             "search" => Ok(Self::Search),
             "palette" => Ok(Self::Palette),
+            "contents" => Ok(Self::Contents),
             _ => Err(KeyContextParseError(s.to_string())),
         }
     }
@@ -77,8 +110,8 @@ mod tests {
         let contexts = [
             KeyContext::Content,
             KeyContext::Sidebar,
-            KeyContext::QuickAccess,
             KeyContext::Search,
+            KeyContext::Palette,
         ];
         for ctx in &contexts {
             let s = ctx.to_string();
@@ -109,5 +142,13 @@ mod tests {
     fn parse_invalid() {
         assert!("unknown".parse::<KeyContext>().is_err());
         assert!("".parse::<KeyContext>().is_err());
+    }
+
+    #[test]
+    fn a_field_owns_its_bare_keys() {
+        assert!(KeyContext::Search.owns_input());
+        assert!(KeyContext::Palette.owns_input());
+        assert!(!KeyContext::Content.owns_input());
+        assert!(!KeyContext::Sidebar.owns_input());
     }
 }

--- a/crates/arto-keybindings/src/engine.rs
+++ b/crates/arto-keybindings/src/engine.rs
@@ -173,16 +173,16 @@ impl KeybindingEngine {
     /// 2. Global match (context=None) → fallback
     /// 3. Different context → invisible (ignored)
     fn find_match(&self, keys: &[KeyChord], context: KeyContext) -> (Option<Action>, bool) {
+        let mut exact_context_match: Option<Action> = None;
+        let mut exact_global_match: Option<Action> = None;
+        let mut has_prefix = false;
+
         // A bare key inside a field is what is being typed, so the global set
         // — where a letter can mean "scroll" — does not answer for it. A chord
         // with a modifier is not typing, and still does: Cmd+W closes the
         // window from inside a search.
         let typing =
             context.owns_input() && keys.first().is_some_and(|chord| chord.modifiers.is_empty());
-
-        let mut exact_context_match: Option<Action> = None;
-        let mut exact_global_match: Option<Action> = None;
-        let mut has_prefix = false;
 
         for binding in &self.bindings {
             // Check context visibility
@@ -433,6 +433,67 @@ mod tests {
     }
 
     #[test]
+    fn a_bare_key_in_a_field_is_typing() {
+        // `j` scrolls the document; typed into the palette it is a letter.
+        let bindings = BindingSet {
+            global: vec![KeyAction {
+                key: "j".to_string(),
+                action: "scroll.down".to_string(),
+            }],
+            ..Default::default()
+        };
+        let mut engine = KeybindingEngine::new(&bindings);
+
+        assert_eq!(
+            engine.process_key(&chord("j"), false, KeyContext::Content),
+            KeyMatchResult::Matched(Action::ScrollDown)
+        );
+        assert_eq!(
+            engine.process_key(&chord("j"), false, KeyContext::Palette),
+            KeyMatchResult::NoMatch
+        );
+    }
+
+    #[test]
+    fn a_chord_in_a_field_is_still_a_shortcut() {
+        // Nobody types Cmd+W into a search box, so it still closes the window.
+        let bindings = BindingSet {
+            global: vec![KeyAction {
+                key: "Cmd+w".to_string(),
+                action: "window.close".to_string(),
+            }],
+            ..Default::default()
+        };
+        let mut engine = KeybindingEngine::new(&bindings);
+
+        assert_eq!(
+            engine.process_key(&chord("Cmd+w"), false, KeyContext::Search),
+            KeyMatchResult::Matched(Action::WindowClose)
+        );
+    }
+
+    #[test]
+    fn a_field_answers_a_bare_key_with_its_own_binding() {
+        let bindings = BindingSet {
+            global: vec![KeyAction {
+                key: "Enter".to_string(),
+                action: "scroll.down".to_string(),
+            }],
+            palette: vec![KeyAction {
+                key: "Enter".to_string(),
+                action: "palette.confirm".to_string(),
+            }],
+            ..Default::default()
+        };
+        let mut engine = KeybindingEngine::new(&bindings);
+
+        assert_eq!(
+            engine.process_key(&chord("Enter"), false, KeyContext::Palette),
+            KeyMatchResult::Matched(Action::PaletteConfirm)
+        );
+    }
+
+    #[test]
     fn different_context_binding_invisible() {
         let bindings = BindingSet {
             sidebar: vec![KeyAction {
@@ -443,8 +504,8 @@ mod tests {
         };
         let mut engine = KeybindingEngine::new(&bindings);
 
-        // In QuickAccess context: sidebar-specific "j" should be invisible
-        let result = engine.process_key(&chord("j"), false, KeyContext::QuickAccess);
+        // In the content: the panel's own "j" should be invisible
+        let result = engine.process_key(&chord("j"), false, KeyContext::Content);
         assert_eq!(result, KeyMatchResult::NoMatch);
     }
 
@@ -458,14 +519,15 @@ mod tests {
 
     #[test]
     fn user_overrides_default_global_binding() {
-        // User edits Cmd+r from window.reload to window.new in their global config.
+        // User edits Cmd+r from window.reload to window.new_document in their
+        // global config.
         let mut custom = crate::presets::default_bindings();
         let cmd_r = custom.global.iter_mut().find(|b| b.key == "Cmd+r").unwrap();
-        cmd_r.action = "window.new".to_string();
+        cmd_r.action = "window.new_document".to_string();
 
         let mut engine = KeybindingEngine::new(&custom);
         let result = engine.process_key(&chord("Cmd+r"), false, KeyContext::Content);
-        assert_eq!(result, KeyMatchResult::Matched(Action::WindowNew));
+        assert_eq!(result, KeyMatchResult::Matched(Action::WindowNewDocument));
     }
 
     #[test]
@@ -491,27 +553,5 @@ mod tests {
         // In sidebar: content-only Ctrl+j binding is not visible.
         let result = engine.process_key(&chord("Ctrl+j"), false, KeyContext::Sidebar);
         assert_eq!(result, KeyMatchResult::NoMatch);
-    }
-
-    #[test]
-    fn a_bare_key_in_a_field_is_typing() {
-        // `j` scrolls the document; typed into the palette it is a letter.
-        let bindings = BindingSet {
-            global: vec![KeyAction {
-                key: "j".to_string(),
-                action: "scroll.down".to_string(),
-            }],
-            ..Default::default()
-        };
-        let mut engine = KeybindingEngine::new(&bindings);
-
-        assert_eq!(
-            engine.process_key(&chord("j"), false, KeyContext::Content),
-            KeyMatchResult::Matched(Action::ScrollDown)
-        );
-        assert_eq!(
-            engine.process_key(&chord("j"), false, KeyContext::Palette),
-            KeyMatchResult::NoMatch
-        );
     }
 }

--- a/crates/arto-keybindings/src/hint.rs
+++ b/crates/arto-keybindings/src/hint.rs
@@ -10,7 +10,7 @@ pub fn hint_for_action(
     context: Option<KeyContext>,
 ) -> Option<String> {
     let key = context
-        .and_then(|ctx| find_key_for_action(bindings_for_context(bindings, ctx), action))
+        .and_then(|ctx| find_key_for_action(bindings.of(ctx), action))
         .or_else(|| find_key_for_action(&bindings.global, action))
         .or_else(|| find_key_for_action(&bindings.menu_shortcuts, action))?;
     Some(format_shortcut_hint(key))
@@ -21,16 +21,6 @@ fn find_key_for_action<'a>(bindings: &'a [KeyAction], action: &str) -> Option<&'
         .iter()
         .find(|ka| ka.action == action)
         .map(|ka| ka.key.as_str())
-}
-
-fn bindings_for_context(bindings: &BindingSet, context: KeyContext) -> &[KeyAction] {
-    match context {
-        KeyContext::Content => &bindings.content,
-        KeyContext::Sidebar => &bindings.sidebar,
-        KeyContext::QuickAccess => &bindings.quick_access,
-        KeyContext::Search => &bindings.search,
-        KeyContext::Palette => &bindings.palette,
-    }
 }
 
 /// Convert keybinding notation into a platform-appropriate shortcut hint.
@@ -187,29 +177,29 @@ mod tests {
         let bindings = BindingSet {
             menu_shortcuts: vec![KeyAction {
                 key: "Cmd+w".to_string(),
-                action: "tab.close".to_string(),
+                action: "file.open".to_string(),
             }],
             global: vec![KeyAction {
                 key: "x".to_string(),
-                action: "tab.close".to_string(),
+                action: "file.open".to_string(),
             }],
             sidebar: vec![KeyAction {
                 key: "d".to_string(),
-                action: "tab.close".to_string(),
+                action: "file.open".to_string(),
             }],
             ..Default::default()
         };
 
         assert_eq!(
-            hint_for_action(&bindings, "tab.close", Some(KeyContext::Sidebar)),
+            hint_for_action(&bindings, "file.open", Some(KeyContext::Sidebar)),
             Some(format_shortcut_hint("d"))
         );
         assert_eq!(
-            hint_for_action(&bindings, "tab.close", Some(KeyContext::Content)),
+            hint_for_action(&bindings, "file.open", Some(KeyContext::Content)),
             Some(format_shortcut_hint("x"))
         );
         assert_eq!(
-            hint_for_action(&bindings, "tab.close", None),
+            hint_for_action(&bindings, "file.open", None),
             Some(format_shortcut_hint("x"))
         );
 
@@ -218,7 +208,7 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(
-            hint_for_action(&menu_only, "tab.close", None),
+            hint_for_action(&menu_only, "file.open", None),
             Some(format_shortcut_hint("Cmd+w"))
         );
         assert_eq!(hint_for_action(&menu_only, "no.such.action", None), None);

--- a/crates/arto-keybindings/src/presets.rs
+++ b/crates/arto-keybindings/src/presets.rs
@@ -52,13 +52,11 @@ fn parse_bindings_json(json: &str, name: &str) -> BindingSet {
 }
 
 fn validate_preset_bindings(name: &str, bindings: &BindingSet) {
-    let fields: [(&str, &Vec<KeyAction>); 6] = [
+    let fields: [(&str, &Vec<KeyAction>); 4] = [
         ("global", &bindings.global),
         ("content", &bindings.content),
         ("sidebar", &bindings.sidebar),
-        ("quick_access", &bindings.quick_access),
         ("search", &bindings.search),
-        ("palette", &bindings.palette),
     ];
 
     for (context, actions) in fields {

--- a/crates/arto-keybindings/src/presets/default.json
+++ b/crates/arto-keybindings/src/presets/default.json
@@ -140,12 +140,16 @@
       "action": "sidebar.face_starred"
     },
     {
-      "key": "Ctrl+ArrowLeft",
-      "action": "focus.places"
-    },
-    {
       "key": "Cmd+k",
       "action": "palette.open"
+    },
+    {
+      "key": "Cmd+j",
+      "action": "contents.toggle"
+    },
+    {
+      "key": "Ctrl+ArrowLeft",
+      "action": "focus.places"
     }
   ],
   "content": [
@@ -172,24 +176,6 @@
     {
       "key": "Ctrl+ArrowLeft",
       "action": "focus.places"
-    }
-  ],
-  "search": [
-    {
-      "key": "Enter",
-      "action": "search.next"
-    },
-    {
-      "key": "Shift+Enter",
-      "action": "search.prev"
-    },
-    {
-      "key": "Escape",
-      "action": "search.clear"
-    },
-    {
-      "key": "Cmd+Enter",
-      "action": "search.pin_current"
     }
   ],
   "sidebar": [
@@ -234,6 +220,24 @@
       "action": "focus.places"
     }
   ],
+  "search": [
+    {
+      "key": "Tab",
+      "action": "search.next"
+    },
+    {
+      "key": "Shift+Tab",
+      "action": "search.prev"
+    },
+    {
+      "key": "Enter",
+      "action": "search.pin_current"
+    },
+    {
+      "key": "Escape",
+      "action": "search.clear"
+    }
+  ],
   "palette": [
     {
       "key": "ArrowDown",
@@ -258,6 +262,32 @@
     {
       "key": "Escape",
       "action": "palette.close"
+    }
+  ],
+  "contents": [
+    {
+      "key": "ArrowDown",
+      "action": "contents.next"
+    },
+    {
+      "key": "ArrowUp",
+      "action": "contents.prev"
+    },
+    {
+      "key": "Tab",
+      "action": "contents.next"
+    },
+    {
+      "key": "Shift+Tab",
+      "action": "contents.prev"
+    },
+    {
+      "key": "Enter",
+      "action": "contents.confirm"
+    },
+    {
+      "key": "Escape",
+      "action": "contents.close"
     }
   ]
 }

--- a/crates/arto-keybindings/src/presets/emacs.json
+++ b/crates/arto-keybindings/src/presets/emacs.json
@@ -14,10 +14,6 @@
       "action": "window.new_document"
     },
     {
-      "key": "Cmd+w",
-      "action": "window.close"
-    },
-    {
       "key": "Cmd+o",
       "action": "file.open"
     },
@@ -28,6 +24,10 @@
     {
       "key": "Cmd+Shift+r",
       "action": "file.reveal_in_finder"
+    },
+    {
+      "key": "Cmd+w",
+      "action": "window.close"
     },
     {
       "key": "Cmd+f",
@@ -160,6 +160,14 @@
       "action": "sidebar.face_starred"
     },
     {
+      "key": "Cmd+k",
+      "action": "palette.open"
+    },
+    {
+      "key": "Ctrl+x t",
+      "action": "contents.toggle"
+    },
+    {
       "key": "Ctrl+x p",
       "action": "focus.places"
     },
@@ -170,10 +178,6 @@
     {
       "key": "Ctrl+x r",
       "action": "focus.recent"
-    },
-    {
-      "key": "Cmd+k",
-      "action": "palette.open"
     }
   ],
   "content": [
@@ -200,36 +204,6 @@
     {
       "key": "Ctrl+x o",
       "action": "focus.places"
-    }
-  ],
-  "search": [
-    {
-      "key": "Enter",
-      "action": "search.next"
-    },
-    {
-      "key": "Shift+Enter",
-      "action": "search.prev"
-    },
-    {
-      "key": "Ctrl+s",
-      "action": "search.next"
-    },
-    {
-      "key": "Ctrl+r",
-      "action": "search.prev"
-    },
-    {
-      "key": "Ctrl+g",
-      "action": "search.clear"
-    },
-    {
-      "key": "Escape",
-      "action": "search.clear"
-    },
-    {
-      "key": "Ctrl+Enter",
-      "action": "search.pin_current"
     }
   ],
   "sidebar": [
@@ -270,6 +244,36 @@
       "action": "focus.places"
     }
   ],
+  "search": [
+    {
+      "key": "Ctrl+s",
+      "action": "search.next"
+    },
+    {
+      "key": "Ctrl+r",
+      "action": "search.prev"
+    },
+    {
+      "key": "Tab",
+      "action": "search.next"
+    },
+    {
+      "key": "Shift+Tab",
+      "action": "search.prev"
+    },
+    {
+      "key": "Enter",
+      "action": "search.pin_current"
+    },
+    {
+      "key": "Ctrl+g",
+      "action": "search.clear"
+    },
+    {
+      "key": "Escape",
+      "action": "search.clear"
+    }
+  ],
   "palette": [
     {
       "key": "Ctrl+n",
@@ -298,6 +302,36 @@
     {
       "key": "Escape",
       "action": "palette.close"
+    }
+  ],
+  "contents": [
+    {
+      "key": "Ctrl+n",
+      "action": "contents.next"
+    },
+    {
+      "key": "Ctrl+p",
+      "action": "contents.prev"
+    },
+    {
+      "key": "ArrowDown",
+      "action": "contents.next"
+    },
+    {
+      "key": "ArrowUp",
+      "action": "contents.prev"
+    },
+    {
+      "key": "Enter",
+      "action": "contents.confirm"
+    },
+    {
+      "key": "Ctrl+g",
+      "action": "contents.close"
+    },
+    {
+      "key": "Escape",
+      "action": "contents.close"
     }
   ]
 }

--- a/crates/arto-keybindings/src/presets/preset.schema.json
+++ b/crates/arto-keybindings/src/presets/preset.schema.json
@@ -9,10 +9,9 @@
     "global": { "$ref": "#/$defs/bindings" },
     "content": { "$ref": "#/$defs/bindings" },
     "sidebar": { "$ref": "#/$defs/bindings" },
-    "quickAccess": { "$ref": "#/$defs/bindings" },
-    "rightSidebar": { "$ref": "#/$defs/bindings" },
-    "search": { "$ref": "#/$defs/bindings" },
-    "palette": { "$ref": "#/$defs/bindings" }
+    "palette": { "$ref": "#/$defs/bindings" },
+    "contents": { "$ref": "#/$defs/bindings" },
+    "search": { "$ref": "#/$defs/bindings" }
   },
   "$defs": {
     "bindings": {

--- a/crates/arto-keybindings/src/presets/vim.json
+++ b/crates/arto-keybindings/src/presets/vim.json
@@ -14,10 +14,6 @@
       "action": "window.new_document"
     },
     {
-      "key": "Cmd+w",
-      "action": "window.close"
-    },
-    {
       "key": "Cmd+o",
       "action": "file.open"
     },
@@ -28,6 +24,10 @@
     {
       "key": "Cmd+Shift+r",
       "action": "file.reveal_in_finder"
+    },
+    {
+      "key": "Cmd+w",
+      "action": "window.close"
     },
     {
       "key": "Cmd+f",
@@ -260,6 +260,14 @@
       "action": "sidebar.face_starred"
     },
     {
+      "key": "Cmd+k",
+      "action": "palette.open"
+    },
+    {
+      "key": "g o",
+      "action": "contents.toggle"
+    },
+    {
       "key": "Ctrl+w h",
       "action": "focus.places"
     },
@@ -278,10 +286,6 @@
     {
       "key": "Backslash r",
       "action": "focus.recent"
-    },
-    {
-      "key": "Cmd+k",
-      "action": "palette.open"
     }
   ],
   "content": [
@@ -304,24 +308,6 @@
     {
       "key": "[ [",
       "action": "content.prev_heading"
-    }
-  ],
-  "search": [
-    {
-      "key": "Enter",
-      "action": "search.next"
-    },
-    {
-      "key": "Shift+Enter",
-      "action": "search.prev"
-    },
-    {
-      "key": "Escape",
-      "action": "search.clear"
-    },
-    {
-      "key": "Ctrl+Enter",
-      "action": "search.pin_current"
     }
   ],
   "sidebar": [
@@ -394,6 +380,36 @@
       "action": "focus.places"
     }
   ],
+  "search": [
+    {
+      "key": "Tab",
+      "action": "search.next"
+    },
+    {
+      "key": "Shift+Tab",
+      "action": "search.prev"
+    },
+    {
+      "key": "Ctrl+n",
+      "action": "search.next"
+    },
+    {
+      "key": "Ctrl+p",
+      "action": "search.prev"
+    },
+    {
+      "key": "Enter",
+      "action": "search.pin_current"
+    },
+    {
+      "key": "Escape",
+      "action": "search.clear"
+    },
+    {
+      "key": "Ctrl+c",
+      "action": "search.clear"
+    }
+  ],
   "palette": [
     {
       "key": "Ctrl+n",
@@ -438,6 +454,52 @@
     {
       "key": "Ctrl+c",
       "action": "palette.close"
+    }
+  ],
+  "contents": [
+    {
+      "key": "j",
+      "action": "contents.next"
+    },
+    {
+      "key": "k",
+      "action": "contents.prev"
+    },
+    {
+      "key": "Ctrl+n",
+      "action": "contents.next"
+    },
+    {
+      "key": "Ctrl+p",
+      "action": "contents.prev"
+    },
+    {
+      "key": "ArrowDown",
+      "action": "contents.next"
+    },
+    {
+      "key": "ArrowUp",
+      "action": "contents.prev"
+    },
+    {
+      "key": "Enter",
+      "action": "contents.confirm"
+    },
+    {
+      "key": "l",
+      "action": "contents.confirm"
+    },
+    {
+      "key": "Escape",
+      "action": "contents.close"
+    },
+    {
+      "key": "q",
+      "action": "contents.close"
+    },
+    {
+      "key": "Ctrl+c",
+      "action": "contents.close"
     }
   ]
 }

--- a/crates/arto-keybindings/src/resolve.rs
+++ b/crates/arto-keybindings/src/resolve.rs
@@ -81,17 +81,23 @@ impl BindingSet {
     fn resolve_with(self, fold_menu_shortcuts: bool) -> (Vec<ResolvedBinding>, Vec<BindingError>) {
         let mut resolved = Vec::new();
         let mut errors = Vec::new();
-        let mut resolve = |actions: Vec<KeyAction>, context: Option<KeyContext>| {
-            resolve_field(actions, context, &mut resolved, &mut errors);
-        };
         if fold_menu_shortcuts {
-            resolve(self.menu_shortcuts, None);
+            resolve_field(
+                self.menu_shortcuts.clone(),
+                None,
+                &mut resolved,
+                &mut errors,
+            );
         }
-        resolve(self.global, None);
-        resolve(self.content, Some(KeyContext::Content));
-        resolve(self.sidebar, Some(KeyContext::Sidebar));
-        resolve(self.quick_access, Some(KeyContext::QuickAccess));
-        resolve(self.search, Some(KeyContext::Search));
+        resolve_field(self.global.clone(), None, &mut resolved, &mut errors);
+        for context in KeyContext::ALL {
+            resolve_field(
+                self.of(context).clone(),
+                Some(context),
+                &mut resolved,
+                &mut errors,
+            );
+        }
         (resolved, errors)
     }
 }

--- a/crates/arto/src/components/app/keybinding_engine.rs
+++ b/crates/arto/src/components/app/keybinding_engine.rs
@@ -15,14 +15,10 @@ pub(super) struct KeyEventData {
     pub(super) key: String,
     pub(super) modifiers: u32,
     pub(super) repeat: bool,
+    /// Which of the app's own fields the key was typed into, if any. A field
+    /// answers a bare key out of its own bindings alone.
     #[serde(default)]
-    pub(super) search_focused: bool,
-}
-
-fn should_skip_keybinding(data: &KeyEventData) -> bool {
-    // In search input, plain Escape is handled by SearchBar (blur input).
-    // Skip keybinding processing so it does not trigger search.clear.
-    data.search_focused && data.modifiers == 0 && data.key == "Escape"
+    pub(super) field: Option<String>,
 }
 
 /// Maximum readiness-poll attempts for the JS keyboard API before giving up.
@@ -57,9 +53,9 @@ fn push_menu_accelerators_to_js() {
     ));
 }
 
-/// Off macOS there is no native menu — the same commands hang off the glyph in
-/// the header and are dispatched by the engine (see
-/// `BindingSet::into_resolved_bindings`), so there is nothing to skip.
+/// Only macOS has a native menu. Everywhere else menu shortcuts are dispatched
+/// by the engine (see `BindingSet::into_resolved_bindings`) — there is nothing
+/// to skip.
 #[cfg(not(target_os = "macos"))]
 fn push_menu_accelerators_to_js() {}
 
@@ -157,9 +153,6 @@ pub(super) fn setup_keybinding_engine(
                 if chord.is_modifier_only() {
                     continue;
                 }
-                if should_skip_keybinding(&data) {
-                    continue;
-                }
                 let overlay_visible = is_shortcut_overlay_visible(shortcut_overlay_visibility);
                 if overlay_visible
                     && handle_shortcut_overlay_close_key(&data, shortcut_overlay_visibility)
@@ -171,10 +164,14 @@ pub(super) fn setup_keybinding_engine(
                     continue;
                 }
 
-                let context = if data.search_focused {
-                    KeyContext::Search
-                } else {
-                    state.focused_panel.read().key_context()
+                let context = match data.field.as_deref() {
+                    Some("search") => KeyContext::Search,
+                    Some("palette") => KeyContext::Palette,
+                    // A list held open over the document is what the keys are
+                    // for as long as it is there, whichever half of the window
+                    // the focus was in when it was asked for.
+                    _ if *state.contents_open.read() => KeyContext::Contents,
+                    _ => state.focused_panel.read().key_context(),
                 };
                 let result = engine
                     .read()
@@ -193,13 +190,11 @@ pub(super) fn setup_keybinding_engine(
                             continue;
                         }
                         if action == Action::Cancel {
-                            // Cancel chain: reset engine state + return focus to content + close overlays + close search + clear content cursor
+                            // Half-typed chord, everything over the document,
+                            // and the cursor in the page itself: Escape drops
+                            // all three.
                             engine.read().borrow_mut().reset();
-                            state.focused_panel.set(crate::state::FocusedPanel::Content);
-                            state.left_hover_active.set(false);
-                            if *state.search_open.read() {
-                                state.toggle_search();
-                            }
+                            state.dismiss_overlays();
                             crate::keybindings::dispatcher::content_cursor_eval("clearCursor");
                             close_shortcut_overlay(shortcut_overlay_visibility);
                         } else if action == Action::HelpShowKeyboardShortcuts {
@@ -235,57 +230,4 @@ pub(super) fn setup_keybinding_engine(
             tracing::debug!("Keybinding engine rebuilt after config change");
         }
     });
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn skips_plain_escape_when_search_input_is_focused() {
-        let data = KeyEventData {
-            key: "Escape".to_string(),
-            modifiers: 0,
-            repeat: false,
-            search_focused: true,
-        };
-
-        assert!(should_skip_keybinding(&data));
-    }
-
-    #[test]
-    fn does_not_skip_non_escape_in_search_input() {
-        let data = KeyEventData {
-            key: "Enter".to_string(),
-            modifiers: 0,
-            repeat: false,
-            search_focused: true,
-        };
-
-        assert!(!should_skip_keybinding(&data));
-    }
-
-    #[test]
-    fn does_not_skip_escape_when_search_input_is_not_focused() {
-        let data = KeyEventData {
-            key: "Escape".to_string(),
-            modifiers: 0,
-            repeat: false,
-            search_focused: false,
-        };
-
-        assert!(!should_skip_keybinding(&data));
-    }
-
-    #[test]
-    fn does_not_skip_modified_escape_in_search_input() {
-        let data = KeyEventData {
-            key: "Escape".to_string(),
-            modifiers: 8,
-            repeat: false,
-            search_focused: true,
-        };
-
-        assert!(!should_skip_keybinding(&data));
-    }
 }

--- a/crates/arto/src/components/content.rs
+++ b/crates/arto/src/components/content.rs
@@ -56,8 +56,8 @@ pub fn Content() -> Element {
     let gutter_visible = use_memo(move || state.visible_chrome().gutter);
     let trace_count = use_memo(move || state.trace_count());
 
-    // With nothing to read, the whole area is the welcome page — the trace and
-    // the gutter have nothing to say beside it.
+    // With nothing to read, the whole area is the welcome page — the trace and the
+    // gutter have nothing to say beside it.
     let showing_welcome = use_memo(move || state.document.read().is_empty());
 
     rsx! {
@@ -101,8 +101,12 @@ pub fn Content() -> Element {
         // The contents live beside the document rather than in a panel of
         // their own: always there, 24px wide, and impossible to open by
         // accident because there is nothing to open.
-        if gutter_visible() && !showing_welcome() {
-            ContentsGutter { headings: headings() }
+        //
+        // Held open by name, the same list stays out without the ruler — which
+        // is what makes `contents.toggle` reach the headings at a width that
+        // folded the ruler away.
+        if !showing_welcome() && (gutter_visible() || *state.contents_open.read()) {
+            ContentsGutter { headings: headings(), ruler: gutter_visible() }
         }
         }
     }

--- a/crates/arto/src/components/content/gutter.rs
+++ b/crates/arto/src/components/content/gutter.rs
@@ -6,6 +6,7 @@ use crate::components::pinned_marks::PinnedMarks;
 use crate::document_link::scroll_to_heading_js;
 use crate::markdown::HeadingInfo;
 use crate::pinned_search::{PinnedSearch, PINNED_SEARCHES, PINNED_SEARCHES_CHANGED};
+use crate::state::AppState;
 
 /// The contents, as a column of ticks beside the document — and the names
 /// those ticks stand for, for as long as the pointer is in the column.
@@ -30,8 +31,20 @@ use crate::pinned_search::{PinnedSearch, PINNED_SEARCHES, PINNED_SEARCHES_CHANGE
 /// mark and the way to change it in two places, and the way to change it in a
 /// bar that closes.
 ///
+/// Asked for by name (`contents.toggle`), the same list is held open instead
+/// of following the pointer, and the keyboard walks it. It is one list either
+/// way: a second panel drawn somewhere else would be a second thing to learn
+/// for the same headings — and at a width that has folded the ruler away, the
+/// list asked for by name is the only way to them, so it is drawn without the
+/// ruler beside it.
 #[component]
-pub fn ContentsGutter(headings: Vec<HeadingInfo>) -> Element {
+pub fn ContentsGutter(
+    headings: Vec<HeadingInfo>,
+    /// Whether the ruler is drawn beside the document. A narrow window folds
+    /// it away; the list can still be asked for.
+    ruler: bool,
+) -> Element {
+    let state = use_context::<AppState>();
     let mut pinned = use_signal(|| PINNED_SEARCHES.read().pinned_searches.clone());
 
     use_future(move || async move {
@@ -42,19 +55,23 @@ pub fn ContentsGutter(headings: Vec<HeadingInfo>) -> Element {
     });
 
     let marks = pinned.read().clone();
+    let open = *state.contents_open.read();
     // Nothing to rest on, and nothing to open: with neither a heading nor a
-    // mark there is no map to draw.
-    if headings.is_empty() && marks.is_empty() {
+    // mark there is no map to draw. Asked for by name it still answers, so
+    // that the key does something rather than nothing.
+    if headings.is_empty() && marks.is_empty() && !open {
         return rsx! {};
     }
 
     rsx! {
-        Ruler { headings: headings.clone() }
+        if ruler {
+            Ruler { headings: headings.clone() }
+        }
 
         // A sibling of the ruler, and after it: resting in the column is what
         // brings this out, and that is said in CSS as
         // `.contents-gutter:hover ~ .contents-toc`.
-        Names { headings, marks }
+        Names { headings, marks, open }
     }
 }
 
@@ -106,10 +123,17 @@ fn Ruler(headings: Vec<HeadingInfo>) -> Element {
 
 /// What the ticks stand for: the marks a search pinned, then the headings.
 #[component]
-fn Names(headings: Vec<HeadingInfo>, marks: Vec<PinnedSearch>) -> Element {
+fn Names(headings: Vec<HeadingInfo>, marks: Vec<PinnedSearch>, open: bool) -> Element {
+    let mut state = use_context::<AppState>();
+    let cursor = *state.contents_cursor.read();
     let nothing_pinned = marks.is_empty();
 
-    let go_to = move |id: String| {
+    // Picking a place is the end of a list held open. One that came out under
+    // the pointer goes when the pointer does, so it has nothing to close.
+    let mut go_to = move |id: String| {
+        if open {
+            state.close_contents();
+        }
         spawn(async move {
             let _ = document::eval(&scroll_to_heading_js(&id)).await;
         });
@@ -118,6 +142,7 @@ fn Names(headings: Vec<HeadingInfo>, marks: Vec<PinnedSearch>) -> Element {
     rsx! {
         nav {
             class: "contents-toc",
+            class: if open { "open" },
             "aria-label": "Contents",
 
             PinnedMarks { pinned_searches: marks }
@@ -130,13 +155,17 @@ fn Names(headings: Vec<HeadingInfo>, marks: Vec<PinnedSearch>) -> Element {
                 div { class: "contents-toc-empty", "No headings" }
             }
 
-            for heading in headings.iter().cloned() {
+            for (at, heading) in headings.iter().cloned().enumerate() {
                 {
                     let id = heading.id.clone();
                     rsx! {
                         button {
                             key: "{heading.id}",
                             class: "contents-toc-row",
+                            // Where the keys are, as opposed to where the
+                            // reader is: the row marked `data-current` is the
+                            // one being read, and the two are read together.
+                            class: if cursor == Some(at) { "keyboard-focused" },
                             "data-level": "{heading.level}",
                             "data-heading": "{heading.id}",
                             onclick: move |_| go_to(id.clone()),

--- a/crates/arto/src/components/content/preferences_view/tabs/keybindings_tab.rs
+++ b/crates/arto/src/components/content/preferences_view/tabs/keybindings_tab.rs
@@ -108,45 +108,16 @@ pub fn KeybindingsTab(config: Signal<Config>, has_changes: Signal<bool>) -> Elem
                 config,
                 has_changes,
             }
-            BindingSection {
-                title: "Content",
-                scope: BindingScope::Engine(Some(KeyContext::Content)),
-                bindings: keybindings.content.clone(),
-                filter_query: filter_text(),
-                config,
-                has_changes,
-            }
-            BindingSection {
-                title: "Sidebar",
-                scope: BindingScope::Engine(Some(KeyContext::Sidebar)),
-                bindings: keybindings.sidebar.clone(),
-                filter_query: filter_text(),
-                config,
-                has_changes,
-            }
-            BindingSection {
-                title: "Quick Access",
-                scope: BindingScope::Engine(Some(KeyContext::QuickAccess)),
-                bindings: keybindings.quick_access.clone(),
-                filter_query: filter_text(),
-                config,
-                has_changes,
-            }
-            BindingSection {
-                title: "Palette",
-                scope: BindingScope::Engine(Some(KeyContext::Palette)),
-                bindings: keybindings.palette.clone(),
-                filter_query: filter_text(),
-                config,
-                has_changes,
-            }
-            BindingSection {
-                title: "Search",
-                scope: BindingScope::Engine(Some(KeyContext::Search)),
-                bindings: keybindings.search.clone(),
-                filter_query: filter_text(),
-                config,
-                has_changes,
+            for context in KeyContext::ALL {
+                BindingSection {
+                    key: "{context}",
+                    title: context.label(),
+                    scope: BindingScope::Engine(Some(context)),
+                    bindings: keybindings.of(context).clone(),
+                    filter_query: filter_text(),
+                    config,
+                    has_changes,
+                }
             }
         }
     }
@@ -787,11 +758,7 @@ fn bindings_mut(set: &mut crate::config::BindingSet, scope: BindingScope) -> &mu
     match scope {
         BindingScope::Menu => &mut set.menu_shortcuts,
         BindingScope::Engine(None) => &mut set.global,
-        BindingScope::Engine(Some(KeyContext::Content)) => &mut set.content,
-        BindingScope::Engine(Some(KeyContext::Sidebar)) => &mut set.sidebar,
-        BindingScope::Engine(Some(KeyContext::QuickAccess)) => &mut set.quick_access,
-        BindingScope::Engine(Some(KeyContext::Search)) => &mut set.search,
-        BindingScope::Engine(Some(KeyContext::Palette)) => &mut set.palette,
+        BindingScope::Engine(Some(context)) => set.of_mut(context),
     }
 }
 
@@ -878,11 +845,7 @@ fn action_label(action_str: &str) -> String {
 fn context_label(context: Option<KeyContext>) -> &'static str {
     match context {
         None => "Global",
-        Some(KeyContext::Content) => "Content",
-        Some(KeyContext::Sidebar) => "Sidebar",
-        Some(KeyContext::QuickAccess) => "Quick Access",
-        Some(KeyContext::Search) => "Search",
-        Some(KeyContext::Palette) => "Palette",
+        Some(context) => context.label(),
     }
 }
 
@@ -1006,7 +969,7 @@ mod tests {
     #[test]
     fn action_label_converts_dot_and_underscore() {
         assert_eq!(action_label("scroll.down"), "Scroll Down");
-        assert_eq!(action_label("tab.close_all"), "Tab Close All");
+        assert_eq!(action_label("window.new_document"), "Window New Document");
         assert_eq!(action_label("cancel"), "Cancel");
         assert_eq!(
             action_label("clipboard.copy_file_path"),
@@ -1157,12 +1120,12 @@ mod tests {
                 context: Some(KeyContext::Content),
             },
         ];
-        // Adding "j" to Global — overridden by both Sidebar and Content
+        // Adding "j" to Global — overridden by both the panel and the content
         let result = check_conflict(&resolved, "j", None);
         match result {
             Some(BindingNotice::Overwrite(msg)) => {
                 assert!(msg.contains("Content"), "should list Content: {msg}");
-                assert!(msg.contains("Sidebar"), "should list Sidebar: {msg}");
+                assert!(msg.contains("Panel"), "should list Panel: {msg}");
             }
             other => panic!("Expected Overwrite, got {other:?}"),
         }

--- a/crates/arto/src/keybindings/dispatcher.rs
+++ b/crates/arto/src/keybindings/dispatcher.rs
@@ -10,6 +10,26 @@ use crate::utils::task::spawn_detached;
 
 use super::Action;
 
+mod clipboard;
+mod contents;
+mod palette;
+mod panel;
+mod reveal;
+mod search;
+
+use clipboard::*;
+use contents::*;
+use palette::*;
+use panel::*;
+use reveal::*;
+use search::*;
+
+// What the rest of the app reaches for by name, which is what the menus and
+// the content's own context menu need.
+pub(crate) use clipboard::{copy_image_from_src, copy_rasterized_image};
+pub(crate) use palette::activate_palette_row;
+pub(crate) use reveal::content_cursor_eval;
+
 /// Execute an action by dispatching to the appropriate handler.
 ///
 /// This is the main entry point for action execution after the engine
@@ -44,7 +64,7 @@ pub fn dispatch_action(action: &Action, mut state: AppState) {
         Action::SearchOpen => search_open(&mut state),
         Action::SearchNext => search_navigate_eval("next"),
         Action::SearchPrev => search_navigate_eval("prev"),
-        Action::SearchClear => search_clear_eval(),
+        Action::SearchClear => state.close_search(),
         Action::SearchPinCurrent => search_pin_current(&mut state),
 
         // --- Zoom ---
@@ -52,19 +72,9 @@ pub fn dispatch_action(action: &Action, mut state: AppState) {
         Action::ZoomOut => state.zoom_out(),
         Action::ZoomReset => state.zoom_reset(),
 
-        // --- Palette ---
-        Action::PaletteOpen => state.toggle_palette(),
-        Action::PaletteNext => step_palette(&mut state, true),
-        Action::PalettePrev => step_palette(&mut state, false),
-        Action::PaletteConfirm => {
-            let at = crate::components::palette::cursor_row(&state, *state.palette_rows.read());
-            activate_palette_row(state, at);
-        }
-        Action::PaletteClose => state.close_palette(),
-
         // --- Window ---
-        // A new window is a fresh start: nothing this one happened to have
-        // wandered into.
+        // A new window is a fresh start: the places, the welcome page, and nothing
+        // this window happened to have wandered into.
         Action::WindowNew => {
             crate::window::create_main_window_sync(
                 &dioxus::desktop::window(),
@@ -74,7 +84,7 @@ pub fn dispatch_action(action: &Action, mut state: AppState) {
         }
         Action::WindowDuplicate => duplicate_window(&mut state),
         // Putting the document down is what "new" means for a window that
-        // reads one: the empty page takes its place, offering the next.
+        // reads one: the welcome page takes its place, offering the next.
         Action::WindowNewDocument => {
             state.update_document(|document| *document = crate::state::Document::default());
         }
@@ -130,11 +140,9 @@ pub fn dispatch_action(action: &Action, mut state: AppState) {
         // One per face: the keyboard goes to the list that was asked for,
         // rather than to whichever the panel happened to be showing.
         Action::FocusPlaces => face_to(&mut state, crate::state::Face::Places),
-        Action::FocusStarred => face_to(&mut state, crate::state::Face::Starred),
         Action::FocusRecent => face_to(&mut state, crate::state::Face::Recent),
-        Action::FocusContent => {
-            state.focus_content();
-        }
+        Action::FocusStarred => face_to(&mut state, crate::state::Face::Starred),
+        Action::FocusContent => state.focus_content(),
 
         // --- Cursor ---
         Action::CursorDown => dispatch_cursor_move(&mut state, CursorDirection::Down),
@@ -151,9 +159,36 @@ pub fn dispatch_action(action: &Action, mut state: AppState) {
         Action::ContentOpenViewer => open_content_viewer_from_cursor(&state),
 
         // --- Directory ---
+        // Walking the root itself is gone: a root's parent is added alongside
+        // it now rather than replacing it, and the tree holds several roots at
+        // once, so there is no single "current directory" to step through.
         Action::DirectoryParent => {
-            state.go_to_parent_directory();
+            let parent = state
+                .sidebar
+                .read()
+                .primary_root()
+                .and_then(|root| root.parent().map(|p| p.to_path_buf()));
+            if let Some(parent) = parent {
+                state.add_root(parent);
+            }
         }
+
+        // --- Palette ---
+        Action::PaletteOpen => state.toggle_palette(),
+        Action::PaletteNext => step_palette(&mut state, true),
+        Action::PalettePrev => step_palette(&mut state, false),
+        Action::PaletteConfirm => {
+            let at = crate::components::palette::cursor_row(&state, *state.palette_rows.read());
+            activate_palette_row(state, at);
+        }
+        Action::PaletteClose => state.close_palette(),
+
+        // --- Contents ---
+        Action::ContentsToggle => state.toggle_contents(),
+        Action::ContentsNext => step_contents(&mut state, true),
+        Action::ContentsPrev => step_contents(&mut state, false),
+        Action::ContentsConfirm => confirm_contents(&mut state),
+        Action::ContentsClose => state.close_contents(),
 
         // --- File ---
         Action::FileOpen => {
@@ -194,6 +229,9 @@ pub fn dispatch_action(action: &Action, mut state: AppState) {
         Action::AppGoToHomepage => {
             let _ = open::that("https://github.com/arto-app/Arto");
         }
+        // Both are answered before dispatch, in `keybinding_engine`: they act
+        // on the overlay, which is the window's own state and not the
+        // document's.
         Action::HelpShowKeyboardShortcuts => {}
 
         // --- Sidebar ---
@@ -207,644 +245,13 @@ pub fn dispatch_action(action: &Action, mut state: AppState) {
             state.sidebar.write().show_all_files = !current;
         }
 
-        // --- Right sidebar ---
         // --- Theme ---
         Action::ThemeSetLight => state.current_theme.set(Theme::Light),
         Action::ThemeSetDark => state.current_theme.set(Theme::Dark),
         Action::ThemeSetAuto => state.current_theme.set(Theme::Auto),
 
-        // Cancel is handled in app.rs before dispatch
         Action::Cancel => {}
     }
-}
-
-/// What the tree is drawing, as the cursor needs to see it.
-struct TreeShape {
-    /// Every root the tree draws, in the order it draws them, each with the
-    /// group it is drawn in.
-    roots: Vec<(crate::state::Group, std::path::PathBuf)>,
-    /// The rows that are open — see [`crate::state::TreeRow`].
-    expanded: std::collections::HashSet<crate::state::TreeRow>,
-    show_all_files: bool,
-}
-
-/// The tree's shape, if it has any root at all.
-fn extract_sidebar_data(state: &AppState) -> Option<TreeShape> {
-    use crate::state::Group;
-
-    let sidebar = state.sidebar.read();
-    // The window's own folder first, which is the order the tree draws them.
-    let roots: Vec<_> = sidebar
-        .roots
-        .temps()
-        .iter()
-        .map(|root| (Group::Current, root.clone()))
-        .chain(
-            sidebar
-                .roots
-                .places()
-                .iter()
-                .map(|root| (Group::Bookmark, root.clone())),
-        )
-        .collect();
-    (!roots.is_empty()).then(|| TreeShape {
-        roots,
-        expanded: sidebar.expanded_dirs.clone(),
-        show_all_files: sidebar.show_all_files,
-    })
-}
-
-/// The rows the panel is drawing, in the order it draws them.
-///
-/// One list per face, and the cursor walks whichever is on screen — the same
-/// keys, over a tree, a history or a set of stars. What is folded away counts:
-/// a cursor on a row nobody can see is a cursor nobody can follow.
-fn panel_items(state: &AppState) -> Vec<crate::state::PanelRow> {
-    match state.sidebar.peek().face {
-        crate::state::Face::Places => match extract_sidebar_data(state) {
-            Some(tree) => sidebar_cursor::visible_items_in_roots(
-                &tree.roots,
-                &tree.expanded,
-                tree.show_all_files,
-            ),
-            None => Vec::new(),
-        },
-        crate::state::Face::Recent => {
-            let folded = state.sidebar.peek().recent_collapsed.clone();
-            crate::visits::VISITS
-                .read()
-                .grouped(chrono::Local::now())
-                .into_iter()
-                .filter(|(bucket, _)| !folded.contains(&bucket.heading()))
-                .flat_map(|(_, visits)| {
-                    visits
-                        .into_iter()
-                        .map(|visit| (crate::state::Group::Flat, visit.path.clone()))
-                })
-                .collect()
-        }
-        crate::state::Face::Starred => crate::bookmarks::BOOKMARKS
-            .read()
-            .items
-            .iter()
-            .filter(|bookmark| !bookmark.is_dir())
-            .map(|bookmark| (crate::state::Group::Flat, bookmark.path.clone()))
-            .collect(),
-    }
-}
-
-/// Put the cursor on the first row, if it is not on one already.
-fn rest_cursor(state: &mut AppState) {
-    let items = panel_items(state);
-    let resting = state
-        .panel_cursor
-        .peek()
-        .as_ref()
-        .is_some_and(|at| items.contains(at));
-    if !resting {
-        state.panel_cursor.set(items.first().cloned());
-    }
-}
-
-/// Show a face and take the keyboard to it, cursor and all.
-fn face_to(state: &mut AppState, face: crate::state::Face) {
-    state.focus_face(face);
-    rest_cursor(state);
-    scroll_cursor_into_view();
-}
-
-/// Step along the rail to the next face.
-fn step_face(state: &mut AppState, forward: bool) {
-    state.step_face(forward);
-    rest_cursor(state);
-    scroll_cursor_into_view();
-}
-
-enum CursorDirection {
-    Down,
-    Up,
-}
-
-fn dispatch_cursor_move(state: &mut AppState, direction: CursorDirection) {
-    let panel = *state.focused_panel.read();
-    match panel {
-        FocusedPanel::Panel => {
-            let items = panel_items(state);
-            if !items.is_empty() {
-                let current = state.panel_cursor.read().clone();
-                let next = match direction {
-                    CursorDirection::Down => sidebar_cursor::move_down(&current, &items),
-                    CursorDirection::Up => sidebar_cursor::move_up(&current, &items),
-                };
-                state.panel_cursor.set(next);
-                scroll_cursor_into_view();
-            }
-        }
-        FocusedPanel::Content => {}
-    }
-}
-
-/// cursor.enter — "Enter into": directory → set as root, file → open, heading → scroll to.
-fn dispatch_cursor_enter(state: &mut AppState) {
-    let panel = *state.focused_panel.read();
-    match panel {
-        FocusedPanel::Panel => {
-            let Some((_, path)) = state.panel_cursor.read().clone() else {
-                return;
-            };
-            if path.is_dir() {
-                state.add_root(&path);
-            } else if path.exists() {
-                state.open_file(&path);
-            }
-        }
-        // Right sidebar & quick access: same as cursor.open (scroll to heading / open bookmark)
-        FocusedPanel::Content => {}
-    }
-}
-
-/// cursor.open — "Open/expand": directory → expand tree, file → open, heading → scroll to.
-fn dispatch_cursor_open(state: &mut AppState) {
-    let panel = *state.focused_panel.read();
-    match panel {
-        FocusedPanel::Panel => open_sidebar(state),
-        FocusedPanel::Content => {}
-    }
-}
-
-/// Open what the cursor is on: a document is read, a folder opens onto its
-/// contents with the cursor on the first of them.
-fn open_sidebar(state: &mut AppState) {
-    let Some(row) = state.panel_cursor.read().clone() else {
-        return;
-    };
-    let (group, path) = row.clone();
-
-    if !path.is_dir() {
-        if path.exists() {
-            state.open_file(&path);
-        }
-        return;
-    }
-
-    let root = root_of(state, &row);
-    if !state.sidebar.peek().is_expanded(group, &root, &path) {
-        state.toggle_directory_expansion(group, &root, &path);
-    }
-    let items = panel_items(state);
-    let next = items
-        .iter()
-        .position(|item| item == &row)
-        .and_then(|at| items.get(at + 1).cloned());
-    if let Some(next) = next {
-        state.panel_cursor.set(Some(next));
-        scroll_cursor_into_view();
-    }
-}
-
-/// Which root of its own group the cursor's row descends from.
-fn root_of(state: &AppState, row: &crate::state::PanelRow) -> std::path::PathBuf {
-    let (group, path) = row;
-    let roots = extract_sidebar_data(state)
-        .map(|tree| tree.roots)
-        .unwrap_or_default();
-    roots
-        .into_iter()
-        .find(|(row_group, root)| row_group == group && path.starts_with(root))
-        .map(|(_, root)| root)
-        .unwrap_or_else(|| path.to_path_buf())
-}
-
-fn dispatch_cursor_collapse(state: &mut AppState) {
-    let panel = *state.focused_panel.read();
-    match panel {
-        FocusedPanel::Panel => {
-            let Some(row) = state.panel_cursor.read().clone() else {
-                return;
-            };
-            let (group, path) = row.clone();
-            let root = root_of(state, &row);
-            if path.is_dir() && state.sidebar.peek().is_expanded(group, &root, &path) {
-                state.toggle_directory_expansion(group, &root, &path);
-                return;
-            }
-            // Out of a folder is up to the one holding it, where the list has
-            // one.
-            let items = panel_items(state);
-            if let Some(parent) = sidebar_cursor::find_parent_dir(&row, &items) {
-                state.panel_cursor.set(Some(parent));
-                scroll_cursor_into_view();
-            }
-        }
-        // No-op for other panels
-        FocusedPanel::Content => {}
-    }
-}
-
-/// Scroll the keyboard-focused element into view using JS.
-fn scroll_cursor_into_view() {
-    scroll_into_view(".keyboard-focused");
-}
-
-/// Bring the row a cursor just moved to into view, with room around it.
-///
-/// On the next frame, because the row it is looking for is the one the move
-/// has yet to draw.
-///
-/// Not `scrollIntoView({ block: 'nearest' })`: that is satisfied by a row
-/// with one pixel showing, so the cursor spends the whole list pinned to an
-/// edge with nothing ahead of it. The row is kept a couple of rows clear of
-/// both ends instead — what is coming next is as much of an answer as where
-/// the cursor is.
-fn scroll_into_view(selector: &'static str) {
-    spawn_detached(async move {
-        let js = format!(
-            r#"
-            requestAnimationFrame(() => {{
-                const row = document.querySelector({selector:?});
-                if (!row) return;
-                let box = row.parentElement;
-                while (box && box.scrollHeight <= box.clientHeight) {{
-                    box = box.parentElement;
-                }}
-                if (!box) {{
-                    row.scrollIntoView({{ block: 'nearest' }});
-                    return;
-                }}
-                const rowBox = row.getBoundingClientRect();
-                const view = box.getBoundingClientRect();
-                // Two rows of room, or a third of the list where two rows is
-                // most of it.
-                const margin = Math.min(rowBox.height * 2, view.height / 3);
-                const above = rowBox.top - view.top;
-                const below = view.bottom - rowBox.bottom;
-                if (above < margin) {{
-                    box.scrollTop += above - margin;
-                }} else if (below < margin) {{
-                    box.scrollTop -= below - margin;
-                }}
-            }});
-            "#
-        );
-        if let Err(e) = document::eval(&js).await {
-            tracing::debug!(selector, "Failed to scroll cursor into view: {e}");
-        }
-    });
-}
-
-fn search_navigate_eval(direction: &'static str) {
-    spawn_detached(async move {
-        let js = format!("window.Arto.search.navigate('{direction}')");
-        if let Err(e) = document::eval(&js).await {
-            tracing::debug!(%direction, "Search navigate failed: {e}");
-        }
-    });
-}
-
-fn search_open(state: &mut AppState) {
-    let mut app_state = *state;
-    spawn_detached(async move {
-        let js = r#"
-            (() => {
-                const s = window.getSelection();
-                dioxus.send(s ? s.toString() : "");
-            })()
-        "#;
-        let mut eval = document::eval(js);
-        match eval.recv::<String>().await {
-            Ok(text) if !text.trim().is_empty() => {
-                app_state.open_search_with_text(Some(text));
-            }
-            Ok(_) | Err(_) => {
-                app_state.open_search_with_text(None);
-            }
-        }
-    });
-}
-
-fn search_clear_eval() {
-    spawn_detached(async move {
-        if let Err(e) = document::eval("window.Arto.search.clear();").await {
-            tracing::debug!("Search clear failed: {e}");
-        }
-    });
-}
-
-fn search_pin_current(state: &mut AppState) {
-    let mut app_state = *state;
-    spawn_detached(async move {
-        #[derive(serde::Deserialize)]
-        struct QueryValue {
-            value: String,
-        }
-
-        let mut eval = document::eval(
-            r#"
-            (() => {
-                const input = document.querySelector('.search-input');
-                dioxus.send({ value: input?.value || '' });
-            })()
-            "#,
-        );
-        match eval.recv::<QueryValue>().await {
-            Ok(result) if !result.value.is_empty() => {
-                let _ = add_pinned_search(result.value);
-                app_state.update_search_results(0, 0);
-                let _ = document::eval(
-                    r#"
-                    (() => {
-                        const input = document.querySelector('.search-input');
-                        if (input) {
-                            input.value = '';
-                            input.focus();
-                        }
-                        window.Arto.search.clear();
-                    })()
-                    "#,
-                )
-                .await;
-            }
-            Ok(_) => {}
-            Err(e) => tracing::debug!("Search pin current failed: {e}"),
-        }
-    });
-}
-
-fn scroll_eval(method: &'static str) {
-    spawn_detached(async move {
-        let js = format!("window.Arto.scroll.{method}();");
-        if let Err(e) = document::eval(&js).await {
-            tracing::debug!(%method, "Scroll eval failed: {e}");
-        }
-    });
-}
-
-pub(crate) fn content_cursor_eval(method: &'static str) {
-    spawn_detached(async move {
-        let js = format!("window.Arto.contentCursor.{method}()");
-        if let Err(e) = document::eval(&js).await {
-            tracing::debug!(%method, "Content cursor eval failed: {e}");
-        }
-    });
-}
-
-fn copy_content_cursor_text(js_getter: &'static str) {
-    spawn_detached(async move {
-        let js = format!(
-            "(() => {{ const t = window.Arto?.contentCursor?.{js_getter}() ?? ''; dioxus.send(t); }})()"
-        );
-        let mut eval = document::eval(&js);
-        match eval.recv::<String>().await {
-            Ok(text) if !text.is_empty() => {
-                // What the document shows for an image is a URL only this app
-                // can resolve, so anything leaving it says where the file is.
-                let text = crate::assets::images::with_paths_for_urls(&text);
-                crate::utils::clipboard::copy_text(&text);
-                show_action_feedback("Copied");
-            }
-            Ok(_) => {}
-            Err(e) => tracing::debug!(js_getter, "Content cursor copy failed: {e}"),
-        }
-    });
-}
-
-fn copy_image_from_cursor(opaque: bool) {
-    spawn_detached(async move {
-        #[derive(serde::Deserialize)]
-        #[serde(tag = "kind", rename_all = "snake_case")]
-        enum CopyImageTarget {
-            Image { src: String },
-            Math,
-            Mermaid,
-            None,
-        }
-
-        let js = r#"
-            (() => {
-                const cursor = window.Arto?.contentCursor;
-                const el = cursor?.getCurrentElement?.();
-                if (!el) { dioxus.send({ kind: 'none' }); return; }
-
-                if (el.tagName === 'IMG') {
-                    const src = cursor?.getImageSrc?.() ?? '';
-                    if (!src) { dioxus.send({ kind: 'none' }); return; }
-                    dioxus.send({ kind: 'image', src });
-                    return;
-                }
-
-                if (
-                    el instanceof HTMLElement &&
-                    (
-                        el.classList.contains('preprocessed-math-display') ||
-                        el.classList.contains('preprocessed-math')
-                    )
-                ) {
-                    dioxus.send({ kind: 'math' });
-                    return;
-                }
-
-                if (el instanceof HTMLElement && el.classList.contains('preprocessed-mermaid')) {
-                    dioxus.send({ kind: 'mermaid' });
-                    return;
-                }
-
-                dioxus.send({ kind: 'none' });
-            })();
-        "#;
-        let mut eval = document::eval(js);
-        let Ok(target) = eval.recv::<CopyImageTarget>().await else {
-            return;
-        };
-
-        match target {
-            CopyImageTarget::Image { src } => {
-                copy_image_from_src(src, opaque).await;
-            }
-            CopyImageTarget::Math => {
-                copy_special_block_from_cursor("mathElement", opaque).await;
-            }
-            CopyImageTarget::Mermaid => {
-                copy_special_block_from_cursor("mermaidElement", opaque).await;
-            }
-            CopyImageTarget::None => {}
-        }
-    });
-}
-
-/// Put the PNG a rasterization returns on the clipboard, and say so when
-/// there is none.
-///
-/// `subject` names what was being rasterized, for the log line. Every way
-/// this can fail is reported: silence is what let a Copy Image that copied
-/// nothing look like a menu item nobody had clicked.
-pub(crate) async fn copy_rasterized_image(mut eval: document::Eval, subject: &str) {
-    match eval.recv::<Option<String>>().await {
-        Ok(Some(data_url)) => {
-            crate::utils::clipboard::copy_image_from_data_url(&data_url);
-            show_action_feedback("Copied");
-        }
-        Ok(None) => {
-            tracing::warn!(%subject, "Rasterizing for clipboard copy produced no image")
-        }
-        Err(e) => {
-            tracing::warn!(%e, %subject, "Rasterizing for clipboard copy failed")
-        }
-    }
-}
-
-async fn copy_special_block_from_cursor(kind: &str, opaque: bool) {
-    let opaque_str = if opaque { "true" } else { "false" };
-    let js = format!(
-        r#"
-        (async () => {{
-            const cursor = window.Arto?.contentCursor;
-            const el = cursor?.getCurrentElement?.();
-            if (!(el instanceof HTMLElement)) {{ dioxus.send(null); return; }}
-            dioxus.send(await window.Arto.rasterize.{kind}(el, {opaque_str}));
-        }})();
-        "#,
-    );
-    copy_rasterized_image(document::eval(&js), kind).await;
-}
-
-pub(crate) async fn copy_image_from_src(src: String, opaque: bool) {
-    // An image the app serves for the document is read here rather than in the
-    // WebView. Drawing it to a canvas there would taint the canvas — it comes
-    // from the app's own origin, not the document's — and asking for it as a
-    // CORS request is worse still, because a custom scheme does not take part
-    // in CORS and the load simply fails. Reading it costs one encode of an
-    // image somebody deliberately asked to copy.
-    let rasterize_src = if let Some(data_url) = crate::assets::images::data_url_for(&src) {
-        data_url
-    } else if src.starts_with("http://") || src.starts_with("https://") {
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        std::thread::spawn({
-            let src = src.clone();
-            move || {
-                let _ = tx.send(crate::utils::image::download_image_as_data_url(&src));
-            }
-        });
-        match rx.await {
-            Ok(Ok(data_url)) => data_url,
-            Ok(Err(e)) => {
-                tracing::error!(%e, "Failed to download image for clipboard copy");
-                return;
-            }
-            Err(_) => {
-                tracing::error!("Image download thread was cancelled");
-                return;
-            }
-        }
-    } else {
-        src
-    };
-
-    let Ok(src_json) = serde_json::to_string(&rasterize_src) else {
-        tracing::error!("Failed to serialize image src as JSON");
-        return;
-    };
-    let opaque_str = if opaque { "true" } else { "false" };
-    let js = format!(
-        "(async () => {{ dioxus.send(await window.Arto.rasterize.image({}, {})); }})();",
-        src_json, opaque_str
-    );
-    copy_rasterized_image(document::eval(&js), "image").await;
-}
-
-fn copy_image_path_from_cursor() {
-    spawn_detached(async move {
-        let js =
-            "(() => { const src = window.Arto?.contentCursor?.getImageSrc?.() ?? ''; dioxus.send(src); })()";
-        let mut eval = document::eval(js);
-        match eval.recv::<String>().await {
-            Ok(src) if !src.is_empty() => {
-                // The path the reader means, not the URL the WebView was given.
-                let src = crate::assets::images::with_paths_for_urls(&src);
-                crate::utils::clipboard::copy_text(&src);
-                show_action_feedback("Copied");
-            }
-            Ok(_) => {}
-            Err(e) => tracing::debug!("Copy image path failed: {e}"),
-        }
-    });
-}
-
-fn copy_link_path_from_cursor() {
-    spawn_detached(async move {
-        let js =
-            "(() => { const href = window.Arto?.contentCursor?.getLinkHref?.() ?? ''; dioxus.send(href); })()";
-        let mut eval = document::eval(js);
-        match eval.recv::<String>().await {
-            Ok(href) if !href.is_empty() => {
-                crate::utils::clipboard::copy_text(href);
-                show_action_feedback("Copied");
-            }
-            Ok(_) => {}
-            Err(e) => tracing::debug!("Copy link path failed: {e}"),
-        }
-    });
-}
-
-fn copy_file_path_with_line(file: std::path::PathBuf, is_range: bool) {
-    spawn_detached(async move {
-        let js =
-            "(() => { dioxus.send(window.Arto?.contentCursor?.getSourceLineRange() ?? null); })()";
-        let mut eval = document::eval(js);
-        if let Ok(Some((start, end))) = eval.recv::<Option<(u32, u32)>>().await {
-            let path_str = file.display().to_string();
-            let text = if is_range && start != end {
-                format!("{path_str}:{start}-{end}")
-            } else {
-                format!("{path_str}:{start}")
-            };
-            crate::utils::clipboard::copy_text(&text);
-            show_action_feedback("Copied");
-        }
-    });
-}
-
-fn copy_markdown_source(file: std::path::PathBuf) {
-    spawn_detached(async move {
-        #[derive(serde::Deserialize)]
-        struct MarkdownSourceRequest {
-            range: Option<(u32, u32)>,
-            selected_text: String,
-        }
-
-        let js = r#"
-            (() => {
-                const range = window.Arto?.contentCursor?.getSourceLineRange?.() ?? null;
-                const selection = window.getSelection();
-                const selected_text = selection ? selection.toString() : "";
-                dioxus.send({ range, selected_text });
-            })()
-        "#;
-        let mut eval = document::eval(js);
-        if let Ok(MarkdownSourceRequest {
-            range: Some((start, end)),
-            selected_text,
-        }) = eval.recv::<MarkdownSourceRequest>().await
-        {
-            let handle = std::thread::spawn(move || {
-                let source = crate::utils::source_lines::extract_source_lines(&file, start, end)?;
-                if selected_text.trim().is_empty() {
-                    return Some(source);
-                }
-                Some(
-                    crate::markdown::extract_source_selection(&source, &selected_text)
-                        .unwrap_or(source),
-                )
-            });
-            match handle.join() {
-                Ok(Some(md)) => {
-                    crate::utils::clipboard::copy_text(&md);
-                    show_action_feedback("Copied");
-                }
-                Ok(None) => tracing::debug!(%start, %end, "No source lines extracted"),
-                Err(_) => tracing::debug!("Source extraction thread panicked"),
-            }
-        }
-    });
 }
 
 pub(crate) fn show_action_feedback(message: &str) {
@@ -855,8 +262,48 @@ pub(crate) fn show_action_feedback(message: &str) {
     });
 }
 
+/// Open a copy of this window beside it.
+///
+/// A duplicate is for reading the same thing two ways — the document, the
+/// place in it, and the folders that were open to reach it — so it carries
+/// all three, and the window's own look with them. Its own scroll position
+/// is saved into the history first, which is what the copy then restores.
+fn duplicate_window(state: &mut AppState) {
+    let anchor = *state.current_scroll_anchor.read();
+    state.save_current_scroll_anchor(anchor);
+
+    let document = state.document();
+    let (temps, sidebar_pinned, sidebar_width, sidebar_show_all_files, sidebar_zoom_level) = {
+        let sidebar = state.sidebar.read();
+        (
+            sidebar.roots.temps().to_vec(),
+            sidebar.pinned,
+            sidebar.width,
+            sidebar.show_all_files,
+            sidebar.zoom_level,
+        )
+    };
+
+    let params = crate::window::CreateMainWindowConfigParams {
+        directory: None,
+        temps,
+        theme: *state.current_theme.read(),
+        content_full_width: *state.content_full_width.read(),
+        sidebar_pinned,
+        sidebar_width,
+        sidebar_show_all_files,
+        sidebar_zoom_level,
+        zoom_level: *state.zoom_level.read(),
+        ..crate::window::CreateMainWindowConfigParams::default()
+    };
+    crate::window::create_main_window_sync(&dioxus::desktop::window(), document, params);
+}
+
 fn get_current_file(state: &AppState) -> Option<std::path::PathBuf> {
-    state.current_file()
+    match &state.document.read().content {
+        crate::state::DocumentContent::File(path) => Some(path.clone()),
+        _ => None,
+    }
 }
 
 fn pick_markdown_file() -> Option<std::path::PathBuf> {
@@ -872,25 +319,6 @@ fn pick_directory() -> Option<std::path::PathBuf> {
     FileDialog::new()
         .set_directory(std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("/")))
         .pick_folder()
-}
-
-fn toggle_bookmark_on_cursor_or_current(state: &mut AppState) {
-    let target_path = get_bookmark_target_path(state).or_else(|| get_current_file(state));
-    let Some(path) = target_path else { return };
-
-    let is_bookmarked = crate::bookmarks::toggle_bookmark(&path);
-    if is_bookmarked {
-        show_action_feedback("Bookmarked");
-    } else {
-        show_action_feedback("Bookmark removed");
-    }
-}
-
-fn get_bookmark_target_path(state: &AppState) -> Option<std::path::PathBuf> {
-    match *state.focused_panel.read() {
-        FocusedPanel::Panel => state.panel_cursor.read().clone().map(|(_, path)| path),
-        FocusedPanel::Content => None,
-    }
 }
 
 fn open_content_viewer_from_cursor(state: &AppState) {
@@ -993,182 +421,4 @@ fn open_link_from_cursor(state: &mut AppState, open_in_new_window: bool) {
         };
         open_document_link(&mut app_state, &current_file, &href, how);
     });
-}
-
-fn save_image_from_cursor() {
-    spawn_detached(async move {
-        #[derive(serde::Deserialize)]
-        #[serde(tag = "kind", rename_all = "snake_case")]
-        enum SaveImageTarget {
-            Image { src: String },
-            Math,
-            Mermaid,
-            None,
-        }
-
-        let js = r#"
-            (() => {
-                const cursor = window.Arto?.contentCursor;
-                const el = cursor?.getCurrentElement?.();
-                if (!el) { dioxus.send({ kind: 'none' }); return; }
-
-                if (el.tagName === 'IMG') {
-                    const src = cursor?.getImageSrc?.() ?? '';
-                    if (!src) { dioxus.send({ kind: 'none' }); return; }
-                    dioxus.send({ kind: 'image', src });
-                    return;
-                }
-
-                if (
-                    el instanceof HTMLElement &&
-                    (
-                        el.classList.contains('preprocessed-math-display') ||
-                        el.classList.contains('preprocessed-math')
-                    )
-                ) {
-                    dioxus.send({ kind: 'math' });
-                    return;
-                }
-
-                if (el instanceof HTMLElement && el.classList.contains('preprocessed-mermaid')) {
-                    dioxus.send({ kind: 'mermaid' });
-                    return;
-                }
-
-                dioxus.send({ kind: 'none' });
-            })()
-        "#;
-        let mut eval = document::eval(js);
-        let Ok(target) = eval.recv::<SaveImageTarget>().await else {
-            return;
-        };
-
-        match target {
-            SaveImageTarget::Image { src } => {
-                std::thread::spawn(move || {
-                    // `save_image` knows `data:` and `http(s)`; the app's own
-                    // protocol resolves nowhere outside a WebView, so an image
-                    // the app serves is read here and handed over as bytes.
-                    let src = crate::assets::images::data_url_for(&src).unwrap_or(src);
-                    crate::utils::image::save_image(&src);
-                });
-            }
-            SaveImageTarget::Math => {
-                save_special_block_from_cursor("mathElement").await;
-            }
-            SaveImageTarget::Mermaid => {
-                save_special_block_from_cursor("mermaidElement").await;
-            }
-            SaveImageTarget::None => {}
-        }
-    });
-}
-
-async fn save_special_block_from_cursor(kind: &str) {
-    let js = format!(
-        r#"
-        (async () => {{
-            const cursor = window.Arto?.contentCursor;
-            const el = cursor?.getCurrentElement?.();
-            if (!(el instanceof HTMLElement)) {{ dioxus.send(null); return; }}
-            dioxus.send(await window.Arto.rasterize.{kind}(el, true));
-        }})();
-        "#,
-    );
-    let mut eval = document::eval(&js);
-    match eval.recv::<Option<String>>().await {
-        Ok(Some(data_url)) => {
-            std::thread::spawn(move || {
-                crate::utils::image::save_image(&data_url);
-            });
-        }
-        Ok(None) => tracing::warn!(%kind, "Rasterizing for save produced no image"),
-        Err(e) => tracing::warn!(%e, %kind, "Rasterizing for save failed"),
-    }
-}
-
-fn set_parent_of_current_file_as_root(state: &mut AppState) {
-    let Some(file) = get_current_file(state) else {
-        return;
-    };
-    let Some(parent) = file.parent() else {
-        return;
-    };
-    state.add_root(parent);
-}
-
-/// Open a second window on the same document, at the same place in it.
-///
-/// What a window is made of is what gets copied: the document and where the
-/// reader had reached in it, the panel's shape, and the zoom. The new window
-/// is otherwise its own.
-fn duplicate_window(state: &mut AppState) {
-    let anchor = *state.current_scroll_anchor.read();
-    state.save_current_scroll_anchor(anchor);
-
-    let document = state.document();
-    let (directory, sidebar_pinned, sidebar_width, sidebar_show_all_files, sidebar_zoom_level) = {
-        let sidebar = state.sidebar.read();
-        (
-            sidebar.primary_root().cloned(),
-            sidebar.pinned,
-            sidebar.width,
-            sidebar.show_all_files,
-            sidebar.zoom_level,
-        )
-    };
-
-    let params = crate::window::CreateMainWindowConfigParams {
-        directory,
-        theme: *state.current_theme.read(),
-        content_full_width: *state.content_full_width.read(),
-        sidebar_pinned,
-        sidebar_width,
-        sidebar_show_all_files,
-        sidebar_zoom_level,
-        zoom_level: *state.zoom_level.read(),
-        ..crate::window::CreateMainWindowConfigParams::default()
-    };
-    crate::window::create_main_window_sync(&dioxus::desktop::window(), document, params);
-}
-
-/// Move the palette's cursor by one row.
-fn step_palette(state: &mut AppState, forward: bool) {
-    let len = *state.palette_rows.read();
-    let at = crate::components::palette::cursor_row(state, len);
-    state
-        .palette_cursor
-        .set(Some(crate::components::palette::step_cursor(
-            at, len, forward,
-        )));
-    scroll_into_view(".palette-row.keyboard-focused");
-}
-
-/// Take the row the palette is on: read the document, work in the folder, or
-/// do the thing.
-///
-/// The palette closes first. A command can put a modal file dialog or a new
-/// window on screen, and the list it was picked from has no business still
-/// floating over that.
-pub fn activate_palette_row(mut state: AppState, index: usize) {
-    let row = {
-        let visits = crate::visits::VISITS.read();
-        let (starred, places) = crate::components::palette::kept();
-        crate::components::palette::rows_for(
-            &visits.items,
-            &starred,
-            &places,
-            &state.palette_query.read(),
-        )
-        .get(index)
-        .cloned()
-    };
-    state.close_palette();
-    match row {
-        Some(crate::components::palette::Row::Document(visit)) => state.open_file(&visit.path),
-        Some(crate::components::palette::Row::Starred(path)) => state.open_file(&path),
-        Some(crate::components::palette::Row::Place(path)) => state.add_root(&path),
-        Some(crate::components::palette::Row::Command(action)) => dispatch_action(&action, state),
-        None => {}
-    }
 }

--- a/crates/arto/src/keybindings/dispatcher/clipboard.rs
+++ b/crates/arto/src/keybindings/dispatcher/clipboard.rs
@@ -1,0 +1,359 @@
+//! Putting what is on screen somewhere else: the clipboard, and a file.
+//!
+//! Every one of these reaches into the page, because what is being copied is
+//! whatever the content cursor is on and only the page knows what that is.
+
+use dioxus::document;
+
+use super::*;
+
+pub(super) fn copy_content_cursor_text(js_getter: &'static str) {
+    spawn_detached(async move {
+        let js = format!(
+            "(() => {{ const t = window.Arto?.contentCursor?.{js_getter}() ?? ''; dioxus.send(t); }})()"
+        );
+        let mut eval = document::eval(&js);
+        match eval.recv::<String>().await {
+            Ok(text) if !text.is_empty() => {
+                // What the document shows for an image is a URL only this app
+                // can resolve, so anything leaving it says where the file is.
+                let text = crate::assets::images::with_paths_for_urls(&text);
+                crate::utils::clipboard::copy_text(&text);
+                show_action_feedback("Copied");
+            }
+            Ok(_) => {}
+            Err(e) => tracing::debug!(js_getter, "Content cursor copy failed: {e}"),
+        }
+    });
+}
+
+pub(super) fn copy_image_from_cursor(opaque: bool) {
+    spawn_detached(async move {
+        #[derive(serde::Deserialize)]
+        #[serde(tag = "kind", rename_all = "snake_case")]
+        enum CopyImageTarget {
+            Image { src: String },
+            Math,
+            Mermaid,
+            None,
+        }
+
+        let js = r#"
+            (() => {
+                const cursor = window.Arto?.contentCursor;
+                const el = cursor?.getCurrentElement?.();
+                if (!el) { dioxus.send({ kind: 'none' }); return; }
+
+                if (el.tagName === 'IMG') {
+                    const src = cursor?.getImageSrc?.() ?? '';
+                    if (!src) { dioxus.send({ kind: 'none' }); return; }
+                    dioxus.send({ kind: 'image', src });
+                    return;
+                }
+
+                if (
+                    el instanceof HTMLElement &&
+                    (
+                        el.classList.contains('preprocessed-math-display') ||
+                        el.classList.contains('preprocessed-math')
+                    )
+                ) {
+                    dioxus.send({ kind: 'math' });
+                    return;
+                }
+
+                if (el instanceof HTMLElement && el.classList.contains('preprocessed-mermaid')) {
+                    dioxus.send({ kind: 'mermaid' });
+                    return;
+                }
+
+                dioxus.send({ kind: 'none' });
+            })();
+        "#;
+        let mut eval = document::eval(js);
+        let Ok(target) = eval.recv::<CopyImageTarget>().await else {
+            return;
+        };
+
+        match target {
+            CopyImageTarget::Image { src } => {
+                copy_image_from_src(src, opaque).await;
+            }
+            CopyImageTarget::Math => {
+                copy_special_block_from_cursor("mathElement", opaque).await;
+            }
+            CopyImageTarget::Mermaid => {
+                copy_special_block_from_cursor("mermaidElement", opaque).await;
+            }
+            CopyImageTarget::None => {}
+        }
+    });
+}
+
+/// Put the PNG a rasterization returns on the clipboard, and say so when
+/// there is none.
+///
+/// `subject` names what was being rasterized, for the log line. Every way
+/// this can fail is reported: silence is what let a Copy Image that copied
+/// nothing look like a menu item nobody had clicked.
+pub(crate) async fn copy_rasterized_image(mut eval: document::Eval, subject: &str) {
+    match eval.recv::<Option<String>>().await {
+        Ok(Some(data_url)) => {
+            crate::utils::clipboard::copy_image_from_data_url(&data_url);
+            show_action_feedback("Copied");
+        }
+        Ok(None) => {
+            tracing::warn!(%subject, "Rasterizing for clipboard copy produced no image")
+        }
+        Err(e) => {
+            tracing::warn!(%e, %subject, "Rasterizing for clipboard copy failed")
+        }
+    }
+}
+
+pub(super) async fn copy_special_block_from_cursor(kind: &str, opaque: bool) {
+    let opaque_str = if opaque { "true" } else { "false" };
+    let js = format!(
+        r#"
+        (async () => {{
+            const cursor = window.Arto?.contentCursor;
+            const el = cursor?.getCurrentElement?.();
+            if (!(el instanceof HTMLElement)) {{ dioxus.send(null); return; }}
+            dioxus.send(await window.Arto.rasterize.{kind}(el, {opaque_str}));
+        }})();
+        "#,
+    );
+    copy_rasterized_image(document::eval(&js), kind).await;
+}
+
+pub(crate) async fn copy_image_from_src(src: String, opaque: bool) {
+    // An image the app serves for the document is read here rather than in the
+    // WebView. Drawing it to a canvas there would taint the canvas — it comes
+    // from the app's own origin, not the document's — and asking for it as a
+    // CORS request is worse still, because a custom scheme does not take part
+    // in CORS and the load simply fails. Reading it costs one encode of an
+    // image somebody deliberately asked to copy.
+    let rasterize_src = if let Some(data_url) = crate::assets::images::data_url_for(&src) {
+        data_url
+    } else if src.starts_with("http://") || src.starts_with("https://") {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        std::thread::spawn({
+            let src = src.clone();
+            move || {
+                let _ = tx.send(crate::utils::image::download_image_as_data_url(&src));
+            }
+        });
+        match rx.await {
+            Ok(Ok(data_url)) => data_url,
+            Ok(Err(e)) => {
+                tracing::error!(%e, "Failed to download image for clipboard copy");
+                return;
+            }
+            Err(_) => {
+                tracing::error!("Image download thread was cancelled");
+                return;
+            }
+        }
+    } else {
+        src
+    };
+
+    let Ok(src_json) = serde_json::to_string(&rasterize_src) else {
+        tracing::error!("Failed to serialize image src as JSON");
+        return;
+    };
+    let opaque_str = if opaque { "true" } else { "false" };
+    let js = format!(
+        "(async () => {{ dioxus.send(await window.Arto.rasterize.image({}, {})); }})();",
+        src_json, opaque_str
+    );
+    copy_rasterized_image(document::eval(&js), "image").await;
+}
+
+pub(super) fn copy_image_path_from_cursor() {
+    spawn_detached(async move {
+        let js =
+            "(() => { const src = window.Arto?.contentCursor?.getImageSrc?.() ?? ''; dioxus.send(src); })()";
+        let mut eval = document::eval(js);
+        match eval.recv::<String>().await {
+            Ok(src) if !src.is_empty() => {
+                // The path the reader means, not the URL the WebView was given.
+                let src = crate::assets::images::with_paths_for_urls(&src);
+                crate::utils::clipboard::copy_text(&src);
+                show_action_feedback("Copied");
+            }
+            Ok(_) => {}
+            Err(e) => tracing::debug!("Copy image path failed: {e}"),
+        }
+    });
+}
+
+pub(super) fn copy_link_path_from_cursor() {
+    spawn_detached(async move {
+        let js =
+            "(() => { const href = window.Arto?.contentCursor?.getLinkHref?.() ?? ''; dioxus.send(href); })()";
+        let mut eval = document::eval(js);
+        match eval.recv::<String>().await {
+            Ok(href) if !href.is_empty() => {
+                crate::utils::clipboard::copy_text(href);
+                show_action_feedback("Copied");
+            }
+            Ok(_) => {}
+            Err(e) => tracing::debug!("Copy link path failed: {e}"),
+        }
+    });
+}
+
+pub(super) fn copy_file_path_with_line(file: std::path::PathBuf, is_range: bool) {
+    spawn_detached(async move {
+        let js =
+            "(() => { dioxus.send(window.Arto?.contentCursor?.getSourceLineRange() ?? null); })()";
+        let mut eval = document::eval(js);
+        if let Ok(Some((start, end))) = eval.recv::<Option<(u32, u32)>>().await {
+            let path_str = file.display().to_string();
+            let text = if is_range && start != end {
+                format!("{path_str}:{start}-{end}")
+            } else {
+                format!("{path_str}:{start}")
+            };
+            crate::utils::clipboard::copy_text(&text);
+            show_action_feedback("Copied");
+        }
+    });
+}
+
+pub(super) fn copy_markdown_source(file: std::path::PathBuf) {
+    spawn_detached(async move {
+        #[derive(serde::Deserialize)]
+        struct MarkdownSourceRequest {
+            range: Option<(u32, u32)>,
+            selected_text: String,
+        }
+
+        let js = r#"
+            (() => {
+                const range = window.Arto?.contentCursor?.getSourceLineRange?.() ?? null;
+                const selection = window.getSelection();
+                const selected_text = selection ? selection.toString() : "";
+                dioxus.send({ range, selected_text });
+            })()
+        "#;
+        let mut eval = document::eval(js);
+        if let Ok(MarkdownSourceRequest {
+            range: Some((start, end)),
+            selected_text,
+        }) = eval.recv::<MarkdownSourceRequest>().await
+        {
+            let handle = std::thread::spawn(move || {
+                let source = crate::utils::source_lines::extract_source_lines(&file, start, end)?;
+                if selected_text.trim().is_empty() {
+                    return Some(source);
+                }
+                Some(
+                    crate::markdown::extract_source_selection(&source, &selected_text)
+                        .unwrap_or(source),
+                )
+            });
+            match handle.join() {
+                Ok(Some(md)) => {
+                    crate::utils::clipboard::copy_text(&md);
+                    show_action_feedback("Copied");
+                }
+                Ok(None) => tracing::debug!(%start, %end, "No source lines extracted"),
+                Err(_) => tracing::debug!("Source extraction thread panicked"),
+            }
+        }
+    });
+}
+
+pub(super) fn save_image_from_cursor() {
+    spawn_detached(async move {
+        #[derive(serde::Deserialize)]
+        #[serde(tag = "kind", rename_all = "snake_case")]
+        enum SaveImageTarget {
+            Image { src: String },
+            Math,
+            Mermaid,
+            None,
+        }
+
+        let js = r#"
+            (() => {
+                const cursor = window.Arto?.contentCursor;
+                const el = cursor?.getCurrentElement?.();
+                if (!el) { dioxus.send({ kind: 'none' }); return; }
+
+                if (el.tagName === 'IMG') {
+                    const src = cursor?.getImageSrc?.() ?? '';
+                    if (!src) { dioxus.send({ kind: 'none' }); return; }
+                    dioxus.send({ kind: 'image', src });
+                    return;
+                }
+
+                if (
+                    el instanceof HTMLElement &&
+                    (
+                        el.classList.contains('preprocessed-math-display') ||
+                        el.classList.contains('preprocessed-math')
+                    )
+                ) {
+                    dioxus.send({ kind: 'math' });
+                    return;
+                }
+
+                if (el instanceof HTMLElement && el.classList.contains('preprocessed-mermaid')) {
+                    dioxus.send({ kind: 'mermaid' });
+                    return;
+                }
+
+                dioxus.send({ kind: 'none' });
+            })()
+        "#;
+        let mut eval = document::eval(js);
+        let Ok(target) = eval.recv::<SaveImageTarget>().await else {
+            return;
+        };
+
+        match target {
+            SaveImageTarget::Image { src } => {
+                std::thread::spawn(move || {
+                    // `save_image` knows `data:` and `http(s)`; the app's own
+                    // protocol resolves nowhere outside a WebView, so an image
+                    // the app serves is read here and handed over as bytes.
+                    let src = crate::assets::images::data_url_for(&src).unwrap_or(src);
+                    crate::utils::image::save_image(&src);
+                });
+            }
+            SaveImageTarget::Math => {
+                save_special_block_from_cursor("mathElement").await;
+            }
+            SaveImageTarget::Mermaid => {
+                save_special_block_from_cursor("mermaidElement").await;
+            }
+            SaveImageTarget::None => {}
+        }
+    });
+}
+
+pub(super) async fn save_special_block_from_cursor(kind: &str) {
+    let js = format!(
+        r#"
+        (async () => {{
+            const cursor = window.Arto?.contentCursor;
+            const el = cursor?.getCurrentElement?.();
+            if (!(el instanceof HTMLElement)) {{ dioxus.send(null); return; }}
+            dioxus.send(await window.Arto.rasterize.{kind}(el, true));
+        }})();
+        "#,
+    );
+    let mut eval = document::eval(&js);
+    match eval.recv::<Option<String>>().await {
+        Ok(Some(data_url)) => {
+            std::thread::spawn(move || {
+                crate::utils::image::save_image(&data_url);
+            });
+        }
+        Ok(None) => tracing::warn!(%kind, "Rasterizing for save produced no image"),
+        Err(e) => tracing::warn!(%e, %kind, "Rasterizing for save failed"),
+    }
+}

--- a/crates/arto/src/keybindings/dispatcher/contents.rs
+++ b/crates/arto/src/keybindings/dispatcher/contents.rs
@@ -1,0 +1,79 @@
+//! Moving through the contents while they are held open.
+//!
+//! The list is the gutter's own — the same headings, in the same place — so
+//! these keys move a cursor through what is already on screen rather than
+//! opening a second list of their own.
+
+use super::*;
+
+/// Move the cursor by one heading, from wherever it is.
+pub(super) fn step_contents(state: &mut AppState, forward: bool) {
+    let next = step(
+        *state.contents_cursor.read(),
+        state.headings.read().len(),
+        forward,
+    );
+    if next.is_none() {
+        return;
+    }
+    state.contents_cursor.set(next);
+    scroll_into_view(".contents-toc-row.keyboard-focused");
+}
+
+/// Where one step lands, or `None` when there is nothing to step through.
+///
+/// From nowhere it starts at the end it is walking from: the first step down
+/// lands on the first heading, the first step up on the last. Both ends stop
+/// rather than wrap — this list is the document's shape, and a cursor that
+/// reappeared at the top of it would lose where the reader was in it. (The
+/// palette wraps, because there the list is short and its order is not the
+/// document's.)
+fn step(at: Option<usize>, len: usize, forward: bool) -> Option<usize> {
+    let last = len.checked_sub(1)?;
+    Some(match (at, forward) {
+        (None, true) => 0,
+        (None, false) => last,
+        (Some(at), true) => (at + 1).min(last),
+        (Some(at), false) => at.saturating_sub(1),
+    })
+}
+
+/// Go to the heading the cursor is on, and let the list go.
+///
+/// The list was opened to get somewhere; once it has, keeping it over the
+/// page would leave the reader looking at the map instead of the place.
+pub(super) fn confirm_contents(state: &mut AppState) {
+    let Some(at) = *state.contents_cursor.read() else {
+        return;
+    };
+    let Some(id) = state.headings.read().get(at).map(|h| h.id.clone()) else {
+        return;
+    };
+    state.close_contents();
+    spawn_detached(async move {
+        let _ = document::eval(&crate::document_link::scroll_to_heading_js(&id)).await;
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_first_step_starts_at_the_end_it_is_walking_from() {
+        assert_eq!(step(None, 4, true), Some(0));
+        assert_eq!(step(None, 4, false), Some(3));
+    }
+
+    #[test]
+    fn both_ends_stop_rather_than_wrap() {
+        assert_eq!(step(Some(3), 4, true), Some(3));
+        assert_eq!(step(Some(0), 4, false), Some(0));
+    }
+
+    #[test]
+    fn a_document_with_no_headings_has_nowhere_to_step() {
+        assert_eq!(step(None, 0, true), None);
+        assert_eq!(step(Some(0), 0, false), None);
+    }
+}

--- a/crates/arto/src/keybindings/dispatcher/palette.rs
+++ b/crates/arto/src/keybindings/dispatcher/palette.rs
@@ -1,0 +1,47 @@
+//! Moving through the palette and taking what it is on.
+//!
+//! The palette's query and cursor are the window's state, which is what lets
+//! a binding move them from out here.
+
+use super::*;
+
+/// Move the palette's cursor by one row.
+pub(super) fn step_palette(state: &mut AppState, forward: bool) {
+    let len = *state.palette_rows.read();
+    let at = crate::components::palette::cursor_row(state, len);
+    state
+        .palette_cursor
+        .set(Some(crate::components::palette::step_cursor(
+            at, len, forward,
+        )));
+    scroll_into_view(".palette-row.keyboard-focused");
+}
+
+/// Take the row the palette is on: read the document, work in the folder, or
+/// do the thing.
+///
+/// The palette closes first. A command can put a modal file dialog or a new
+/// window on screen, and the list it was picked from has no business still
+/// floating over that.
+pub fn activate_palette_row(mut state: AppState, index: usize) {
+    let row = {
+        let visits = crate::visits::VISITS.read();
+        let (starred, places) = crate::components::palette::kept();
+        crate::components::palette::rows_for(
+            &visits.items,
+            &starred,
+            &places,
+            &state.palette_query.read(),
+        )
+        .get(index)
+        .cloned()
+    };
+    state.close_palette();
+    match row {
+        Some(crate::components::palette::Row::Document(visit)) => state.open_file(&visit.path),
+        Some(crate::components::palette::Row::Starred(path)) => state.open_file(&path),
+        Some(crate::components::palette::Row::Place(path)) => state.add_root(&path),
+        Some(crate::components::palette::Row::Command(action)) => dispatch_action(&action, state),
+        None => {}
+    }
+}

--- a/crates/arto/src/keybindings/dispatcher/panel.rs
+++ b/crates/arto/src/keybindings/dispatcher/panel.rs
@@ -1,0 +1,261 @@
+//! The panel's keyboard: which face is showing, where the cursor is in it,
+//! and what happens to the row it is on.
+
+use super::*;
+
+/// Clone sidebar data needed for cursor navigation, releasing the read guard.
+///
+/// The rows the panel is drawing, in the order it draws them.
+///
+/// One list per face, and the cursor walks whichever is on screen — the same
+/// keys, over a tree, a history or a set of stars. What is folded away counts:
+/// a cursor on a row nobody can see is a cursor nobody can follow.
+pub(super) fn panel_items(state: &AppState) -> Vec<crate::state::PanelRow> {
+    match state.sidebar.peek().face {
+        crate::state::Face::Places => match extract_sidebar_data(state) {
+            Some(tree) => sidebar_cursor::visible_items_in_roots(
+                &tree.roots,
+                &tree.expanded,
+                tree.show_all_files,
+            ),
+            None => Vec::new(),
+        },
+        crate::state::Face::Recent => {
+            let folded = state.sidebar.peek().recent_collapsed.clone();
+            crate::visits::VISITS
+                .read()
+                .grouped(chrono::Local::now())
+                .into_iter()
+                .filter(|(bucket, _)| !folded.contains(&bucket.heading()))
+                .flat_map(|(_, visits)| {
+                    visits
+                        .into_iter()
+                        .map(|visit| (crate::state::Group::Flat, visit.path.clone()))
+                })
+                .collect()
+        }
+        crate::state::Face::Starred => crate::bookmarks::BOOKMARKS
+            .read()
+            .items
+            .iter()
+            .filter(|bookmark| !bookmark.is_dir())
+            .map(|bookmark| (crate::state::Group::Flat, bookmark.path.clone()))
+            .collect(),
+    }
+}
+
+/// Put the cursor on the first row, if it is not on one already.
+pub(super) fn rest_cursor(state: &mut AppState) {
+    let items = panel_items(state);
+    let resting = state
+        .panel_cursor
+        .peek()
+        .as_ref()
+        .is_some_and(|at| items.contains(at));
+    if !resting {
+        state.panel_cursor.set(items.first().cloned());
+    }
+}
+
+/// Show a face and take the keyboard to it, cursor and all — or put the panel
+/// away, if that is where the keyboard already is.
+///
+/// Asking for the face you are already in is asking to leave: one key opens
+/// the list and closes it again, which is what a reader means by pressing it
+/// twice. Asking for a different face while in the panel only changes faces.
+pub(super) fn face_to(state: &mut AppState, face: crate::state::Face) {
+    let already_here =
+        *state.focused_panel.read() == FocusedPanel::Panel && state.sidebar.peek().face == face;
+    if already_here {
+        state.hide_panel();
+        return;
+    }
+    state.focus_face(face);
+    rest_cursor(state);
+    scroll_cursor_into_view();
+}
+
+/// Step along the rail to the next face.
+pub(super) fn step_face(state: &mut AppState, forward: bool) {
+    state.step_face(forward);
+    rest_cursor(state);
+    scroll_cursor_into_view();
+}
+
+/// Which root of its own group the cursor's row descends from.
+fn root_of(state: &AppState, row: &crate::state::PanelRow) -> std::path::PathBuf {
+    let (group, path) = row;
+    let roots = extract_sidebar_data(state)
+        .map(|tree| tree.roots)
+        .unwrap_or_default();
+    roots
+        .into_iter()
+        .find(|(row_group, root)| row_group == group && path.starts_with(root))
+        .map(|(_, root)| root)
+        .unwrap_or_else(|| path.to_path_buf())
+}
+
+/// What the tree is drawing, as the cursor needs to see it.
+pub(super) struct TreeShape {
+    /// Every root the tree draws, in the order it draws them, each with the
+    /// group it is drawn in.
+    roots: Vec<(crate::state::Group, std::path::PathBuf)>,
+    /// The rows that are open — see [`crate::state::Sidebar::expanded_dirs`].
+    expanded: std::collections::HashSet<crate::state::TreeRow>,
+    show_all_files: bool,
+}
+
+/// The tree's shape, if it has any root at all.
+pub(super) fn extract_sidebar_data(state: &AppState) -> Option<TreeShape> {
+    use crate::state::Group;
+
+    let sidebar = state.sidebar.read();
+    // The window's own folder first, which is the order the tree draws them.
+    let roots: Vec<_> = sidebar
+        .roots
+        .temps()
+        .iter()
+        .map(|root| (Group::Current, root.clone()))
+        .chain(
+            sidebar
+                .roots
+                .places()
+                .iter()
+                .map(|root| (Group::Bookmark, root.clone())),
+        )
+        .collect();
+    (!roots.is_empty()).then(|| TreeShape {
+        roots,
+        expanded: sidebar.expanded_dirs.clone(),
+        show_all_files: sidebar.show_all_files,
+    })
+}
+
+pub(super) enum CursorDirection {
+    Down,
+    Up,
+}
+
+pub(super) fn dispatch_cursor_move(state: &mut AppState, direction: CursorDirection) {
+    if *state.focused_panel.read() != FocusedPanel::Panel {
+        return;
+    }
+    let items = panel_items(state);
+    if items.is_empty() {
+        return;
+    }
+    let current = state.panel_cursor.read().clone();
+    let next = match direction {
+        CursorDirection::Down => sidebar_cursor::move_down(&current, &items),
+        CursorDirection::Up => sidebar_cursor::move_up(&current, &items),
+    };
+    state.panel_cursor.set(next);
+    scroll_cursor_into_view();
+}
+
+/// cursor.enter — "Enter into": directory → set as root, file → open, heading → scroll to.
+pub(super) fn dispatch_cursor_enter(state: &mut AppState) {
+    let panel = *state.focused_panel.read();
+    match panel {
+        FocusedPanel::Panel => {
+            let Some((_, path)) = state.panel_cursor.read().clone() else {
+                return;
+            };
+            if path.is_dir() {
+                state.add_root(&path);
+            } else if path.exists() {
+                state.open_from_panel(&path);
+            }
+        }
+        FocusedPanel::Content => {}
+    }
+}
+
+/// cursor.open — "Open/expand": directory → expand tree, file → open, heading → scroll to.
+pub(super) fn dispatch_cursor_open(state: &mut AppState) {
+    let panel = *state.focused_panel.read();
+    match panel {
+        FocusedPanel::Panel => open_panel_row(state),
+        FocusedPanel::Content => {}
+    }
+}
+
+/// Open what the cursor is on: a document is read, a folder opens onto its
+/// contents with the cursor on the first of them.
+pub(super) fn open_panel_row(state: &mut AppState) {
+    let Some(row) = state.panel_cursor.read().clone() else {
+        return;
+    };
+    let (group, path) = row.clone();
+
+    if !path.is_dir() {
+        if path.exists() {
+            state.open_from_panel(&path);
+        }
+        return;
+    }
+
+    let root = root_of(state, &row);
+    if !state.sidebar.peek().is_expanded(group, &root, &path) {
+        state.toggle_directory_expansion(group, &root, &path);
+    }
+    let items = panel_items(state);
+    let next = items
+        .iter()
+        .position(|item| item == &row)
+        .and_then(|at| items.get(at + 1).cloned());
+    if let Some(next) = next {
+        state.panel_cursor.set(Some(next));
+        scroll_cursor_into_view();
+    }
+}
+
+pub(super) fn dispatch_cursor_collapse(state: &mut AppState) {
+    if *state.focused_panel.read() != FocusedPanel::Panel {
+        return;
+    }
+    let Some(row) = state.panel_cursor.read().clone() else {
+        return;
+    };
+    let (group, path) = row.clone();
+    let root = root_of(state, &row);
+    if path.is_dir() && state.sidebar.peek().is_expanded(group, &root, &path) {
+        state.toggle_directory_expansion(group, &root, &path);
+        return;
+    }
+    // Out of a folder is up to the one holding it, where the list has one.
+    let items = panel_items(state);
+    if let Some(parent) = sidebar_cursor::find_parent_dir(&row, &items) {
+        state.panel_cursor.set(Some(parent));
+        scroll_cursor_into_view();
+    }
+}
+
+pub(super) fn toggle_bookmark_on_cursor_or_current(state: &mut AppState) {
+    let target_path = get_bookmark_target_path(state).or_else(|| get_current_file(state));
+    let Some(path) = target_path else { return };
+
+    let is_bookmarked = crate::bookmarks::toggle_bookmark(&path);
+    if is_bookmarked {
+        show_action_feedback("Bookmarked");
+    } else {
+        show_action_feedback("Bookmark removed");
+    }
+}
+
+pub(super) fn get_bookmark_target_path(state: &AppState) -> Option<std::path::PathBuf> {
+    match *state.focused_panel.read() {
+        FocusedPanel::Panel => state.panel_cursor.read().clone().map(|(_, path)| path),
+        FocusedPanel::Content => None,
+    }
+}
+
+pub(super) fn set_parent_of_current_file_as_root(state: &mut AppState) {
+    let Some(file) = get_current_file(state) else {
+        return;
+    };
+    let Some(parent) = file.parent() else {
+        return;
+    };
+    state.add_root(parent);
+}

--- a/crates/arto/src/keybindings/dispatcher/reveal.rs
+++ b/crates/arto/src/keybindings/dispatcher/reveal.rs
@@ -1,0 +1,74 @@
+//! Bringing something into view, and the page's own scrolling.
+
+use dioxus::document;
+
+use super::*;
+
+/// Scroll the keyboard-focused element into view using JS.
+pub(super) fn scroll_cursor_into_view() {
+    scroll_into_view(".keyboard-focused");
+}
+
+/// Bring the row a cursor just moved to into view, with room around it.
+///
+/// On the next frame, because the row it is looking for is the one the move
+/// has yet to draw.
+///
+/// Not `scrollIntoView({ block: 'nearest' })`: that is satisfied by a row
+/// with one pixel showing, so the cursor spends the whole list pinned to an
+/// edge with nothing ahead of it. The row is kept a couple of rows clear of
+/// both ends instead — what is coming next is as much of an answer as where
+/// the cursor is.
+pub(super) fn scroll_into_view(selector: &'static str) {
+    spawn_detached(async move {
+        let js = format!(
+            r#"
+            requestAnimationFrame(() => {{
+                const row = document.querySelector({selector:?});
+                if (!row) return;
+                let box = row.parentElement;
+                while (box && box.scrollHeight <= box.clientHeight) {{
+                    box = box.parentElement;
+                }}
+                if (!box) {{
+                    row.scrollIntoView({{ block: 'nearest' }});
+                    return;
+                }}
+                const rowBox = row.getBoundingClientRect();
+                const view = box.getBoundingClientRect();
+                // Two rows of room, or a third of the list where two rows is
+                // most of it.
+                const margin = Math.min(rowBox.height * 2, view.height / 3);
+                const above = rowBox.top - view.top;
+                const below = view.bottom - rowBox.bottom;
+                if (above < margin) {{
+                    box.scrollTop += above - margin;
+                }} else if (below < margin) {{
+                    box.scrollTop -= below - margin;
+                }}
+            }});
+            "#
+        );
+        if let Err(e) = document::eval(&js).await {
+            tracing::debug!(selector, "Failed to scroll cursor into view: {e}");
+        }
+    });
+}
+
+pub(super) fn scroll_eval(method: &'static str) {
+    spawn_detached(async move {
+        let js = format!("window.Arto.scroll.{method}();");
+        if let Err(e) = document::eval(&js).await {
+            tracing::debug!(%method, "Scroll eval failed: {e}");
+        }
+    });
+}
+
+pub(crate) fn content_cursor_eval(method: &'static str) {
+    spawn_detached(async move {
+        let js = format!("window.Arto.contentCursor.{method}()");
+        if let Err(e) = document::eval(&js).await {
+            tracing::debug!(%method, "Content cursor eval failed: {e}");
+        }
+    });
+}

--- a/crates/arto/src/keybindings/dispatcher/search.rs
+++ b/crates/arto/src/keybindings/dispatcher/search.rs
@@ -1,0 +1,78 @@
+//! The find field's actions.
+//!
+//! The field itself is `crate::components::find`; these are what the
+//! bindings in the `search` context do to it.
+
+use dioxus::document;
+
+use super::*;
+
+pub(super) fn search_navigate_eval(direction: &'static str) {
+    spawn_detached(async move {
+        let js = format!("window.Arto.search.navigate('{direction}')");
+        if let Err(e) = document::eval(&js).await {
+            tracing::debug!(%direction, "Search navigate failed: {e}");
+        }
+    });
+}
+
+pub(super) fn search_open(state: &mut AppState) {
+    let mut app_state = *state;
+    spawn_detached(async move {
+        let js = r#"
+            (() => {
+                const s = window.getSelection();
+                dioxus.send(s ? s.toString() : "");
+            })()
+        "#;
+        let mut eval = document::eval(js);
+        match eval.recv::<String>().await {
+            Ok(text) if !text.trim().is_empty() => {
+                app_state.open_search_with_text(Some(text));
+            }
+            Ok(_) | Err(_) => {
+                app_state.open_search_with_text(None);
+            }
+        }
+    });
+}
+
+pub(super) fn search_pin_current(state: &mut AppState) {
+    let mut app_state = *state;
+    spawn_detached(async move {
+        #[derive(serde::Deserialize)]
+        struct QueryValue {
+            value: String,
+        }
+
+        let mut eval = document::eval(
+            r#"
+            (() => {
+                const input = document.querySelector('.search-input');
+                dioxus.send({ value: input?.value || '' });
+            })()
+            "#,
+        );
+        match eval.recv::<QueryValue>().await {
+            Ok(result) if !result.value.is_empty() => {
+                let _ = add_pinned_search(result.value);
+                app_state.update_search_results(0, 0);
+                let _ = document::eval(
+                    r#"
+                    (() => {
+                        const input = document.querySelector('.search-input');
+                        if (input) {
+                            input.value = '';
+                            input.focus();
+                        }
+                        window.Arto.search.clear();
+                    })()
+                    "#,
+                )
+                .await;
+            }
+            Ok(_) => {}
+            Err(e) => tracing::debug!("Search pin current failed: {e}"),
+        }
+    });
+}

--- a/crates/arto/src/state/app_state.rs
+++ b/crates/arto/src/state/app_state.rs
@@ -19,7 +19,7 @@ pub use document::{Document, DocumentContent};
 pub use focused_panel::*;
 pub use sidebar::{Face, Group, PanelRow, Sidebar, TreeRow};
 
-/// Information about a single search match for display in the Search tab.
+/// Information about a single search match.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SearchMatch {
     /// 0-based index of this match
@@ -64,10 +64,44 @@ pub struct AppState {
     /// Whether the content area ignores the markdown body's max-width and fills the pane.
     pub content_full_width: Signal<bool>,
     pub sidebar: Signal<Sidebar>,
-    /// The headings of the document on screen, for the contents beside it.
+    /// Headings of the document being read, drawn as the contents gutter
+    /// beside it.
     pub headings: Signal<Vec<HeadingInfo>>,
     pub position: Signal<LogicalPosition<i32>>,
     pub size: Signal<LogicalSize<u32>>,
+    /// Bumped whenever `config.json` changes.
+    ///
+    /// The configuration lives behind a plain lock rather than a signal, so
+    /// nothing subscribes to it. Anything derived from it reads this instead,
+    /// which is what makes a saved preference redraw the window that is
+    /// looking at it.
+    pub config_revision: Signal<u32>,
+    /// Whether the contents are held open.
+    ///
+    /// Resting in the gutter brings the same list out under the pointer; this
+    /// is the list asked for by name, which stays out until it is dismissed
+    /// and answers to the keyboard while it does. It is also the only way to
+    /// the headings at a width that folded the gutter away.
+    pub contents_open: Signal<bool>,
+    /// Which heading the keys are on while the contents are held open, as an
+    /// index into [`Self::headings`].
+    pub contents_cursor: Signal<Option<usize>>,
+    /// What is typed into the palette, and which row the keys act on.
+    ///
+    /// Here rather than inside the palette, because the keys that move through
+    /// it are bindings like any other: they are dispatched from outside the
+    /// component, so what they move has to be reachable from there. Reset when
+    /// the palette opens.
+    pub palette_query: Signal<String>,
+    pub palette_cursor: Signal<Option<usize>>,
+    /// How many rows the palette is showing, written by the palette each time
+    /// it draws. The keys need it to know where the list ends.
+    pub palette_rows: Signal<usize>,
+    /// Whether the palette is showing.
+    ///
+    /// It is the quickest window on the history — open, return, back to the
+    /// last document — so it is per-window state and never persisted.
+    pub palette_open: Signal<bool>,
     // Search state (not persisted, managed via JavaScript for IME compatibility)
     pub search_open: Signal<bool>,
     pub search_match_count: Signal<usize>,
@@ -77,11 +111,11 @@ pub struct AppState {
     /// Monotonic counter bumped on every open-search request, so the search
     /// input is (re)focused even when the bar is already open.
     pub search_focus_request: Signal<u64>,
-    /// Current search query string (for display in Search tab)
+    /// Current search query string
     pub search_query: Signal<Option<String>>,
-    /// All search matches with context (for Search tab display)
+    /// All search matches with context
     pub search_matches: Signal<Vec<SearchMatch>>,
-    /// Pinned search matches by ID (for Search tab display)
+    /// Pinned search matches by ID
     pub pinned_matches: Signal<HashMap<PinnedSearchId, Vec<SearchMatch>>>,
     /// Pending scroll position to restore after navigation (for back/forward).
     /// When Some, FileViewer will scroll to this position instead of resetting to top.
@@ -95,35 +129,18 @@ pub struct AppState {
     pub current_scroll_anchor: Signal<ScrollAnchor>,
     /// Reload trigger counter. Incrementing this forces FileViewer to re-read the file
     /// from disk without going through the use_memo PartialEq gate in content.rs.
-    /// Used by manual reload (header button, tab context menu) and file watcher.
+    /// Used by manual reload (header button, context menu) and file watcher.
     pub reload_trigger: Signal<usize>,
     /// Which panel currently has keyboard focus (for context-aware keybindings).
     pub focused_panel: Signal<FocusedPanel>,
-    /// Bumped when the configuration changes, because the configuration is
-    /// not a signal and nothing subscribes to it. Anything derived from it
-    /// reads this instead, which is what makes a saved preference redraw the
-    /// window that is looking at it.
-    pub config_revision: Signal<u32>,
-    /// Whether the command palette is open.
-    pub palette_open: Signal<bool>,
-    /// What is typed into the palette, and which row the keys act on.
+    /// Where the keyboard is in the panel: the row it is on, in whichever
+    /// face is showing.
     ///
-    /// Here rather than inside the palette, because the keys that move through
-    /// it are bindings like any other: they are dispatched from outside the
-    /// component, so what they move has to be reachable from there. Reset when
-    /// the palette opens.
-    pub palette_query: Signal<String>,
-    pub palette_cursor: Signal<Option<usize>>,
-    /// How many rows the palette is showing, written by the palette each time
-    /// it draws. The keys need it to know where the list ends.
-    pub palette_rows: Signal<usize>,
-    /// Bumped whenever this window records a visit, so its own lists redraw
-    /// without waiting for the broadcast to come back round.
-    pub visits_revision: Signal<u32>,
-    /// Which row of the panel the keyboard is on — see [`PanelRow`].
+    /// A row rather than a position, because the three faces are three lists
+    /// of the same thing — a document, or a folder — and a row survives the
+    /// list being rebuilt under it, which a position does not. See
+    /// [`PanelRow`] for why it is not simply a path.
     pub panel_cursor: Signal<Option<PanelRow>>,
-    /// Keyboard cursor position in the Quick Access list (index into bookmarks).
-    pub quick_access_cursor: Signal<Option<usize>>,
     /// Whether the left sidebar overlay is currently shown (hover/focus triggered).
     /// Transient UI state — not persisted.
     pub left_hover_active: Signal<bool>,
@@ -138,6 +155,14 @@ pub struct AppState {
     /// signal) so the hoisted context menu's "Reload" action can trigger a
     /// refresh from outside the tree subtree. Transient UI state — not persisted.
     pub sidebar_refresh_counter: Signal<u32>,
+    /// Bumped when this window records a visit.
+    ///
+    /// The history itself lives outside Dioxus (`crate::visits::VISITS`) and
+    /// announces itself over a broadcast, which every window hears — including
+    /// this one, one poll of the runtime later. The lists in *this* window
+    /// read this signal instead, so what the window did shows in the same
+    /// frame as the document it did it to.
+    pub visits_revision: Signal<u32>,
 }
 
 impl AppState {
@@ -154,6 +179,13 @@ impl AppState {
             position: Signal::new(Default::default()),
             size: Signal::new(Default::default()),
             // Search state
+            config_revision: Signal::new(0),
+            contents_open: Signal::new(false),
+            contents_cursor: Signal::new(None),
+            palette_query: Signal::new(String::new()),
+            palette_cursor: Signal::new(None),
+            palette_rows: Signal::new(0),
+            palette_open: Signal::new(false),
             search_open: Signal::new(false),
             search_match_count: Signal::new(0),
             search_current_index: Signal::new(0),
@@ -167,17 +199,11 @@ impl AppState {
             current_scroll_anchor: Signal::new(ScrollAnchor::TOP),
             reload_trigger: Signal::new(0),
             focused_panel: Signal::new(FocusedPanel::Content),
-            config_revision: Signal::new(0),
-            palette_open: Signal::new(false),
-            palette_query: Signal::new(String::new()),
-            palette_cursor: Signal::new(None),
-            palette_rows: Signal::new(0),
-            visits_revision: Signal::new(0),
             panel_cursor: Signal::new(None),
-            quick_access_cursor: Signal::new(None),
             left_hover_active: Signal::new(false),
             sidebar_context_menu: Signal::new(None),
             sidebar_refresh_counter: Signal::new(0),
+            visits_revision: Signal::new(0),
         }
     }
 }
@@ -189,21 +215,12 @@ impl Default for AppState {
 }
 
 impl AppState {
-    /// Move the window to the folder above the one it is in.
-    pub fn go_to_parent_directory(&mut self) {
-        let parent = self
-            .sidebar
-            .read()
-            .primary_root()
-            .and_then(|root| root.parent().map(|parent| parent.to_path_buf()));
-        if let Some(parent) = parent {
-            self.add_root(parent);
-        }
-    }
-
     /// Toggle full-width content mode, which lets the markdown body ignore its
     /// max-width and fill the entire content pane.
     pub fn toggle_content_full_width(&mut self) {
+        if self.document.read().is_empty() {
+            return;
+        }
         let was_full_width = *self.content_full_width.read();
         self.content_full_width.set(!was_full_width);
     }
@@ -230,6 +247,31 @@ impl AppState {
         self.zoom_level.set(normalize_content_zoom(current + delta));
     }
 
+    /// Hold the contents open, or let them go.
+    ///
+    /// The cursor starts nowhere: the list marks the heading being read on its
+    /// own, and a cursor placed on top of that mark before a key has been
+    /// pressed would only be a second mark saying the same thing.
+    pub fn toggle_contents(&mut self) {
+        if *self.contents_open.read() {
+            self.close_contents();
+        } else {
+            self.contents_open.set(true);
+            self.contents_cursor.set(None);
+        }
+    }
+
+    /// Let the palette go.
+    pub fn close_palette(&mut self) {
+        self.palette_open.set(false);
+    }
+
+    /// Let the contents go, and the keys in them with it.
+    pub fn close_contents(&mut self) {
+        self.contents_open.set(false);
+        self.contents_cursor.set(None);
+    }
+
     /// Toggle the palette.
     ///
     /// Every opening starts empty, with the cursor on the row "take me back"
@@ -244,19 +286,39 @@ impl AppState {
         self.palette_open.set(open);
     }
 
-    /// Let the palette go.
-    pub fn close_palette(&mut self) {
-        self.palette_open.set(false);
-    }
-
     /// Toggle the find field in the header
     ///
     /// Note: Does NOT clear search state when closing. Search highlights and
     /// results persist until the user explicitly clears them (via clear button)
     /// or the content changes. This enables the "persistent highlighting" feature.
     pub fn toggle_search(&mut self) {
+        if self.document.read().is_empty() {
+            return;
+        }
         let new_state = !*self.search_open.read();
         self.search_open.set(new_state);
+    }
+
+    /// End the search: the field goes, and the temporary highlights go with
+    /// it.
+    ///
+    /// What was pinned stays. It is not this search any more, it is a mark on
+    /// the document, and the contents beside the page is where it lives.
+    pub fn close_search(&mut self) {
+        self.search_open.set(false);
+    }
+
+    /// Put away everything that is over the document, and give the keyboard
+    /// back to the page.
+    ///
+    /// What Escape means, in one place: the engine used to spell this out as
+    /// a list of signals, which meant every overlay added since had to be
+    /// remembered there as well as where it lives.
+    pub fn dismiss_overlays(&mut self) {
+        self.focus_content();
+        self.close_palette();
+        self.close_contents();
+        self.close_search();
     }
 
     /// Update search results from JavaScript callback (basic count/current only)
@@ -281,7 +343,12 @@ impl AppState {
 
     /// Open the find field and populate it with the given text
     pub fn open_search_with_text(&mut self, text: Option<String>) {
-        // Set initial text for SearchBar to pick up
+        // Nothing to search: the welcome page is a list of documents, and the
+        // palette is what searches that.
+        if self.document.read().is_empty() {
+            return;
+        }
+        // What the field opens with — a selection, usually.
         self.search_initial_text.set(text);
         // Open the field
         self.search_open.set(true);


### PR DESCRIPTION
## Summary

- `search`, `palette` and `contents` become keyboard contexts with bindings of their own, in all three presets.
- Inside a field a bare key is text and a chord still reaches the window — one line in the engine.
- The dispatcher is split by what an action acts on.

## Why

Two things were hard-wired. A field swallowed its own keys — the search box knew what Return and Escape meant, and the palette had arrows written into it — so none of it could be rebound, and vim or emacs readers got whatever the field's author had typed. And the dispatcher had grown into one match arm per action in one file, with the tree's cursor, the clipboard, the search and the scrolling all in it.

A field is a keyboard context now, like the panel: `search`, `palette` and `contents` each have their own bindings, and each preset says what belongs in them — Tab walks the matches, Ctrl+n and Ctrl+p walk the palette in vim and emacs, Ctrl+g closes it for emacs. The rule that makes this safe is one line in the engine: inside a field, a *bare* key is what is being typed, so the global set (where a letter can mean "scroll") does not answer for it, while a chord with a modifier still does, and Cmd+W closes the window from inside a search.

The contents get the same treatment: held open by name they are a list, and a list answers to the keys the panel's lists do.

The dispatcher is split by what an action acts on — the panel, the palette, the search, the contents, the clipboard, and bringing something into view — and a cursor move scrolls with a couple of rows of room around it rather than the least the browser can get away with, so what is coming next is as much of an answer as where the cursor is.

## Test Plan

- [ ] The find field, the palette and the contents each answer to their own bindings, and the vim and emacs presets differ as documented
- [ ] A bare letter typed into a field is text; a chord still reaches the window
- [ ] `just fmt check test`

## Stack

These land in order; each is based on the one above it.

1. #265 — chore(dev): sign the bundle `dx serve` builds on macOS
2. #266 — feat(preferences): a window, not a tab
3. #267 — feat(window): one document to a window
4. #268 — feat(panel): several roots, and the folders you keep
5. #269 — feat(panel): one panel, three faces, and the history among them
6. #270 — feat(contents): the contents live beside the page
7. #271 — feat(header): the document's name is the way back, and one glyph opens the app
8. #272 — feat(search): find in the header, and the marks stay in the contents
9. #273 — feat(welcome): a window with nothing open says what there is to read
10. #274 — feat(layout): give way to the document
11. #275 — feat(keys): every list and every field answers to bindings 👈 **this one**
12. #276 — feat(recent): remember where a document was left, and open it there
13. #277 — feat(menu): give every menu row its icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01731Zfkg9P6V4Lm7buLEN53
