### PR TITLE
feat(recent): remember where a document was left, and open it there

### DIFF
--- a/crates/arto/src/components/app.rs
+++ b/crates/arto/src/components/app.rs
@@ -196,6 +196,12 @@ pub fn App(
         // Unregister this window's state from the global mapping
         crate::window::unregister_window_state(window_id);
 
+        // The other way a document is left: the history keeps the place so
+        // that opening it again opens where the reader was.
+        let mut state = state;
+        state.keep_reading_position();
+        crate::visits::save_visits();
+
         // Save last used state from this window to disk for next app launch
         let mut persisted = PersistedState::from(&state);
         let window_metrics = crate::window::metrics::capture_window_metrics(&window().window);

--- a/crates/arto/src/state/app_state/document/file_ops.rs
+++ b/crates/arto/src/state/app_state/document/file_ops.rs
@@ -5,11 +5,16 @@ use dioxus::prelude::*;
 use std::path::{Path, PathBuf};
 
 impl AppState {
-    /// Read a file in this window.
+    /// Read a file in this window, at the place it was left.
     ///
     /// Opening the document already on screen is not a move, so it does
-    /// nothing: the window would otherwise gain a history entry for standing
-    /// still.
+    /// nothing beyond noting the visit: the window would otherwise gain a
+    /// history entry for standing still.
+    ///
+    /// A document that has been read before opens where the reader had got
+    /// to. Coming back to a long document at the top of it is being made to
+    /// find your place again every time, and the history is already keeping
+    /// the answer.
     pub fn open_file(&mut self, file: impl AsRef<Path>) {
         // Folded here rather than at each store's own door, so that the
         // window and the lists beside it are all talking about the same
@@ -20,12 +25,16 @@ impl AppState {
         let file = file.as_path();
         self.reveal_in_roots(file);
         if self.current_file().as_deref() != Some(file) {
+            self.keep_reading_position();
+            let resume = crate::visits::position(file).filter(|anchor| !anchor.is_top());
+            self.pending_scroll_anchor.set(resume);
             self.update_document(|document| document.navigate_to(file));
         }
         // Recorded once the window is already showing it. Every window on the
-        // history reads it against the document on screen, so announcing the
-        // visit first would redraw them all around a document that is not the
-        // current one yet.
+        // history reads it against the document on screen — the trace leaves
+        // out what is being read, the palette starts on the one before it —
+        // so announcing the visit first would redraw them all around a
+        // document that is not the current one yet.
         self.record_visit(file);
     }
 
@@ -39,6 +48,19 @@ impl AppState {
     pub fn record_visit(&mut self, file: impl AsRef<Path>) {
         crate::visits::record_visit(file.as_ref());
         *self.visits_revision.write() += 1;
+    }
+
+    /// Hand the document on screen's place to the history, so that leaving it
+    /// is what saves it.
+    ///
+    /// The position is noted in memory as the page scrolls; this is where it
+    /// is put on the row it belongs to before the row stops being the current
+    /// one. The write to disk comes with the visit that follows.
+    pub fn keep_reading_position(&mut self) {
+        let Some(file) = self.current_file() else {
+            return;
+        };
+        crate::visits::keep_position(&file, *self.current_scroll_anchor.read());
     }
 
     /// Follow a link inside the document being read.

--- a/crates/arto/src/state/app_state/document/history.rs
+++ b/crates/arto/src/state/app_state/document/history.rs
@@ -15,6 +15,7 @@ impl AppState {
     pub fn save_scroll_and_go_back(&mut self) -> bool {
         let position = *self.current_scroll_anchor.read();
         self.save_current_scroll_anchor(position);
+        self.keep_reading_position();
         self.go_back_in_history()
     }
 
@@ -25,6 +26,7 @@ impl AppState {
     pub fn save_scroll_and_go_forward(&mut self) -> bool {
         let position = *self.current_scroll_anchor.read();
         self.save_current_scroll_anchor(position);
+        self.keep_reading_position();
         self.go_forward_in_history()
     }
 

--- a/crates/arto/src/visits.rs
+++ b/crates/arto/src/visits.rs
@@ -11,6 +11,7 @@
 //! the year. [`group`] is where that happens, and it is pure so the
 //! boundaries can be tested against a fixed clock.
 
+use crate::scroll_anchor::ScrollAnchor;
 use chrono::{DateTime, Datelike, Days, Local, NaiveDate, Weekday};
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
@@ -25,12 +26,20 @@ use tokio::sync::broadcast;
 /// where to find it again. Only the count is bounded, and generously.
 pub const MAX_VISITS: usize = 5_000;
 
-/// One document, and when it was last read.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// One document, when it was last read, and how far into it the reader had
+/// got.
+///
+/// The position is part of what "I have read this" means: a document opened
+/// again from the history opens where it was left, rather than at a top the
+/// reader has already been past. A history written before positions were kept
+/// has none, which reads as the top.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Visit {
     pub path: PathBuf,
     pub at: DateTime<Local>,
+    #[serde(default)]
+    pub anchor: ScrollAnchor,
 }
 
 impl Visit {
@@ -38,6 +47,7 @@ impl Visit {
         Self {
             path: path.into(),
             at,
+            anchor: ScrollAnchor::TOP,
         }
     }
 }
@@ -213,6 +223,25 @@ impl Visits {
         self.items.truncate(MAX_VISITS);
     }
 
+    /// Note how far into a document the reader has got.
+    ///
+    /// The order is left alone: this is not a visit, it is the same visit
+    /// still going on, and moving the row would make scrolling look like
+    /// reading something new.
+    pub fn keep_position(&mut self, path: &Path, anchor: ScrollAnchor) {
+        if let Some(visit) = self.items.iter_mut().find(|visit| visit.path == path) {
+            visit.anchor = anchor;
+        }
+    }
+
+    /// Where the reader had got to, if this document has been read before.
+    pub fn position(&self, path: &Path) -> Option<ScrollAnchor> {
+        self.items
+            .iter()
+            .find(|visit| visit.path == path)
+            .map(|visit| visit.anchor)
+    }
+
     /// Forget one document, for a reader who would rather it were not listed.
     pub fn forget(&mut self, path: &Path) {
         self.items.retain(|visit| visit.path != path);
@@ -282,6 +311,30 @@ pub static VISITS: LazyLock<RwLock<Visits>> = LazyLock::new(|| RwLock::new(Visit
 pub static VISITS_CHANGED: LazyLock<broadcast::Sender<()>> =
     LazyLock::new(|| broadcast::channel(16).0);
 
+/// Note where the reader has got to, in memory alone.
+///
+/// Called as a document is left rather than as it is scrolled: the window
+/// already holds the live position, so the history only needs it at the
+/// moment the row stops being the one being read. It goes to disk with the
+/// next save — the visit that follows, or the window closing.
+pub fn keep_position(path: &Path, anchor: ScrollAnchor) {
+    let path = crate::utils::paths::true_spelling(path);
+    VISITS.write().keep_position(&path, anchor);
+}
+
+/// Where the reader had got to in a document they have read before.
+pub fn position(path: &Path) -> Option<ScrollAnchor> {
+    let path = crate::utils::paths::true_spelling(path);
+    VISITS.read().position(&path)
+}
+
+/// Write the history out, positions and all.
+pub fn save_visits() {
+    if let Err(err) = VISITS.read().save() {
+        tracing::warn!(%err, "Failed to save visit history");
+    }
+}
+
 /// Record a visit, persist it, and tell the other windows.
 pub fn record_visit(path: impl Into<PathBuf>) {
     let mut visits = VISITS.write();
@@ -333,6 +386,46 @@ mod tests {
         assert_eq!(short_when(at(8, 30, 19, 44), now), "8/30");
     }
 
+    fn at(y: i32, m: u32, d: u32) -> DateTime<Local> {
+        Local.with_ymd_and_hms(y, m, d, 12, 0, 0).unwrap()
+    }
+
+    #[test]
+    fn a_kept_position_comes_back_and_leaves_the_order_alone() {
+        let mut visits = Visits::default();
+        visits.record("/docs/first.md", at(2026, 9, 8));
+        visits.record("/docs/second.md", at(2026, 9, 9));
+
+        let place = ScrollAnchor {
+            line: 42,
+            fraction: 0.25,
+        };
+        visits.keep_position(Path::new("/docs/first.md"), place);
+
+        assert_eq!(visits.position(Path::new("/docs/first.md")), Some(place));
+        // Reading on is not visiting again: the newest is still the newest.
+        assert_eq!(visits.items[0].path, PathBuf::from("/docs/second.md"));
+    }
+
+    #[test]
+    fn a_document_never_read_has_no_position() {
+        let mut visits = Visits::default();
+        visits.record("/docs/first.md", at(2026, 9, 8));
+        assert_eq!(visits.position(Path::new("/docs/other.md")), None);
+        // One that has been read but not scrolled starts at the top.
+        assert_eq!(
+            visits.position(Path::new("/docs/first.md")),
+            Some(ScrollAnchor::TOP)
+        );
+    }
+
+    #[test]
+    fn a_history_written_before_positions_existed_reads_as_the_top() {
+        let json = r#"{"items":[{"path":"/docs/first.md","at":"2026-09-08T12:00:00+09:00"}]}"#;
+        let visits: Visits = serde_json::from_str(json).expect("loads");
+        assert_eq!(visits.items[0].anchor, ScrollAnchor::TOP);
+    }
+
     fn day(y: i32, m: u32, d: u32) -> NaiveDate {
         NaiveDate::from_ymd_opt(y, m, d).unwrap()
     }
@@ -345,9 +438,7 @@ mod tests {
         day(TODAY.0, TODAY.1, TODAY.2)
     }
 
-    fn at(y: i32, m: u32, d: u32) -> DateTime<Local> {
-        Local.with_ymd_and_hms(y, m, d, 12, 0, 0).unwrap()
-    }
+    // === bucket_for(): the boundaries, from both sides ===
 
     #[test]
     fn today_and_yesterday_stand_alone() {


### PR DESCRIPTION
## Summary

- The history keeps how far into a document the reader got, and opening it again opens there.
- The position is taken as the document is left, not as the page scrolls.

## Why

Coming back to a long document at the top of it is being made to find your place again every time, and the history already knows the answer: it is the list of what has been read, so how far it was read is part of the same fact.

The position is taken as the document is left — another opened, the history walked, the window closed — rather than as the page scrolls: the window already holds the live position, and writing a file per frame to learn nothing new is not worth the disk. Reading on never moves a row, because scrolling is the same visit still going on. Following a link is left alone: a link says where to land.

## Test Plan

- [ ] Reopening a long document opens where it was left, including after a restart
- [ ] Scrolling does not move a row in the history
- [ ] Following a link lands where the link says
- [ ] `just fmt check test`

## Stack

These land in order; each is based on the one above it.

1. #265 — chore(dev): sign the bundle `dx serve` builds on macOS
2. #266 — feat(preferences): a window, not a tab
3. #267 — feat(window): one document to a window
4. #268 — feat(panel): several roots, and the folders you keep
5. #269 — feat(panel): one panel, three faces, and the history among them
6. #270 — feat(contents): the contents live beside the page
7. #271 — feat(header): the document's name is the way back, and one glyph opens the app
8. #272 — feat(search): find in the header, and the marks stay in the contents
9. #273 — feat(welcome): a window with nothing open says what there is to read
10. #274 — feat(layout): give way to the document
11. #275 — feat(keys): every list and every field answers to bindings
12. #276 — feat(recent): remember where a document was left, and open it there 👈 **this one**
13. #277 — feat(menu): give every menu row its icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01731Zfkg9P6V4Lm7buLEN53
