### PR TITLE
fix(pins): let a pinned row answer where it lights up

### DIFF
--- a/crates/arto/src/components/pinned_marks.rs
+++ b/crates/arto/src/components/pinned_marks.rs
@@ -47,36 +47,37 @@ fn PinnedMark(pinned: PinnedSearch) -> Element {
     let disabled = pinned.disabled;
 
     rsx! {
+        // The popover hangs off this rather than off the row, so that a click
+        // inside it is not also a click on the row that opened it.
         div {
-            class: "contents-toc-row contents-toc-pin",
-            class: if disabled { "disabled" },
+            class: "contents-toc-pin-slot",
 
-            // The colour is the control: pressing it opens what can be done
-            // to the mark, which is mostly a choice of colour.
-            button {
-                class: "contents-toc-pin-dot {color.css_class()}",
+            // The row is the control, all of it: it lights up under the
+            // pointer as one thing, so it has to answer as one thing.
+            div {
+                class: "contents-toc-row contents-toc-pin",
+                class: if disabled { "disabled" },
                 title: "Colour, visibility, remove",
-                onclick: move |evt| {
-                    evt.stop_propagation();
-                    show_popover.toggle();
-                },
-            }
+                onclick: move |_| show_popover.toggle(),
 
-            span { class: "contents-toc-name", "{pattern}" }
+                // Except the colour, which is the mark showing or not showing
+                // on the page — the one thing here that is worth a click of
+                // its own, and the thing the dot already says.
+                button {
+                    class: "contents-toc-pin-dot {color.css_class()}",
+                    title: if disabled { "Show" } else { "Hide" },
+                    onclick: {
+                        let id = id.clone();
+                        move |evt: Event<MouseData>| {
+                            evt.stop_propagation();
+                            toggle_pinned_search_disabled(&id);
+                        }
+                    },
+                }
 
-            span { class: "contents-toc-pin-count", "{count}" }
+                span { class: "contents-toc-name", "{pattern}" }
 
-            button {
-                class: "contents-toc-pin-remove",
-                title: "Remove",
-                onclick: {
-                    let id = id.clone();
-                    move |evt: Event<MouseData>| {
-                        evt.stop_propagation();
-                        remove_pinned_search(&id);
-                    }
-                },
-                Icon { name: IconName::Close, size: 12 }
+                span { class: "contents-toc-pin-count", "{count}" }
             }
 
             if *show_popover.read() {

--- a/frontend/style/components/contents-gutter.css
+++ b/frontend/style/components/contents-gutter.css
@@ -285,7 +285,9 @@
   background: var(--border-color);
 }
 
-.contents-toc-pin {
+/* What the popover is placed against. The row cannot be it: a popover inside
+   the row is inside the thing that opens it. */
+.contents-toc-pin-slot {
   position: relative;
 }
 
@@ -294,8 +296,8 @@
   opacity: var(--opacity-secondary);
 }
 
-/* The colour is the control: what can be done to a mark is mostly a choice of
-   which colour it is. */
+/* The colour says whether the mark is on the page, and pressing it is what
+   takes it off: an outline is the mark named but not shown. */
 .contents-toc-pin-dot {
   flex-shrink: 0;
   width: 10px;
@@ -307,11 +309,24 @@
   /* The mark's own colour, at the strength it has on the page: the dot and
      the words it highlights are the same mark, so they are the same colour. */
   background: var(--pin-colour, var(--border-color));
-  transition: box-shadow var(--transition-quiet) ease;
+  transition:
+    background-color var(--transition-quiet) ease,
+    box-shadow var(--transition-quiet) ease;
+}
+
+.contents-toc-pin.disabled .contents-toc-pin-dot {
+  background: transparent;
+  box-shadow: inset 0 0 0 1px var(--pin-colour, var(--border-color));
 }
 
 .contents-toc-pin-dot:hover {
   box-shadow: 0 0 0 2px var(--bg-row-hover);
+}
+
+.contents-toc-pin.disabled .contents-toc-pin-dot:hover {
+  box-shadow:
+    inset 0 0 0 1px var(--pin-colour, var(--border-color)),
+    0 0 0 2px var(--bg-row-hover);
 }
 
 .contents-toc-pin-dot.highlight-green {
@@ -338,29 +353,6 @@
   font-size: var(--font-size-sm);
   font-variant-numeric: tabular-nums;
   color: var(--text-secondary);
-}
-
-/* Drawn at rest, not on hover: taking a mark off is the one thing a reader
-   comes to this list to do, and a control that appears under the pointer is
-   one that has to be looked for first. */
-.contents-toc-pin-remove {
-  flex: none;
-  display: flex;
-  padding: 0;
-  border: none;
-  background: transparent;
-  color: var(--text-color);
-  cursor: pointer;
-  opacity: var(--opacity-rest);
-  transition: opacity var(--transition-quiet) ease;
-}
-
-.contents-toc-pin:hover .contents-toc-pin-remove {
-  opacity: var(--opacity-secondary);
-}
-
-.contents-toc-pin-remove:hover {
-  opacity: 1;
 }
 
 /* With no headings there is no ruler to rest on, so the marks put one mark in


### PR DESCRIPTION
## Summary

- The whole pinned row opens the mark's settings, not just the colour dot — the row already lights up as one thing under the pointer.
- The colour dot now toggles whether the mark shows on the page, and a hidden mark is drawn as an outline instead of a fill.
- The cross is gone: a mark is taken away from the popover, which is a press and a choice rather than a single click at rest in every row.

## Why

The row highlighted as one control and answered as three. Clicking the word, the count, or anywhere in the highlighted band did nothing; only the 10px dot opened the settings, so the affordance the hover promised was not the one the row honoured.

Making the row the control leaves the dot free for the thing it already says: the colour is the mark as it appears on the page, so pressing it is the natural way to take it off, and an outline says "named, but not shown" beside the line-through the name already carries. Visibility is still in the popover too.

The cross was the one control drawn at rest in every row, sitting a couple of pixels from the count and the word, and it removed a mark without asking. The popover already removes, and reaching it now takes a press and a choice.

The popover is placed against a slot around the row rather than against the row itself: inside the row, every click in the popover was also a click on the control that opened it, which would have toggled it straight back.

## Test Plan

- [x] `just fmt check test`
- [ ] Pin a search, open the contents: clicking anywhere on the row opens the settings popover.
- [ ] Clicking the colour dot hides the mark on the page and leaves the dot as an outline; clicking it again brings the mark back.
- [ ] Choosing a colour, toggling visibility, or removing from the popover closes it and does not re-open it.
- [ ] The row no longer carries a cross, and removal from the popover still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014w3odYiLAnK59A7F1Ph43N

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/arto-app/codesmith/Arto/pr/279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791561881&installation_model_id=435827&pr_number=279&repository=arto-app%2FArto&return_to=https%3A%2F%2Fgithub.com%2Farto-app%2FArto%2Fpull%2F279&signature=520e84f517288f1335d8921e34349ab0eee960205c50a0a3b400e728d2a4447e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->