### PR TITLE
fix(trace): keep the margin trace out of the page it annotates

### DIFF
--- a/.claude/rules/ui-design.md
+++ b/.claude/rules/ui-design.md
@@ -135,6 +135,16 @@ table above is its test. `AppState::visible_chrome` collects the window's own
 numbers for it, measuring width *after zoom* because magnifying the page is
 the same as narrowing the window.
 
+The budget is a model, and one thing is placed against the layout it actually
+gets: the margin trace, which is drawn in the margin the page leaves over
+rather than in a column of its own. The width reserved for it is measured
+against the document's *minimum* width, while the page is set to its own width
+and centred in whatever is left — so magnifying the page, or widening the
+panel beside it, can close that margin while the budget still allows the
+trace. `frontend/src/reading-position.ts` measures what is left and the trace
+fades out when it can no longer stand clear of the text, which is the same
+rule the budget states, applied to the space that is really there.
+
 What comes back is state, never settings: widening the window restores the
 panel exactly as configured. The one thing width never overrides is a panel
 the reader folded with Cmd+B, because that was intent.

--- a/crates/arto/src/components/content.rs
+++ b/crates/arto/src/components/content.rs
@@ -46,6 +46,7 @@ pub fn Content() -> Element {
 
     // Set up scroll position tracking via JavaScript
     use_scroll_anchor_tracker(state);
+    use_measure_on_zoom(zoom_level);
 
     let headings = state.headings;
 
@@ -110,6 +111,20 @@ pub fn Content() -> Element {
         }
         }
     }
+}
+
+/// Ask the chrome set beside the page to measure itself again after a zoom.
+///
+/// The margin trace stands in the page's own margin, and that margin is what
+/// zoom takes: the column is magnified, the trace is not. Nothing in the page
+/// announces it — the window has not been resized, and the page's layout size
+/// is unchanged, only the scale it is drawn at — so the measurement is asked
+/// for from here, where the zoom is known. See `frontend/src/reading-position.ts`.
+fn use_measure_on_zoom(zoom_level: Signal<f64>) {
+    use_effect(move || {
+        let _ = zoom_level();
+        document::eval("window.Arto?.readingPosition?.refresh?.();");
+    });
 }
 
 /// Hook to track scroll position via JavaScript and update state.

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -114,6 +114,17 @@ declare global {
         getSourceLineRange: typeof contentCursor.getSourceLineRange;
         getCurrentElement: typeof contentCursor.getCurrentElement;
       };
+      readingPosition: {
+        /**
+         * Measure again where the reader is and what is set beside the page.
+         *
+         * A scroll and a taller document ask for this on their own. Zoom does
+         * not: it changes how wide the page is drawn without changing the
+         * window or the page's own layout size, so nothing observes it — and
+         * the margin trace is placed against a margin that has just moved.
+         */
+        refresh: typeof refreshReadingPosition;
+      };
       feedback: {
         show: typeof actionFeedback.show;
       };
@@ -384,6 +395,9 @@ export function init(): void {
       getLinkHref: contentCursor.getLinkHref,
       getSourceLineRange: contentCursor.getSourceLineRange,
       getCurrentElement: contentCursor.getCurrentElement,
+    },
+    readingPosition: {
+      refresh: refreshReadingPosition,
     },
     feedback: {
       show: actionFeedback.show,

--- a/frontend/src/reading-position.test.ts
+++ b/frontend/src/reading-position.test.ts
@@ -1,0 +1,29 @@
+import { describe, test, expect } from "vitest";
+
+import { TRACE_GAP, traceColumn } from "./reading-position";
+
+describe("traceColumn", () => {
+  test("moves the column up against the page, a gap short of the text", () => {
+    // A wide window: the page is centred far from the area's left edge, so
+    // the trace travels most of that distance to reach it.
+    expect(traceColumn(500, 138)).toEqual({ offset: 500 - 138 - TRACE_GAP, crowded: false });
+  });
+
+  test("stays where it is laid out when the page is exactly a gap away", () => {
+    expect(traceColumn(138 + TRACE_GAP, 138)).toEqual({ offset: 0, crowded: false });
+  });
+
+  test("rounds to whole pixels", () => {
+    expect(traceColumn(300.6, 138).offset).toEqual(Math.round(300.6 - 138 - TRACE_GAP));
+  });
+
+  test("gives way when the margin cannot hold it at that distance", () => {
+    // Magnifying the page widens the column while the trace keeps its size,
+    // so the margin closes from the document's side.
+    expect(traceColumn(138 + TRACE_GAP - 1, 138)).toEqual({ offset: 0, crowded: true });
+  });
+
+  test("gives way rather than being written over the text", () => {
+    expect(traceColumn(20, 138)).toEqual({ offset: 0, crowded: true });
+  });
+});

--- a/frontend/src/reading-position.ts
+++ b/frontend/src/reading-position.ts
@@ -34,7 +34,37 @@ const TRACE_OFFSET = "--trace-offset";
  * Kept here rather than as padding on the column, so that widening the gap
  * moves the whole column instead of eating the room its names are set in.
  */
-const TRACE_GAP = 56;
+export const TRACE_GAP = 56;
+
+/** The attribute that says the page has taken the margin the trace sits in. */
+const CROWDED = "data-trace-crowded";
+
+/**
+ * Where the trace's column goes, and whether there is a margin left for it.
+ *
+ * Both arguments are measured from the left edge of the reading area:
+ * `traceRight` is where the column ends where it is laid out, `bodyLeft`
+ * where the page begins. The column is moved right until it stands
+ * `TRACE_GAP` short of the page.
+ *
+ * The layout budget reserves the trace's width against the document's
+ * *minimum* width, but the page is set to its own width and centred in
+ * whatever is left of the window — so magnifying the page, or a wide panel
+ * beside it, closes the margin while the budget still allows the trace. When
+ * the margin can no longer hold the column at its distance from the text, the
+ * trace gives way, as it does to every other claim on the space; the
+ * alternative is a column of names written over the first inch of every line.
+ */
+export function traceColumn(
+  bodyLeft: number,
+  traceRight: number,
+): { offset: number; crowded: boolean } {
+  const room = bodyLeft - traceRight;
+  if (room < TRACE_GAP) {
+    return { offset: 0, crowded: true };
+  }
+  return { offset: Math.round(room - TRACE_GAP), crowded: false };
+}
 
 /** The attribute that marks the heading the reader is inside. */
 const CURRENT = "data-current";
@@ -157,20 +187,31 @@ function scroller(): HTMLElement | null {
  * with the middle of a document that no longer exists.
  */
 let measured: HTMLElement | null = null;
+
+/**
+ * The reading area the page is centred in.
+ *
+ * What the trace is placed against is the margin between the two, and the
+ * area is the side of it that the panel moves: widening a pinned panel takes
+ * the margin without touching the page, which keeps its own width and simply
+ * has less room to be centred in.
+ */
+let framed: HTMLElement | null = null;
 let growth: ResizeObserver | null = null;
 
-function watchBody(body: HTMLElement | null): void {
-  if (body === measured) {
-    return;
+/** Move the one observation kept in a slot from `current` to `next`. */
+function watch(current: HTMLElement | null, next: HTMLElement | null): HTMLElement | null {
+  if (current === next) {
+    return current;
   }
   growth ??= new ResizeObserver(() => refreshReadingPosition());
-  if (measured) {
-    growth.unobserve(measured);
+  if (current) {
+    growth.unobserve(current);
   }
-  measured = body;
-  if (body) {
-    growth.observe(body);
+  if (next) {
+    growth.observe(next);
   }
+  return next;
 }
 
 function update(): void {
@@ -188,7 +229,8 @@ function update(): void {
 
   const area = content.closest<HTMLElement>(".content-area");
   const body = content.querySelector<HTMLElement>(".markdown-body");
-  watchBody(body);
+  measured = watch(measured, body);
+  framed = watch(framed, content);
   if (area) {
     const document_ = body?.getBoundingClientRect().height ?? content.clientHeight;
     const window_ = content.clientHeight;
@@ -199,9 +241,14 @@ function update(): void {
     const trace = area.querySelector<HTMLElement>(".margin-trace");
     if (trace && body) {
       const traceRight = trace.offsetLeft + trace.offsetWidth;
+      // The page is measured where it is painted, because zoom is what closes
+      // the margin: the column is magnified with the document, the trace is
+      // not. `offsetLeft` reads the same space, the trace being outside the
+      // zoomed wrapper.
       const bodyLeft = body.getBoundingClientRect().left - area.getBoundingClientRect().left;
-      const offset = Math.max(0, Math.round(bodyLeft - traceRight - TRACE_GAP));
+      const { offset, crowded } = traceColumn(bodyLeft, traceRight);
       area.style.setProperty(TRACE_OFFSET, `${offset}px`);
+      area.toggleAttribute(CROWDED, crowded);
       // Until this has run once, the column is still at the window's edge
       // rather than beside the text; drawn there and then moved, it reads as
       // the page settling into place after the reader is already looking.

--- a/frontend/style/components/content/margin-trace.css
+++ b/frontend/style/components/content/margin-trace.css
@@ -67,6 +67,18 @@
   transition: none;
 }
 
+/* No margin left to be a note in. The width the layout budget reserves is
+   measured against the document's minimum, but the page is set to its own
+   width and centred in whatever is left of the window — so magnifying the
+   page closes the margin from the document's side while the budget still
+   allows the trace. `reading-position.ts` measures what is actually left and
+   says so here; the trace yields it, the way it yields to every other claim
+   on the space. */
+.content-area[data-trace-crowded] .margin-trace {
+  opacity: 0;
+  pointer-events: none;
+}
+
 /* Out of the way, and seen to go: it fades, rather than closing like a door.
    It can simply fade now that it holds no width of the page's — nothing moves
    when it goes. */


### PR DESCRIPTION
## Summary

- Measure the margin trace's place again when the zoom changes, and when the reading area is resized — not only when the page itself is.
- Fade the trace out when the page has taken the margin it stands in, instead of clamping its offset to zero and letting it land on the text.
- Cover the placement rule with unit tests (`traceColumn`) and note in `.claude/rules/ui-design.md` that the trace answers to the measured margin as well as to the layout budget.

## Why

Zooming in wrote the recent list over the first inch of every line. Two things let that happen.

The trace's place was never measured again after a zoom. A scroll, a document that grows and a resized window all ask for the measurement, but zoom asks for nothing: the window is the same size and the page keeps its layout width, only the scale it is drawn at changes, so neither the resize listener nor the `ResizeObserver` on the body fires. The column stayed where the unzoomed page had left room for it. The app knows when the zoom changed, so it now says so through `window.Arto.readingPosition.refresh`. The same measurement was stale when a pinned panel was widened, which takes the margin without touching the page, so the reading area is observed too.

And nothing put a floor under the offset. The layout budget reserves the trace's width against the document's *minimum* width (`sidebar.minContentWidth`, 640px by default), while the page is set to its own width (960px) and centred in whatever is left — so the margin closes well before the budget folds the trace, and magnifying the page closes it that much sooner. What is measured decides it now: with no room to stand clear of the text, the trace fades out, which is what it does for every other claim on the space.

## Test Plan

- [x] `just fmt check test`
- [x] `just docs`
- [ ] Open a document with a wide body, zoom in with Cmd+`+`: the trace fades out instead of landing on the text.
- [ ] Zoom back out: the trace returns to its place beside the page.
- [ ] Pin the panel and widen it: the trace keeps clear of the text, and goes when the margin closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014w3odYiLAnK59A7F1Ph43N

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/arto-app/codesmith/Arto/pr/278"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791561261&installation_model_id=435827&pr_number=278&repository=arto-app%2FArto&return_to=https%3A%2F%2Fgithub.com%2Farto-app%2FArto%2Fpull%2F278&signature=c30a2db2f3e4777e7f9b6c8eabc2444686f034f06d8439d518f63a1ba0b56551"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->