### PR TITLE
fix(recent): leave a document under the day it was read on

### DIFF
--- a/crates/arto/src/components/content/trace.rs
+++ b/crates/arto/src/components/content/trace.rs
@@ -36,9 +36,10 @@ pub fn MarginTrace(count: usize, visible: bool) -> Element {
     let current = state.current_file();
     let rows: Vec<Visit> = {
         let visits = VISITS.read();
-        visits
-            .items
-            .iter()
+        // Documents, not days: the history keeps a row per day a document was
+        // read, and the same name twice in a column of five is one document
+        // taking two of the five places it has.
+        crate::visits::documents(&visits.items)
             // What is on screen is not a trace of where the reader has been.
             .filter(|visit| current.as_deref() != Some(visit.path.as_path()))
             .take(count)

--- a/crates/arto/src/components/content/welcome_view.rs
+++ b/crates/arto/src/components/content/welcome_view.rs
@@ -199,7 +199,11 @@ pub fn WelcomeView() -> Element {
                             div { class: "welcome-group", "{bucket.heading()}" }
                             for visit in entries {
                                 WelcomeRow {
-                                    key: "{visit.path.display()}",
+                                    // The day is part of the key: a document
+                                    // read on two days is a row under each,
+                                    // and two siblings with one key are one
+                                    // row to the renderer.
+                                    key: "{visit.at}:{visit.path.display()}",
                                     path: visit.path.clone(),
                                     icon: IconName::File,
                                     when: crate::visits::short_when(visit.at, now),

--- a/crates/arto/src/components/header/breadcrumb_menu.rs
+++ b/crates/arto/src/components/header/breadcrumb_menu.rs
@@ -103,7 +103,11 @@ pub fn Breadcrumb(label: String) -> Element {
                         div { class: "breadcrumb-group", "{bucket.heading()}" }
                         for visit in entries {
                             div {
-                                key: "{visit.path.display()}",
+                                // The day is part of the key: a document read
+                                // on two days is a row under each, and two
+                                // siblings with one key are one row to the
+                                // renderer.
+                                key: "{visit.at}:{visit.path.display()}",
                                 class: "breadcrumb-row",
                                 title: "{visit.path.display()}",
                                 onclick: {

--- a/crates/arto/src/components/sidebar/recent.rs
+++ b/crates/arto/src/components/sidebar/recent.rs
@@ -5,7 +5,7 @@ use crate::components::document_name::DocumentName;
 use crate::components::icon::{Icon, IconName};
 use crate::components::sidebar::context_menu::{open_row_context_menu, SidebarItemKind};
 use crate::components::sidebar::row_actions::RowActions;
-use crate::state::{AppState, FocusedPanel};
+use crate::state::{AppState, FocusedPanel, Group};
 use crate::visits::{Bucket, Visit, VISITS, VISITS_CHANGED};
 
 /// The whole reading history, newest first.
@@ -103,7 +103,13 @@ pub fn RecentFace() -> Element {
                                         // is what makes the rest of the list
                                         // read as "before this one".
                                         class: if current.as_deref() == Some(visit.path.as_path()) { "active" },
-                                        class: if cursor.as_ref().is_some_and(|(_, at)| *at == visit.path) { "keyboard-focused" },
+                                        // The day as well as the path: the
+                                        // same document under two days is two
+                                        // rows, and the cursor is on one of
+                                        // them.
+                                        class: if cursor.as_ref().is_some_and(|(group, at)| {
+                                            *group == Group::Day(bucket) && *at == visit.path
+                                        }) { "keyboard-focused" },
                                         onclick: {
                                             let path = visit.path.clone();
                                             move |_| state.open_from_panel(&path)

--- a/crates/arto/src/keybindings/dispatcher/panel.rs
+++ b/crates/arto/src/keybindings/dispatcher/panel.rs
@@ -27,10 +27,14 @@ pub(super) fn panel_items(state: &AppState) -> Vec<crate::state::PanelRow> {
                 .grouped(chrono::Local::now())
                 .into_iter()
                 .filter(|(bucket, _)| !folded.contains(&bucket.heading()))
-                .flat_map(|(_, visits)| {
+                // Named by the day as well as by the path: a document read on
+                // two days is a row under each, and a cursor that knew only
+                // the path would find the first of them wherever it was and
+                // never walk past it.
+                .flat_map(|(bucket, visits)| {
                     visits
                         .into_iter()
-                        .map(|visit| (crate::state::Group::Flat, visit.path.clone()))
+                        .map(move |visit| (crate::state::Group::Day(bucket), visit.path.clone()))
                 })
                 .collect()
         }

--- a/crates/arto/src/state/app_state/sidebar.rs
+++ b/crates/arto/src/state/app_state/sidebar.rs
@@ -52,8 +52,14 @@ pub enum Group {
     Current,
     /// One of the folders kept, which every window has.
     Bookmark,
-    /// A face whose rows are one list with no groups in it: Recent and Starred.
+    /// A face whose rows are one list with no groups in it: Starred.
     Flat,
+    /// One day of the history. The same document is a row under every day it
+    /// was read on — which is what the history is for — so, as with a folder
+    /// that is in both of the tree's groups, the day is part of what names
+    /// the row: without it a cursor could not walk from today's copy to
+    /// yesterday's, because it could not tell them apart.
+    Day(crate::visits::Bucket),
 }
 
 /// A row of the tree: which group it is drawn in, which root it descends

--- a/crates/arto/src/state/app_state/sidebar_cursor.rs
+++ b/crates/arto/src/state/app_state/sidebar_cursor.rs
@@ -295,6 +295,34 @@ mod tests {
         assert!(items.is_empty());
     }
 
+    /// The history draws a document once under every day it was read on, so
+    /// two rows can name one path. The day is part of what names a row, and
+    /// this is why: keyed by the path alone the cursor found the first of them
+    /// wherever it stood, and everything below the second was unreachable.
+    #[test]
+    fn the_cursor_walks_past_a_document_listed_under_two_days() {
+        use crate::state::Group;
+        use crate::visits::Bucket;
+
+        let items = vec![
+            (Group::Day(Bucket::Today), PathBuf::from("/a.md")),
+            (Group::Day(Bucket::Today), PathBuf::from("/b.md")),
+            (Group::Day(Bucket::Yesterday), PathBuf::from("/a.md")),
+            (Group::Day(Bucket::Yesterday), PathBuf::from("/c.md")),
+        ];
+
+        let mut at = Some(items[0].clone());
+        for expected in &items[1..] {
+            at = move_down(&at, &items);
+            assert_eq!(at.as_ref(), Some(expected));
+        }
+
+        for expected in items[..items.len() - 1].iter().rev() {
+            at = move_up(&at, &items);
+            assert_eq!(at.as_ref(), Some(expected));
+        }
+    }
+
     #[test]
     fn move_down_from_none_selects_first() {
         let items = vec![PathBuf::from("/a"), PathBuf::from("/b")];

--- a/crates/arto/src/visits.rs
+++ b/crates/arto/src/visits.rs
@@ -23,7 +23,15 @@ use tokio::sync::broadcast;
 /// How many visits are kept.
 ///
 /// There is no expiry: reading something a year ago is still a fact about
-/// where to find it again. Only the count is bounded, and generously.
+/// where to find it again. Only the count is bounded, and generously — but a
+/// visit is one document on one day, so a document read every day costs a row
+/// a day, and the ceiling is reached in months of heavy reading rather than
+/// years. What falls off is the oldest rows, which are also the ones nothing
+/// but the history itself still names.
+///
+/// It is a count rather than a size because the file is written whole every
+/// time a document is opened: at this ceiling it is about a megabyte, which
+/// is a write worth not thinking about, and ten times that would not be.
 pub const MAX_VISITS: usize = 5_000;
 
 /// One document, when it was last read, and how far into it the reader had
@@ -57,7 +65,7 @@ impl Visit {
 /// The order of the variants is the order they appear, newest first, and no
 /// two of them can hold the same day: [`bucket_for`] tries them in this order
 /// and stops at the first that fits.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Bucket {
     Today,
     Yesterday,
@@ -198,9 +206,25 @@ pub fn last_read_under(dir: &Path) -> Option<DateTime<Local>> {
         .map(|visit| visit.at)
 }
 
-/// The visits answering a query, newest first.
+/// The history read as documents rather than as days: one row each, newest
+/// first.
+///
+/// The list itself keeps a visit per day, because what was read yesterday is
+/// a fact about yesterday that reading it again today cannot change. The
+/// windows that group by day want exactly that. The ones that are about
+/// *documents* — the palette, the trace in the margin — want the other
+/// reading: the same document on two days is one answer to "where have I
+/// been", not two.
+pub fn documents(visits: &[Visit]) -> impl Iterator<Item = &Visit> {
+    let mut seen = std::collections::HashSet::new();
+    visits
+        .iter()
+        .filter(move |visit| seen.insert(visit.path.as_path()))
+}
+
+/// The documents answering a query, newest first.
 pub fn filter<'a>(visits: &'a [Visit], query: &str) -> Vec<&'a Visit> {
-    visits.iter().filter(|v| matches(v, query)).collect()
+    documents(visits).filter(|v| matches(v, query)).collect()
 }
 
 /// The visit list, newest first.
@@ -213,13 +237,24 @@ pub struct Visits {
 impl Visits {
     /// Note that `path` was read at `at`.
     ///
-    /// A document read again moves to the front rather than appearing twice:
-    /// the list answers "where have I been", and the same place twice over is
-    /// not two answers.
+    /// One row per document per day. Reading something again today is the
+    /// same day's reading still going on, so the row moves to the front and
+    /// takes the later time; reading it again tomorrow is a new fact, and the
+    /// row it had yesterday stays where it is. The list is grouped by day
+    /// wherever it is drawn, and moving yesterday's row into today would say
+    /// that yesterday's reading never happened.
+    ///
+    /// The new row starts where the last one left off: how far into a
+    /// document the reader had got is a fact about the document, not about
+    /// the day, and opening it tomorrow has to land where opening it an hour
+    /// from now would.
     pub fn record(&mut self, path: impl Into<PathBuf>, at: DateTime<Local>) {
-        let path = path.into();
-        self.items.retain(|visit| visit.path != path);
-        self.items.insert(0, Visit::new(path, at));
+        let day = at.date_naive();
+        let mut visit = Visit::new(path, at);
+        visit.anchor = self.position(&visit.path).unwrap_or(ScrollAnchor::TOP);
+        self.items
+            .retain(|other| other.path != visit.path || other.at.date_naive() != day);
+        self.items.insert(0, visit);
         self.items.truncate(MAX_VISITS);
     }
 
@@ -243,6 +278,10 @@ impl Visits {
     }
 
     /// Forget one document, for a reader who would rather it were not listed.
+    ///
+    /// Every day of it, not the row that was pointed at: what is being asked
+    /// for is that the document not be in the history, and leaving yesterday's
+    /// row behind would answer a question nobody asked.
     pub fn forget(&mut self, path: &Path) {
         self.items.retain(|visit| visit.path != path);
     }
@@ -273,12 +312,13 @@ impl Visits {
         }
     }
 
-    /// One row per document, however the file spells them.
+    /// One row per document per day, however the file spells them.
     ///
     /// A history written before the spellings were folded together holds the
-    /// same document twice — once as it was typed, once as its own folders
-    /// name it. The list is newest first, so the first of a pair is the one
-    /// worth keeping.
+    /// same document twice on the same day — once as it was typed, once as
+    /// its own folders name it — and one written before the day was part of
+    /// what a row says holds every reading of it. The list is newest first,
+    /// so the first of a day's rows is the one worth keeping.
     fn folded(self) -> Self {
         let mut seen = std::collections::HashSet::new();
         Self {
@@ -289,7 +329,7 @@ impl Visits {
                     path: crate::utils::paths::true_spelling(&visit.path),
                     ..visit
                 })
-                .filter(|visit| seen.insert(visit.path.clone()))
+                .filter(|visit| seen.insert((visit.path.clone(), visit.at.date_naive())))
                 .collect(),
         }
     }
@@ -388,6 +428,11 @@ mod tests {
 
     fn at(y: i32, m: u32, d: u32) -> DateTime<Local> {
         Local.with_ymd_and_hms(y, m, d, 12, 0, 0).unwrap()
+    }
+
+    /// The same day at a named hour, for what happens inside one day.
+    fn at_hour(y: i32, m: u32, d: u32, hour: u32) -> DateTime<Local> {
+        Local.with_ymd_and_hms(y, m, d, hour, 0, 0).unwrap()
     }
 
     #[test]
@@ -537,15 +582,74 @@ mod tests {
     }
 
     #[test]
-    fn reading_something_again_moves_it_rather_than_repeating_it() {
+    fn reading_something_again_the_same_day_moves_it_rather_than_repeating_it() {
+        let mut visits = Visits::default();
+        visits.record("/a.md", at_hour(2026, 4, 16, 9));
+        visits.record("/b.md", at_hour(2026, 4, 16, 10));
+        visits.record("/a.md", at_hour(2026, 4, 16, 11));
+
+        assert_eq!(visits.items.len(), 2);
+        assert_eq!(visits.items[0].path, PathBuf::from("/a.md"));
+        assert_eq!(visits.items[0].at, at_hour(2026, 4, 16, 11));
+    }
+
+    #[test]
+    fn reading_something_again_another_day_leaves_the_day_it_was_read() {
+        let mut visits = Visits::default();
+        visits.record("/a.md", at(2026, 4, 15));
+        visits.record("/a.md", at(2026, 4, 16));
+
+        assert_eq!(visits.items.len(), 2);
+        assert_eq!(visits.items[0].at, at(2026, 4, 16));
+        assert_eq!(visits.items[1].at, at(2026, 4, 15));
+    }
+
+    #[test]
+    fn a_new_day_carries_the_place_the_reader_had_got_to() {
+        let place = ScrollAnchor {
+            line: 42,
+            fraction: 0.25,
+        };
+        let mut visits = Visits::default();
+        visits.record("/a.md", at(2026, 4, 15));
+        visits.keep_position(Path::new("/a.md"), place);
+        visits.record("/a.md", at(2026, 4, 16));
+
+        assert_eq!(visits.position(Path::new("/a.md")), Some(place));
+        // And yesterday still says where the reader was yesterday.
+        assert_eq!(visits.items[1].anchor, place);
+    }
+
+    #[test]
+    fn the_lists_about_documents_see_one_row_each() {
         let mut visits = Visits::default();
         visits.record("/a.md", at(2026, 4, 14));
         visits.record("/b.md", at(2026, 4, 15));
         visits.record("/a.md", at(2026, 4, 16));
 
+        let documents: Vec<&PathBuf> = documents(&visits.items).map(|v| &v.path).collect();
+        assert_eq!(
+            documents,
+            vec![&PathBuf::from("/a.md"), &PathBuf::from("/b.md")]
+        );
+    }
+
+    #[test]
+    fn loading_keeps_one_row_per_document_per_day() {
+        // A history written before the day was part of what a row says holds
+        // the same document twice in one day.
+        let visits = Visits {
+            items: vec![
+                Visit::new("/a.md", at_hour(2026, 4, 16, 11)),
+                Visit::new("/a.md", at_hour(2026, 4, 16, 9)),
+                Visit::new("/a.md", at(2026, 4, 15)),
+            ],
+        }
+        .folded();
+
         assert_eq!(visits.items.len(), 2);
-        assert_eq!(visits.items[0].path, PathBuf::from("/a.md"));
-        assert_eq!(visits.items[0].at, at(2026, 4, 16));
+        assert_eq!(visits.items[0].at, at_hour(2026, 4, 16, 11));
+        assert_eq!(visits.items[1].at, at(2026, 4, 15));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- A visit is now one document on **one day**. Reading something again today moves its row to the front of Today with the later time; reading it again tomorrow leaves yesterday's row untouched and adds a row under Today.
- The new day's row carries the reading position forward, so a document opened the next morning still opens where it was left.
- The lists that are about documents rather than days — the palette and the margin trace — go through the new `visits::documents()`, one row per document, so a repeated document does not take two of the five places the trace has.
- A row in the history is now named by its day as well as its path, which is what lets the panel's keyboard cursor walk past a document that appears under two days.

## Why

The history is grouped by day wherever it is drawn, and a list grouped by day is a record. Opening a document read yesterday used to take its row out of Yesterday and put it under Today — which says the reading never happened. Today cannot change what yesterday was.

Where the reading position lives had to be decided with it: how far into a document a reader had got is a fact about the document, not about the day, so a new day's row starts where the last one ended. Without that, the first open after midnight would land at the top of a document the reader was halfway through.

Two things had been keyed by the path alone and could not survive one document being two rows, both found by `/code-review`:

- `sidebar_cursor::move_down` locates the cursor with the *first* row matching it, so a repeated document trapped the cursor between two rows and everything below the second copy was unreachable by keyboard. The day is part of what names a row now — exactly as `Group` already distinguished a folder that appears in both of the tree's lists — and there is a test for it.
- The welcome page and the breadcrumb's history gave two sibling rows the same rsx `key:`, which is one row to the renderer.

`MAX_VISITS` keeps its ceiling of 5,000 rows, so the file stays about a megabyte and is still written whole on each open; its doc comment now says what a row costs. Measured on a real history: 43 rows in 9.6 KB, about 220 bytes a row. A store with a different shape (SQLite and friends) buys nothing at this size — the write is milliseconds and the read happens once at startup — so it is not worth the schema, the migration and the dependency until the ceiling itself needs raising.

## Test Plan

- [x] `just fmt check test` — new unit tests: same-day re-read stays one row, another day keeps the first, a new day carries the position, `documents()` gives one row per document, loading folds one row per document per day, and the cursor walks past a document listed under two days.
- [ ] Open a document read yesterday: its row stays under Yesterday and a new one appears under Today.
- [ ] Re-open it again today: the Today row moves to the front with the new time and no second row appears.
- [ ] Close and reopen it the next day: it opens where it was left.
- [ ] Walk the Recent face with the keyboard past a document that appears under two days; the cursor reaches the rows below it and the highlight follows one row at a time.
- [ ] The palette and the margin trace list each document once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014w3odYiLAnK59A7F1Ph43N

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/arto-app/codesmith/Arto/pr/282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791566298&installation_model_id=435827&pr_number=282&repository=arto-app%2FArto&return_to=https%3A%2F%2Fgithub.com%2Farto-app%2FArto%2Fpull%2F282&signature=a174073994922e8d65445331fe751ce1227ac25bb17cf42993084ae1057d86d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->