### PR TITLE
feat(contents): stand the ruler in the page's own margin

### DIFF
--- a/.claude/rules/ui-design.md
+++ b/.claude/rules/ui-design.md
@@ -125,9 +125,9 @@ page. Things give way from the outside in:
 
 | Order | What folds | Threshold | Default |
 | --- | --- | --- | --- |
-| 1 | Margin trace (138px) | min + rail + panel + trace + gutter | below 1068px |
-| 2 | Panel (its current width) | min + rail + panel + gutter | below 930px |
-| 3 | Contents gutter (24px) | min + rail + gutter | below 704px |
+| 1 | Margin trace (138px) | min + rail + panel + trace + gutter | below 1076px |
+| 2 | Panel (its current width) | min + rail + panel + gutter | below 938px |
+| 3 | Contents gutter (32px) | min + rail + gutter | below 712px |
 | 4 | Rail (40px) | min + rail | below 680px |
 
 `crate::hooks::layout_budget::budget` is the whole rule, and it is pure — the

--- a/crates/arto/src/components/content.rs
+++ b/crates/arto/src/components/content.rs
@@ -99,9 +99,17 @@ pub fn Content() -> Element {
             }
         }
 
+        // The scrollbar as the reader sees it, over the native one that
+        // catches the clicks. See `frontend/src/scroll-indicator.ts`.
+        div {
+            class: "scroll-indicator",
+            "aria-hidden": "true",
+            div { class: "scroll-indicator-thumb" }
+        }
+
         // The contents live beside the document rather than in a panel of
-        // their own: always there, 24px wide, and impossible to open by
-        // accident because there is nothing to open.
+        // their own: always there, in the page's own right margin, and
+        // impossible to open by accident because there is nothing to open.
         //
         // Held open by name, the same list stays out without the ruler — which
         // is what makes `contents.toggle` reach the headings at a width that

--- a/crates/arto/src/components/content/gutter.rs
+++ b/crates/arto/src/components/content/gutter.rs
@@ -12,9 +12,11 @@ use crate::state::AppState;
 /// those ticks stand for, for as long as the pointer is in the column.
 ///
 /// A panel of headings was a second thing to open, close and mis-open; a ruler
-/// down the edge of the text is always there and costs 24px. Depth is the
-/// tick's length, so the shape of the document is legible without a word being
-/// read, and the current tick is the dense one.
+/// down the edge of the text is always there, and what it costs the page is a
+/// column of margin (`layout_budget::GUTTER_WIDTH`, plus the distance it
+/// stands off the text). Depth is the tick's length, so the shape of the
+/// document is legible without a word being read, and the current tick is the
+/// thick one.
 ///
 /// Resting in the column brings the names out over the document. It is the
 /// rail's rule applied to the other edge: the strip is visible, it exists to
@@ -23,8 +25,11 @@ use crate::state::AppState;
 /// while it is out — they are what a pinned search will colour, and a list
 /// that replaced them would take those marks away with it.
 ///
-/// It sits inside the document's own area rather than at the window's edge,
-/// which is why it cannot be opened by accident: there is nothing to open.
+/// It stands in the page's own right margin, opposite the margin trace and
+/// the same distance from the text, rather than at the window's edge — a map
+/// of the document belongs beside the document. That is also why it cannot be
+/// opened by accident: it is nowhere the pointer crosses on its way anywhere,
+/// and there is nothing to open.
 ///
 /// The marks a search pinned are listed here too, above the headings. Their
 /// colour is already on these ticks; listing them anywhere else would put the
@@ -83,6 +88,13 @@ fn Ruler(headings: Vec<HeadingInfo>) -> Element {
             class: "contents-gutter",
             "aria-hidden": "true",
 
+            // The ticks, in a box of their own. The column is as tall as the
+            // page so that they sit level with its middle, and this is what
+            // the pointer can rest in: crossing the empty part of a column is
+            // crossing a margin, not reaching for the contents.
+            div {
+                class: "contents-gutter-run",
+
             // With no headings there are no ticks, and a column with nothing
             // in it cannot be rested on. The marks put one thing in it.
             if headings.is_empty() {
@@ -116,6 +128,7 @@ fn Ruler(headings: Vec<HeadingInfo>) -> Element {
                         }
                     }
                 }
+            }
             }
         }
     }

--- a/crates/arto/src/hooks/layout_budget.rs
+++ b/crates/arto/src/hooks/layout_budget.rs
@@ -21,7 +21,7 @@
 pub const RAIL_WIDTH: f64 = 40.0;
 
 /// The contents gutter's width.
-pub const GUTTER_WIDTH: f64 = 24.0;
+pub const GUTTER_WIDTH: f64 = 32.0;
 
 /// The margin trace's width.
 pub const TRACE_WIDTH: f64 = 138.0;
@@ -82,27 +82,27 @@ mod tests {
     }
 
     // The specification's table, from both sides of every threshold:
-    // 1068 / 930 / 704 / 680 for a 640px document.
+    // 1076 / 938 / 712 / 680 for a 640px document.
 
     #[test]
     fn the_trace_goes_first() {
-        assert!(at(1068.0, 640.0).trace);
-        assert!(!at(1067.0, 640.0).trace);
-        assert!(at(1067.0, 640.0).panel);
+        assert!(at(1076.0, 640.0).trace);
+        assert!(!at(1075.0, 640.0).trace);
+        assert!(at(1075.0, 640.0).panel);
     }
 
     #[test]
     fn then_the_panel() {
-        assert!(at(930.0, 640.0).panel);
-        assert!(!at(929.0, 640.0).panel);
-        assert!(at(929.0, 640.0).gutter);
+        assert!(at(938.0, 640.0).panel);
+        assert!(!at(937.0, 640.0).panel);
+        assert!(at(937.0, 640.0).gutter);
     }
 
     #[test]
     fn then_the_gutter() {
-        assert!(at(704.0, 640.0).gutter);
-        assert!(!at(703.0, 640.0).gutter);
-        assert!(at(703.0, 640.0).rail);
+        assert!(at(712.0, 640.0).gutter);
+        assert!(!at(711.0, 640.0).gutter);
+        assert!(at(711.0, 640.0).rail);
     }
 
     #[test]
@@ -125,16 +125,16 @@ mod tests {
         );
     }
 
-    // The same table with the setting raised: 1228 / 1090 / 864 / 840.
+    // The same table with the setting raised: 1236 / 1098 / 872 / 840.
 
     #[test]
     fn a_wider_document_folds_things_sooner() {
-        assert!(at(1228.0, 800.0).trace);
-        assert!(!at(1227.0, 800.0).trace);
-        assert!(at(1090.0, 800.0).panel);
-        assert!(!at(1089.0, 800.0).panel);
-        assert!(at(864.0, 800.0).gutter);
-        assert!(!at(863.0, 800.0).gutter);
+        assert!(at(1236.0, 800.0).trace);
+        assert!(!at(1235.0, 800.0).trace);
+        assert!(at(1098.0, 800.0).panel);
+        assert!(!at(1097.0, 800.0).panel);
+        assert!(at(872.0, 800.0).gutter);
+        assert!(!at(871.0, 800.0).gutter);
         assert!(at(840.0, 800.0).rail);
         assert!(!at(839.0, 800.0).rail);
     }
@@ -143,9 +143,9 @@ mod tests {
     fn a_wider_panel_folds_at_a_wider_window() {
         // The panel's own width is part of its threshold, so dragging it
         // wider moves the point at which it gives way.
-        assert!(budget(930.0, 640.0, 226.0).panel);
-        assert!(!budget(930.0, 640.0, 280.0).panel);
-        assert!(budget(984.0, 640.0, 280.0).panel);
+        assert!(budget(938.0, 640.0, 226.0).panel);
+        assert!(!budget(938.0, 640.0, 280.0).panel);
+        assert!(budget(992.0, 640.0, 280.0).panel);
     }
 
     #[test]

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -3,6 +3,7 @@ import "../style/main.css";
 import { applyPictureTheme } from "./picture-theme";
 import { refreshReadingPosition, setupReadingPosition } from "./reading-position";
 import { setupRowHover } from "./row-hover";
+import { setupScrollbarReach } from "./scrollbar-reach";
 import { type Theme, currentTheme, isDarkTheme, themedElement } from "./theme";
 import * as mermaidRenderer from "./mermaid-renderer";
 import { renderCoordinator } from "./render-coordinator";
@@ -230,6 +231,9 @@ export function init(): void {
   // The full name of a row the panel had to cut, floating clear of the box
   // that scrolls it.
   setupRowHover();
+  // The scrollbar, brought up to a native width by the pointer arriving at
+  // the edge it is on.
+  setupScrollbarReach();
   const trackAfterRender = (): void => {
     refreshReadingPosition();
     renderCoordinator.onRenderComplete(trackAfterRender);

--- a/frontend/src/reading-position.test.ts
+++ b/frontend/src/reading-position.test.ts
@@ -1,29 +1,29 @@
 import { describe, test, expect } from "vitest";
 
-import { TRACE_GAP, traceColumn } from "./reading-position";
+import { MARGIN_GAP, marginColumn } from "./reading-position";
 
-describe("traceColumn", () => {
+describe("marginColumn", () => {
   test("moves the column up against the page, a gap short of the text", () => {
-    // A wide window: the page is centred far from the area's left edge, so
-    // the trace travels most of that distance to reach it.
-    expect(traceColumn(500, 138)).toEqual({ offset: 500 - 138 - TRACE_GAP, crowded: false });
+    // A wide window: the page is centred far from the edge the column is laid
+    // out at, so the column travels most of that distance to reach it.
+    expect(marginColumn(500)).toEqual({ offset: 500 - MARGIN_GAP, crowded: false });
   });
 
   test("stays where it is laid out when the page is exactly a gap away", () => {
-    expect(traceColumn(138 + TRACE_GAP, 138)).toEqual({ offset: 0, crowded: false });
+    expect(marginColumn(MARGIN_GAP)).toEqual({ offset: 0, crowded: false });
   });
 
   test("rounds to whole pixels", () => {
-    expect(traceColumn(300.6, 138).offset).toEqual(Math.round(300.6 - 138 - TRACE_GAP));
+    expect(marginColumn(300.6).offset).toEqual(Math.round(300.6 - MARGIN_GAP));
   });
 
   test("gives way when the margin cannot hold it at that distance", () => {
-    // Magnifying the page widens the column while the trace keeps its size,
-    // so the margin closes from the document's side.
-    expect(traceColumn(138 + TRACE_GAP - 1, 138)).toEqual({ offset: 0, crowded: true });
+    // Magnifying the page widens the column while the margin's occupant keeps
+    // its size, so the margin closes from the document's side.
+    expect(marginColumn(MARGIN_GAP - 1)).toEqual({ offset: 0, crowded: true });
   });
 
   test("gives way rather than being written over the text", () => {
-    expect(traceColumn(20, 138)).toEqual({ offset: 0, crowded: true });
+    expect(marginColumn(-118)).toEqual({ offset: 0, crowded: true });
   });
 });

--- a/frontend/src/reading-position.ts
+++ b/frontend/src/reading-position.ts
@@ -5,17 +5,20 @@
  *
  * All of it is the same question asked in different words — where in this
  * document are we, and what is around us — so it shares one passive scroll
- * listener and one frame's worth of work.
+ * listener and one frame's worth of work. The scrollbar the reader sees is
+ * the same question again, so it is drawn from here too.
  */
 
+import { drawScrollIndicator } from "./scroll-indicator";
+
 /**
- * How much of the column the margin trace has to centre itself against.
+ * How much of the column a marginal one has to centre itself against.
  *
- * The trace is set level with the middle of what is being read, and what is
- * being read is the document — until the document is taller than the window,
- * when it is the window. So: the smaller of the two.
+ * Both are set level with the middle of what is being read, and what is being
+ * read is the document — until the document is taller than the window, when
+ * it is the window. So: the smaller of the two.
  */
-const TRACE_EXTENT = "--trace-extent";
+const MARGIN_EXTENT = "--margin-extent";
 
 /**
  * How far the margin trace has to move to reach the document.
@@ -29,41 +32,53 @@ const TRACE_EXTENT = "--trace-extent";
 const TRACE_OFFSET = "--trace-offset";
 
 /**
- * How much air is left between the trace and the text it annotates.
+ * How far the contents ruler has to move to reach the document.
+ *
+ * The same errand as [`TRACE_OFFSET`], on the other side: the ruler is laid
+ * out at the right edge of the reading area and moved left into the page's
+ * own margin, so that the two columns stand the same distance from the text
+ * they are about.
+ */
+const GUTTER_OFFSET = "--gutter-offset";
+
+/**
+ * How much air is left between a marginal column and the text it is about.
  *
  * Kept here rather than as padding on the column, so that widening the gap
  * moves the whole column instead of eating the room its names are set in.
  */
-export const TRACE_GAP = 56;
+export const MARGIN_GAP = 56;
 
 /** The attribute that says the page has taken the margin the trace sits in. */
-const CROWDED = "data-trace-crowded";
+const TRACE_CROWDED = "data-trace-crowded";
+
+/** The same, for the margin the contents ruler sits in. */
+const GUTTER_CROWDED = "data-gutter-crowded";
+
+/** The attribute that says the page is keeping the ruler's column back. */
+const RULER = "data-ruler";
 
 /**
- * Where the trace's column goes, and whether there is a margin left for it.
+ * Where a column set in the page's margin goes, and whether there is a margin
+ * left to put it in.
  *
- * Both arguments are measured from the left edge of the reading area:
- * `traceRight` is where the column ends where it is laid out, `bodyLeft`
- * where the page begins. The column is moved right until it stands
- * `TRACE_GAP` short of the page.
+ * `room` is the distance between the column where it is laid out — at one
+ * edge of the reading area — and the page. The column is moved that far,
+ * less the gap it keeps from the text.
  *
- * The layout budget reserves the trace's width against the document's
+ * The layout budget reserves each column's width against the document's
  * *minimum* width, but the page is set to its own width and centred in
  * whatever is left of the window — so magnifying the page, or a wide panel
- * beside it, closes the margin while the budget still allows the trace. When
- * the margin can no longer hold the column at its distance from the text, the
- * trace gives way, as it does to every other claim on the space; the
- * alternative is a column of names written over the first inch of every line.
+ * beside it, closes the margin while the budget still allows the column. When
+ * the margin can no longer hold it at its distance from the text, the column
+ * gives way, as it does to every other claim on the space; the alternative is
+ * a column written over the first inch of every line.
  */
-export function traceColumn(
-  bodyLeft: number,
-  traceRight: number,
-): { offset: number; crowded: boolean } {
-  const room = bodyLeft - traceRight;
-  if (room < TRACE_GAP) {
+export function marginColumn(room: number): { offset: number; crowded: boolean } {
+  if (room < MARGIN_GAP) {
     return { offset: 0, crowded: true };
   }
-  return { offset: Math.round(room - TRACE_GAP), crowded: false };
+  return { offset: Math.round(room - MARGIN_GAP), crowded: false };
 }
 
 /** The attribute that marks the heading the reader is inside. */
@@ -227,6 +242,11 @@ function update(): void {
     listening = content;
   }
 
+  const indicator = document.querySelector<HTMLElement>(".scroll-indicator");
+  if (indicator) {
+    drawScrollIndicator(indicator, content);
+  }
+
   const area = content.closest<HTMLElement>(".content-area");
   const body = content.querySelector<HTMLElement>(".markdown-body");
   measured = watch(measured, body);
@@ -234,25 +254,52 @@ function update(): void {
   if (area) {
     const document_ = body?.getBoundingClientRect().height ?? content.clientHeight;
     const window_ = content.clientHeight;
-    area.style.setProperty(TRACE_EXTENT, `${Math.round(Math.min(document_, window_))}px`);
+    area.style.setProperty(MARGIN_EXTENT, `${Math.round(Math.min(document_, window_))}px`);
 
-    // Layout coordinates for the trace, so that the offset already applied to
-    // it does not feed back into the next measurement.
+    // Layout coordinates for the columns, so that the offset already applied
+    // to one does not feed back into the next measurement. The page is
+    // measured where it is painted, because zoom is what closes these
+    // margins: the page is magnified, the columns beside it are not.
+    // `offsetLeft` reads the same space, both columns being outside the
+    // zoomed wrapper.
+    const page = body?.getBoundingClientRect();
+    const areaLeft = area.getBoundingClientRect().left;
+
     const trace = area.querySelector<HTMLElement>(".margin-trace");
-    if (trace && body) {
+    if (trace && page) {
       const traceRight = trace.offsetLeft + trace.offsetWidth;
-      // The page is measured where it is painted, because zoom is what closes
-      // the margin: the column is magnified with the document, the trace is
-      // not. `offsetLeft` reads the same space, the trace being outside the
-      // zoomed wrapper.
-      const bodyLeft = body.getBoundingClientRect().left - area.getBoundingClientRect().left;
-      const { offset, crowded } = traceColumn(bodyLeft, traceRight);
+      const { offset, crowded } = marginColumn(page.left - areaLeft - traceRight);
       area.style.setProperty(TRACE_OFFSET, `${offset}px`);
-      area.toggleAttribute(CROWDED, crowded);
+      area.toggleAttribute(TRACE_CROWDED, crowded);
       // Until this has run once, the column is still at the window's edge
       // rather than beside the text; drawn there and then moved, it reads as
       // the page settling into place after the reader is already looking.
       area.dataset.traceReady = "";
+    }
+
+    // The ruler's own margin, which is the trace's read from the other side:
+    // it is laid out against the right edge and travels left. Measured
+    // against the area and the column's width rather than against where the
+    // column currently is, because that is what the offset moves: reading it
+    // back would make each measurement an answer to the last one.
+    const gutter = area.querySelector<HTMLElement>(".contents-gutter");
+    // Whether the page keeps the ruler's column back. Answered by looking for
+    // the ruler rather than by asking whether the width allows one: a
+    // document with no headings and nothing pinned has no map to draw, and
+    // the page would have given up the column to nothing.
+    area.toggleAttribute(RULER, gutter !== null);
+    if (gutter && page) {
+      const shelf = area.clientWidth - gutter.offsetWidth;
+      const { offset, crowded } = marginColumn(shelf - (page.right - areaLeft));
+      area.style.setProperty(GUTTER_OFFSET, `${offset}px`);
+      area.toggleAttribute(GUTTER_CROWDED, crowded);
+      area.dataset.gutterReady = "";
+    } else {
+      // What the ruler left behind, when the width folds it away or the
+      // document has no headings: the contents are still opened by name, and
+      // they are placed against the column that is no longer there.
+      area.style.setProperty(GUTTER_OFFSET, "0px");
+      area.toggleAttribute(GUTTER_CROWDED, false);
     }
   }
 

--- a/frontend/src/scroll-indicator.test.ts
+++ b/frontend/src/scroll-indicator.test.ts
@@ -1,0 +1,29 @@
+import { describe, test, expect } from "vitest";
+
+import { MIN_THUMB, thumbFor } from "./scroll-indicator";
+
+describe("thumbFor", () => {
+  test("a page that fits has no bar", () => {
+    expect(thumbFor(0, 800, 800, 800)).toBeNull();
+    expect(thumbFor(0, 800, 400, 800)).toBeNull();
+  });
+
+  test("the thumb is the share of the page that is on screen", () => {
+    expect(thumbFor(0, 800, 1600, 800)).toEqual({ top: 0, height: 400 });
+  });
+
+  test("it travels the track as the page is read", () => {
+    expect(thumbFor(800, 800, 1600, 800)).toEqual({ top: 400, height: 400 });
+    expect(thumbFor(400, 800, 1600, 800)).toEqual({ top: 200, height: 400 });
+  });
+
+  test("a long page still gets a thumb to hold", () => {
+    const thumb = thumbFor(0, 800, 200_000, 800);
+    expect(thumb?.height).toEqual(MIN_THUMB);
+  });
+
+  test("overscroll does not push it off the track", () => {
+    expect(thumbFor(10_000, 800, 1600, 800)).toEqual({ top: 400, height: 400 });
+    expect(thumbFor(-40, 800, 1600, 800)).toEqual({ top: 0, height: 400 });
+  });
+});

--- a/frontend/src/scroll-indicator.ts
+++ b/frontend/src/scroll-indicator.ts
@@ -1,0 +1,67 @@
+/**
+ * The bar that says how far down the page the reader is.
+ *
+ * The native scrollbar is still the one being used — it keeps its full width
+ * and catches every click and drag — but it is not the one being seen: a
+ * scrollbar pseudo-element is painted by the engine's own scrollbar theme,
+ * which repaints when it feels like it, so a width told to change as the
+ * pointer approaches changed once and stayed changed. This is the same bar
+ * drawn as an ordinary element, over the invisible one, where a transition is
+ * a transition.
+ */
+
+/**
+ * The shortest the thumb is drawn.
+ *
+ * On a long document the proportion would put it below a few pixels, which
+ * stops reading as a thumb and starts reading as a speck.
+ */
+export const MIN_THUMB = 28;
+
+/** Where the thumb goes on the track, and how tall it is. */
+export interface Thumb {
+  top: number;
+  height: number;
+}
+
+/**
+ * The thumb for a scroller, or `null` when there is nothing to scroll.
+ *
+ * `viewport` is what is on screen, `content` the whole of the page, and
+ * `track` the height the thumb runs down — the same as the viewport, unless
+ * something is inset from it.
+ */
+export function thumbFor(
+  scrollTop: number,
+  viewport: number,
+  content: number,
+  track: number,
+): Thumb | null {
+  if (content <= viewport || track <= 0) {
+    return null;
+  }
+  const height = Math.min(track, Math.max(MIN_THUMB, Math.round((viewport / content) * track)));
+  const travelled = Math.min(1, Math.max(0, scrollTop / (content - viewport)));
+  return { top: Math.round((track - height) * travelled), height };
+}
+
+/**
+ * Draw the bar for `scroller` on `indicator`.
+ *
+ * Called from the one place that already measures the reading position, so a
+ * scroll costs one frame's work for everything that answers to it.
+ */
+export function drawScrollIndicator(indicator: HTMLElement, scroller: HTMLElement): void {
+  const track = scroller.clientHeight;
+  const thumb = thumbFor(scroller.scrollTop, track, scroller.scrollHeight, track);
+  const bar = indicator.firstElementChild;
+  if (!(bar instanceof HTMLElement)) {
+    return;
+  }
+  indicator.hidden = thumb === null;
+  if (!thumb) {
+    return;
+  }
+  bar.style.height = `${thumb.height}px`;
+  bar.style.transform = `translateY(${thumb.top}px)`;
+}

--- a/frontend/src/scrollbar-reach.test.ts
+++ b/frontend/src/scrollbar-reach.test.ts
@@ -1,0 +1,30 @@
+import { describe, test, expect } from "vitest";
+
+import { REACH, reaching } from "./scrollbar-reach";
+
+/** The reading area, as `getBoundingClientRect` reports it. */
+const box = { top: 40, bottom: 800, left: 0, right: 1200 } as DOMRect;
+
+describe("reaching", () => {
+  test("a pointer on the bar is reaching for it", () => {
+    expect(reaching(1200, 400, box)).toBe(true);
+  });
+
+  test("a pointer within reach of the edge is reaching for it", () => {
+    expect(reaching(1200 - REACH, 400, box)).toBe(true);
+  });
+
+  test("a pointer out in the page is not", () => {
+    expect(reaching(1200 - REACH - 1, 400, box)).toBe(false);
+    expect(reaching(400, 400, box)).toBe(false);
+  });
+
+  test("a pointer above or below the reading area is not, however near the edge", () => {
+    expect(reaching(1190, 20, box)).toBe(false);
+    expect(reaching(1190, 900, box)).toBe(false);
+  });
+
+  test("nor is one past the edge entirely", () => {
+    expect(reaching(1300, 400, box)).toBe(false);
+  });
+});

--- a/frontend/src/scrollbar-reach.ts
+++ b/frontend/src/scrollbar-reach.ts
@@ -1,0 +1,99 @@
+/**
+ * The document's scrollbar, for as long as the pointer is reaching for it.
+ *
+ * The bar is drawn as a hairline: the page has a better position indicator
+ * beside it, and two of them down one edge is one too many. But a hairline is
+ * also what made it hard to catch, and the thing a reader does before catching
+ * a scrollbar is move towards the edge of the window — so that is what brings
+ * it up to a native width, before the aiming starts rather than after it has
+ * failed. The drawing changes; the target never does (`scrollbar.css`).
+ */
+
+/** How near the edge counts as reaching for the bar. */
+export const REACH = 64;
+
+/** The class the stylesheet reads, on `body`. */
+const REACHING = "pointer-near-scrollbar";
+
+/**
+ * Whether a pointer is reaching for the bar down the right edge of `box`.
+ *
+ * The bar runs the height of the reading area, so anywhere down that edge is
+ * the same intention — but only down *that* edge: a pointer level with the
+ * header, or with a window's worth of page below the scroller, is not on its
+ * way to the bar however near the right of the window it is.
+ */
+export function reaching(x: number, y: number, box: DOMRect): boolean {
+  if (y < box.top || y > box.bottom || x > box.right) {
+    return false;
+  }
+  return box.right - x <= REACH;
+}
+
+/**
+ * The scroller the bar belongs to.
+ *
+ * Dioxus can replace the element, and a page `arto page` wrote has none at
+ * all, so it is looked up rather than held.
+ */
+let scroller: HTMLElement | null = null;
+
+/**
+ * Where the scroller is, measured at most once a frame.
+ *
+ * A pointer crossing the window sends events faster than the box can change,
+ * and reading it back on each one is a layout forced per event.
+ */
+let box: DOMRect | null = null;
+let measuring = false;
+
+function measure(): DOMRect | null {
+  if (!scroller?.isConnected) {
+    scroller = document.querySelector<HTMLElement>(".content");
+    box = null;
+  }
+  if (!scroller) {
+    return null;
+  }
+  if (!box) {
+    box = scroller.getBoundingClientRect();
+    if (!measuring) {
+      measuring = true;
+      requestAnimationFrame(() => {
+        measuring = false;
+        box = null;
+      });
+    }
+  }
+  return box;
+}
+
+export function setupScrollbarReach(): void {
+  document.addEventListener(
+    "mousemove",
+    (event) => {
+      const rect = measure();
+      if (!rect) {
+        return;
+      }
+      document.body.classList.toggle(REACHING, reaching(event.clientX, event.clientY, rect));
+    },
+    { passive: true },
+  );
+
+  // A pointer that leaves the window stopped reaching wherever it went out —
+  // and the way out it takes most often is straight over the bar, which is
+  // where the last move it sent from was a reach. Three ways of hearing that
+  // it has gone, because the reader who left the window rightwards is the one
+  // most likely to be left looking at a bar that stayed wide: `mouseleave` on
+  // the document, a `mouseout` with nothing on the other side of it, and the
+  // window losing focus to whatever they went to instead.
+  const away = (): void => document.body.classList.remove(REACHING);
+  document.addEventListener("mouseleave", away);
+  document.addEventListener("mouseout", (event) => {
+    if (!event.relatedTarget) {
+      away();
+    }
+  });
+  window.addEventListener("blur", away);
+}

--- a/frontend/style/components/content/margin-trace.css
+++ b/frontend/style/components/content/margin-trace.css
@@ -37,7 +37,7 @@
      only case that needs measuring, and `reading-position.ts` measures it,
      because nothing in CSS can see how tall a sibling's contents are; without
      it the box is the reading area itself. */
-  height: var(--trace-extent, auto);
+  height: var(--margin-extent, auto);
   /* Moved up against the document rather than left at the window's edge: a
      note in the margin belongs beside the text it is a note on. The distance
      is measured in `reading-position.ts`, because the column it has to reach

--- a/frontend/style/components/contents-gutter.css
+++ b/frontend/style/components/contents-gutter.css
@@ -15,65 +15,188 @@
   position: relative;
 }
 
+/* In the page's own margin, opposite the trace. Out of the flow for the same
+   reason the trace is: the page is centred in the whole of the reading area
+   and the columns beside it take what that leaves over, so that neither of
+   them moves the text by coming or going. How far it travels from the right
+   edge to reach the page is measured in `reading-position.ts`, because the
+   column it is a map of is centred in whatever is left of the window. */
 .contents-gutter {
-  flex-shrink: 0;
-  width: 24px;
-  padding: 28px 0 0;
+  position: absolute;
+  /* Placed rather than moved. A transform would put a translucent box on a
+     layer of its own over the scrolling page, and what that layer had drawn
+     was left behind on the page when either of them moved; `right` keeps the
+     column in the page's own paint. It can be written straight in because the
+     measurement does not read the column's position — see
+     `reading-position.ts` — so where it is put cannot feed back into where it
+     is put next. */
+  right: var(--gutter-offset, 0px);
+  top: 0;
+  width: 32px;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  /* Level with the middle of what is being read, on the same measurement the
+     trace is set by: the two columns are a pair, and a pair that did not
+     start level would read as one of them having slipped. */
+  justify-content: center;
+  height: var(--margin-extent, auto);
+  overflow: hidden;
+  box-sizing: border-box;
+  /* The box is the page's height; the ticks are not. Only they answer to the
+     pointer, or the contents would come out for a pointer crossing an empty
+     column on its way somewhere else. */
+  pointer-events: none;
+  /* Nothing translucent about the column itself: its marks carry their own
+     densities (below), so that the page underneath is never seen through a
+     transparency group of the ruler's. What is left here is the fade in and
+     out of existence, where the column is either painted or not at all. */
+  transition: opacity var(--transition-normal) ease;
+}
+
+/* What the pointer can rest in, and the whole of what it can rest in: the
+   ticks are contiguous down it, so moving from one to the next never leaves
+   the column and never flickers the list beside it. */
+.contents-gutter-run {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 5px;
-  overflow: hidden;
+  gap: 2px;
+  width: 100%;
+  max-height: 100%;
+  pointer-events: auto;
 }
 
+/* The page keeps the ruler's column back: its own 32px and the 56px every
+   marginal column stands off the text by (`MARGIN_GAP` in
+   `reading-position.ts`).
+
+   The trace opposite takes only the margin the page happened to leave, and
+   the ruler cannot: a page is centred in what is left of the window, so the
+   margin it leaves is nothing at all until the window is wide enough for the
+   page to stop growing — a thousand pixels of window in which the map of the
+   document would have been written over the last word of every line, or, if
+   it gave way instead, not drawn at all. The reader can lose a note in the
+   margin at a narrow window; the map is what `contents.toggle` opens by name
+   and what the ticks are a ruler for.
+
+   Only while there is a ruler to keep it for: `data-ruler` says so, and it is
+   set where the ruler is looked for rather than where it is asked for — see
+   `reading-position.ts` — because a document with no headings and nothing
+   pinned draws none. */
+.content-area[data-ruler] .markdown-viewer {
+  padding-right: 88px;
+}
+
+/* Not drawn until it has been measured, so that it fades in beside the text
+   rather than appearing at the window's edge and walking there. */
+.content-area:not([data-gutter-ready]) .contents-gutter {
+  opacity: 0;
+  transition: none;
+}
+
+/* No margin left to be a map in. The page keeps one back, so this is what is
+   left when the window is narrow enough that keeping it back was not enough.
+   Measured in `reading-position.ts`; the ruler gives way, and
+   `contents.toggle` still opens the same list by name. */
+.content-area[data-gutter-crowded] .contents-gutter {
+  opacity: 0;
+}
+
+/* A column that is not drawn is not there to be touched either. Said on the
+   run rather than on the column, because `pointer-events: auto` on a
+   descendant answers for itself whatever an ancestor says: without this the
+   ticks stay hit-testable where the column is invisible, over the scrollbar
+   they sit beside, and the contents come out for a pointer that was reaching
+   for the bar. */
+.content-area[data-gutter-crowded] .contents-gutter-run,
+.content-area:not([data-gutter-ready]) .contents-gutter-run {
+  pointer-events: none;
+}
+
+/* The column is faint at rest and wakes when the pointer is in it — in the
+   page's margin it is close enough to the text to be read as part of it. Said
+   mark by mark rather than as one `opacity` on the column: a translucent
+   group over a scrolling page is what left the marks it had already drawn
+   behind on the page, and the marks keep their own densities anyway. */
+.contents-gutter:hover .contents-gutter-tick::before {
+  opacity: 0.5;
+}
+
+/* A row of constant height, whatever the mark inside it weighs. The mark is
+   the `::before`, so a tick that thickens because the reader reached it does
+   not make the column taller — a column that re-centred itself at every
+   heading would shift the whole map sideways under the pointer, and leave the
+   engine repainting a layer that had already moved. */
 .contents-gutter-tick {
   flex-shrink: 0;
-  height: 2px;
+  height: 6px;
+  display: flex;
+  align-items: center;
   padding: 0;
   border: none;
-  border-radius: 1px;
-  background: var(--text-color);
-  opacity: var(--opacity-rest);
+  background: transparent;
   cursor: pointer;
+}
+
+/* The mark, drawn in a box that never changes size. Thickness is the border
+   giving way, not the box growing: a box that shrank left its old, thicker
+   self painted on the column until something else made the engine repaint
+   that strip — which is what put three current ticks in a column that has
+   one. */
+.contents-gutter-tick::before {
+  content: "";
+  width: 100%;
+  height: 6px;
+  box-sizing: border-box;
+  border-top: 2px solid transparent;
+  border-bottom: 2px solid transparent;
+  border-radius: 3px;
+  background: var(--text-color);
+  background-clip: padding-box;
+  opacity: 0.15;
+  /* The weight is not animated. It is the answer to "where am I", which the
+     reader crosses a heading to change, and an engine asked to interpolate a
+     border on a mark that small leaves the old one drawn where it was. */
   transition:
     background-color var(--transition-quiet) ease,
     opacity var(--transition-quiet) ease;
 }
 
 .contents-gutter-tick[data-level="1"] {
-  width: 15px;
+  width: 24px;
 }
 
 .contents-gutter-tick[data-level="2"] {
-  width: 10px;
+  width: 17px;
 }
 
 .contents-gutter-tick[data-level="3"] {
-  width: 7px;
+  width: 12px;
 }
 
 .contents-gutter-tick[data-level="4"],
 .contents-gutter-tick[data-level="5"],
 .contents-gutter-tick[data-level="6"] {
-  width: 5px;
+  width: 8px;
 }
 
-/* Waking the column must not close the gap between the current tick and the
-   rest: they wake to half, the current one to all of it, so where the reader
-   is stays the densest mark in the column at every step. */
-.contents-gutter:hover .contents-gutter-tick {
-  opacity: 0.5;
+/* Weight, and nothing else in the column has any. Three questions, three
+   devices, none of them shared: the width is how deep the heading is, the
+   colour is a search's, and the thickness is where the reader is. Density
+   said this before and said it too quietly — between two 2px lines a step in
+   opacity is a step between two faint greys. */
+.contents-gutter-tick[data-current]::before {
+  border-top-width: 0;
+  border-bottom-width: 0;
+  opacity: 0.3;
 }
 
-/* Where the reader is, in the one currency this column has. A colour would
-   say it too, and the chrome has none left to spend. */
-.contents-gutter-tick[data-current] {
-  opacity: 0.8;
+.contents-gutter:hover .contents-gutter-tick[data-current]::before {
+  opacity: 1;
 }
 
-.contents-gutter:hover .contents-gutter-tick[data-current],
-.contents-gutter-tick:hover,
-.contents-gutter:hover .contents-gutter-tick:hover {
+.contents-gutter-tick:hover::before {
   opacity: 1;
 }
 
@@ -81,17 +204,23 @@
    document, so this is where a search says *where* its hits are — in the
    colour the pinned search carries, which is the one colour left in the
    interface and the only one that means anything. */
-.contents-gutter-tick[data-hit],
-.contents-gutter:hover .contents-gutter-tick[data-hit] {
-  background: var(--hit-colour);
+/* Colour, and only colour. The mark keeps the width its heading's depth gives
+   it and the thickness every other tick has: a mark that also took length was
+   saying something about depth that was not true, and one that also took
+   weight was answering a question the reader's own mark is the answer to. It
+   is the one thing in this column with a colour, which is device enough. */
+.contents-gutter-tick[data-hit]::before {
+  /* The longhand, and it has to be: `background` is a shorthand, and setting
+     it here would reset `background-clip` with everything else it resets —
+     the paint would spread into the transparent borders that are the mark's
+     thinness, and every marked tick would be drawn at the weight that means
+     "you are here". */
+  background-color: var(--hit-colour);
+  opacity: 0.45;
+}
+
+.contents-gutter:hover .contents-gutter-tick[data-hit]::before {
   opacity: 1;
-  /* Enough of it to be a colour. A 2px sliver of a mid-tone reads as grey on
-     a light ground however saturated it is, so a marked tick takes the length
-     of a top-level heading and twice the weight — which is also what makes it
-     findable in a column of thirty. */
-  height: 4px;
-  min-width: 15px;
-  border-radius: 2px;
 }
 
 /* ---------------------------------------------------------------------- *
@@ -104,7 +233,10 @@
 .contents-toc {
   position: absolute;
   top: 24px;
-  right: 24px;
+  /* Beside the ruler that opened it, wherever the page's margin has put that
+     — not at the window's edge, which is half a screen from the column the
+     pointer is resting in. */
+  right: calc(32px + var(--gutter-offset, 0px));
   z-index: var(--z-dropdown);
   min-width: 260px;
   /* Wide enough for a heading to be read rather than guessed at — most fit

--- a/frontend/style/scrollbar.css
+++ b/frontend/style/scrollbar.css
@@ -42,19 +42,64 @@
    So it is not drawn at rest. It is still there — a document with no headings
    has no gutter, and a scrollbar is also the way to drag a long page about —
    and it appears as soon as the pointer is in the page. */
-.content::-webkit-scrollbar-track {
-  background: transparent;
+/* What can be caught and what is drawn are two different things here. The
+   native bar keeps a native width, so that aiming at it is aiming at
+   something — a 4px strip had to be hunted for — but nothing of it is
+   painted. What the reader sees is `.scroll-indicator`, an ordinary element
+   drawn over it from the scroller's own numbers, because a scrollbar
+   pseudo-element is painted by the engine's scrollbar theme and repaints when
+   that theme decides to: a width told to change as the pointer came near
+   changed once and stayed changed. */
+.content::-webkit-scrollbar {
+  width: 14px;
 }
 
-.content::-webkit-scrollbar-thumb {
-  background: transparent;
-}
-
-.content:hover::-webkit-scrollbar-thumb {
-  background: var(--scrollbar-thumb);
-}
-
-.content:hover::-webkit-scrollbar-thumb:hover,
+.content::-webkit-scrollbar-track,
+.content::-webkit-scrollbar-thumb,
+.content::-webkit-scrollbar-thumb:hover,
 .content::-webkit-scrollbar-thumb:active {
+  background: transparent;
+}
+
+/* The lane the native bar occupies, and nothing else: the clicks go through
+   to it. */
+.scroll-indicator {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 14px;
+  pointer-events: none;
+}
+
+/* Drawn as a hairline, because the page has a better position indicator than
+   a scrollbar beside it and two rulers down one edge is one too many. It is
+   not drawn at all until the pointer is in the page. */
+.scroll-indicator-thumb {
+  position: absolute;
+  top: 0;
+  right: 5px;
+  width: 4px;
+  border-radius: 2px;
+  background: var(--scrollbar-thumb);
+  opacity: 0;
+  transition:
+    width var(--transition-normal) ease,
+    right var(--transition-normal) ease,
+    opacity var(--transition-normal) ease;
+}
+
+.content-area:hover .scroll-indicator-thumb {
+  opacity: 1;
+}
+
+/* Reaching for it is what brings it up to the width it is being reached for
+   at: the thing a reader does before catching a scrollbar is move towards the
+   edge of the window, so that is what widens it — before the aiming, rather
+   than after it has failed. `scrollbar-reach.ts` measures the distance. */
+.pointer-near-scrollbar .scroll-indicator-thumb {
+  width: 10px;
+  right: 2px;
+  opacity: 1;
   background: var(--scrollbar-thumb-hover);
 }


### PR DESCRIPTION
## Summary

- The contents ruler moves out of the flex row and into the page's own right margin, opposite the margin trace and the same distance from the text, level with the middle of what is being read. One measurement in `reading-position.ts` (`marginColumn`) now places both columns.
- The page keeps the ruler's column back — its width plus the gap it stands off the text — so the ruler has somewhere to be at every width the layout budget allows one.
- The marks say three things with three devices, one each: **width** is the heading's depth, **colour** is a pinned search's, **thickness** is where the reader is. A search's mark no longer takes length or weight.
- The ruler is 32px wide with longer marks (24/17/12/8px), and `layout_budget::GUTTER_WIDTH` follows, so every fold threshold moves with it.
- The scrollbar is a native width again and catches every click; what is drawn over it is an ordinary element (`.scroll-indicator`), a hairline at rest that comes up to a catchable width when the pointer reaches for the edge.

## Why

The ruler is a map of the document and it was sitting at the window's edge, half a screen from the document at a wide window, while the trace of what was read before it sat in the page's left margin. They are the same kind of thing — a note set against the text — and now they are set the same way.

What the two cannot share is where their space comes from. The trace takes the margin the page happened to leave, which is honest for a note nobody asked for. The ruler cannot: the page is centred in what is left of the window and leaves no margin at all until the window is wide enough for it to stop growing, which is about a thousand pixels of window in which the map would have been written over the last word of every line — or, giving way instead, not drawn at all. So the page reserves the column, and the ruler is only given up below the width at which the budget folds it, where `contents.toggle` still opens the same list by name.

Three devices for three questions came out of using the same one twice. A search's mark had been taking the length of a top-level heading *and* half again the weight, which left the reader's own position with nothing of its own to be found by — with two pinned marks on screen you could not tell which tick was you.

Two engine notes are written into the CSS because each cost an afternoon:

- A mark drawn in a box that changes size leaves its old, larger self painted on the column until something else forces a repaint — three current ticks in a column that has one. The box is constant now and the thickness is a border giving way inside it.
- `background` is a shorthand that resets `background-clip` along with everything else, so a marked tick was painted over the transparent border that was its thinness. The colour goes on with `background-color`.

The scrollbar changed for the same reason the ruler moved: with the ruler now in the margin, a 4px bar at the very edge had to be hunted for. The native bar keeps a native width (all interaction) and is painted transparent; the visible bar is drawn from the scroller's own numbers, because a scrollbar pseudo-element is painted by the engine's scrollbar theme and repaints when that theme decides to — a width told to change as the pointer came near changed once and stayed changed.

## Test Plan

- [x] `just fmt check test` (Rust suites + 109 frontend tests)
- [x] Reviewed with `/code-review`; findings on the reserve, the hit-testing of a hidden ruler, stale `--gutter-offset`, and the proximity test are fixed in this commit.
- [ ] Read a document at a wide window: the ruler sits in the right margin, level with the middle of the page, faint until the pointer is in it.
- [ ] The current tick is the only thick mark; pinned marks are coloured at ordinary weight; tick length still reads as heading depth.
- [ ] Scroll: no marks left painted behind the current one.
- [ ] Narrow the window past the fold: the ruler goes, the page takes the column back, `contents.toggle` still opens the list, and nothing invisible catches the pointer at the right edge.
- [ ] Full-width mode keeps the column back too; zooming in and out does not hide the ruler.
- [ ] Move the pointer towards the right edge: the scrollbar comes up to a catchable width and goes back when the pointer leaves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014w3odYiLAnK59A7F1Ph43N

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/arto-app/codesmith/Arto/pr/281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791565380&installation_model_id=435827&pr_number=281&repository=arto-app%2FArto&return_to=https%3A%2F%2Fgithub.com%2Farto-app%2FArto%2Fpull%2F281&signature=4abd49f54efe4caf98110f442cd640bf8816e2605aa408935ae0c48882d8cf25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->