### PR TITLE
ci: bundle every OS on a pull request, downloadable for three days

### DIFF
--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -206,5 +206,6 @@ jobs:
           path: ${{ matrix.artifacts }}
           if-no-files-found: error
           # Release bundles are attached to the release and can stay; a
-          # pull-request smoke test only needs to be downloadable for a while.
-          retention-days: ${{ inputs.version != '' && 90 || 7 }}
+          # pull-request bundle only has to stay downloadable while the change
+          # is under review.
+          retention-days: ${{ inputs.version != '' && 90 || 3 }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,11 @@
 name: "CI"
 
 # The fast lane. Every pull request gets the checks that finish in minutes
-# (frontend, Rust per OS, flake evaluation, docs, workflow lint) and one
-# macOS bundle as the release-critical smoke test. The full five-leg bundle
-# matrix and the from-scratch Nix build run on pushes to main and on demand,
-# or on a pull request that touches what they verify.
+# (frontend, Rust per OS, flake evaluation, docs, workflow lint) plus one
+# bundle per OS — macOS, Linux and Windows — so a reviewer can download and
+# run the change on their own machine. The arm64 legs and the from-scratch
+# Nix build run on pushes to main and on demand, or on a pull request that
+# touches what they verify.
 #
 # `ci` at the bottom is the single job to require in branch protection: it
 # always runs and fails if anything it depends on failed.
@@ -49,6 +50,9 @@ jobs:
           LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
         run: |
           all='["macos","ubuntu","ubuntu-arm64","windows","windows-arm64"]'
+          # One leg per OS: what a pull request has to produce so the change
+          # can be downloaded and run on macOS, Linux and Windows.
+          native='["macos","ubuntu","windows"]'
           if [ "$EVENT" != "pull_request" ]; then
             {
               echo "code=true"
@@ -75,12 +79,12 @@ jobs:
           # pnpmDeps hash, so both must go through the from-scratch build.
           if matches '^(flake\.nix|flake\.lock|nix/|Cargo\.lock|frontend/pnpm-lock\.yaml|\.github/workflows/nix\.yml)'; then flake=true; fi
           if matches '(\.md$|^docs/|^lychee\.toml$|^\.github/scripts/)'; then docs=true; fi
-          # The bundle verifies packaging inputs, not application code, so
-          # the full matrix runs only when those inputs (or a label) ask.
-          # crates/arto/assets holds the icon Dioxus.toml embeds.
+          # The arm64 legs duplicate their x86_64 siblings except for the
+          # packaging inputs, so they run only when those inputs (or a label)
+          # ask. crates/arto/assets holds the icon Dioxus.toml embeds.
           if matches '^(crates/arto/Dioxus\.toml|crates/arto/assets/|crates/arto/justfile|justfile|platform/|flake\.nix|flake\.lock|\.github/workflows/bundle\.yml|\.github/actions/)'; then bundle=true; fi
           case ",$LABELS," in *,ci:bundle,*) bundle=true ;; esac
-          if [ "$bundle" = true ]; then targets="$all"; else targets='["macos"]'; fi
+          if [ "$bundle" = true ]; then targets="$all"; else targets="$native"; fi
           {
             echo "code=$code"
             echo "flake=$flake"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,15 +95,20 @@ Arto/
 minutes: the frontend job (lint, type-check, tests, production bundle), one
 Rust job per OS (format, clippy, tests via nextest; the Linux leg adds
 rustdoc, feature combinations, `cargo deny` and `cargo machete`), flake
-evaluation, documentation checks, workflow lint, and a macOS bundle as the
-release-critical smoke test. Only the `ci` job needs to be a required status
+evaluation, documentation checks, workflow lint, and one bundle per OS —
+macOS, Linux and Windows. Only the `ci` job needs to be a required status
 check; it fails if anything it depends on failed.
 
-The expensive jobs run when they can find something: the full five-leg
-bundle (`bundle.yml`) and the from-scratch Nix build (`nix.yml`) run on every
-push to `main`, on a pull request that touches packaging inputs or the flake,
-or on a pull request labelled `ci:bundle`. A new push to a pull request
-cancels the run in flight.
+Each bundle leg uploads its installers (and, off macOS, the standalone
+executable) as a run artifact named `arto-<leg>`, downloadable from the run
+summary page for three days — long enough to try a pull request on the
+machine it matters on. Release bundles are kept for ninety days instead.
+
+The expensive legs run when they can find something: the arm64 bundles
+(`bundle.yml`) and the from-scratch Nix build (`nix.yml`) run on every push
+to `main`, on a pull request that touches packaging inputs or the flake, or
+on a pull request labelled `ci:bundle`. A new push to a pull request cancels
+the run in flight.
 
 Every check has a matching recipe so a CI failure can be reproduced locally
 inside the devShell:


### PR DESCRIPTION
## Summary

- CI builds one bundle leg per OS on every pull request — macOS, Linux and Windows — instead of macOS alone, so each run publishes the `arto-macos`, `arto-ubuntu` and `arto-windows` artifacts.
- The arm64 legs (`ubuntu-arm64`, `windows-arm64`) stay where they were: pushes to `main`, a change to packaging inputs, or the `ci:bundle` label.
- Non-release bundles are kept for 3 days instead of 7; release bundles still keep their 90.
- `CONTRIBUTING.md` now says what a run actually uploads and for how long.

## Why

A pull request could only be tried on macOS. `bundle-targets` fell back to `["macos"]` unless the diff happened to touch `Dioxus.toml`, the justfiles, `platform/` or the flake, so a change to the app itself produced no Linux `.deb`/`.AppImage` and no Windows installer — nothing to hand a reviewer who runs one of those. Building one leg per OS makes every pull request downloadable on the three platforms the app ships to, while the arm64 legs keep their trigger because they only differ from their x86_64 siblings in packaging.

Three days rather than seven for the retention: the artifact exists to be run while the change is under review, and the bundle from a superseded push is worth nothing after that. Shorter is also cheaper on the account's artifact storage, which now holds three times as many bundles per run.

Linux and Windows legs are still `continue-on-error`, so this widening cannot turn a green pull request red.

## Test Plan

- [ ] `just workflows` (actionlint + zizmor) passes — done locally.
- [ ] `just docs` passes — done locally.
- [ ] This pull request's own CI run shows three bundle legs and uploads `arto-macos`, `arto-ubuntu` and `arto-windows`.
- [ ] Each artifact's expiry on the run summary reads 3 days.
- [ ] A push to `main` still runs all five legs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3orBnXNrggxYEu9fJaXNL

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/arto-app/codesmith/Arto/pr/285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791605895&installation_model_id=435827&pr_number=285&repository=arto-app%2FArto&return_to=https%3A%2F%2Fgithub.com%2Farto-app%2FArto%2Fpull%2F285&signature=6a15dd6019e4d7f0f31ed3cac9dad48ea2e466ce7ea14cee2e047bf129b7cc26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->