### PR TITLE
Walk the history with the mouse's side buttons

### DIFF
--- a/crates/arto/src/components/app.rs
+++ b/crates/arto/src/components/app.rs
@@ -2,6 +2,7 @@ mod drag_drop_overlay;
 mod drop_handlers;
 mod keybinding_engine;
 mod listeners;
+mod mouse_navigation;
 mod ready_reporter;
 mod shortcut_overlay;
 
@@ -31,6 +32,7 @@ use drag_drop_overlay::DragDropOverlay;
 use drop_handlers::handle_dropped_files;
 use keybinding_engine::setup_keybinding_engine;
 use listeners::setup_window_listeners;
+use mouse_navigation::setup_mouse_navigation;
 use ready_reporter::setup_ready_reporter;
 use shortcut_overlay::{
     build_shortcut_help_items, close_shortcut_overlay, split_shortcut_help_columns,
@@ -137,6 +139,9 @@ pub fn App(
 
     // Set up keybinding engine (keyboard shortcut processing)
     setup_keybinding_engine(state, shortcut_overlay_visibility);
+
+    // The mouse's side buttons, which reach the history through the page.
+    setup_mouse_navigation(state);
 
     // Handle menu events (only state-dependent events, not global ones)
     #[cfg(target_os = "macos")]

--- a/crates/arto/src/components/app/mouse_navigation.rs
+++ b/crates/arto/src/components/app/mouse_navigation.rs
@@ -1,0 +1,62 @@
+use dioxus::document;
+use dioxus::prelude::*;
+
+use crate::keybindings::dispatcher::dispatch_action;
+use crate::keybindings::Action;
+use crate::state::AppState;
+
+/// Maximum readiness-poll attempts for the JS mouse API before giving up.
+///
+/// The listener ships inside the renderer bundle, which a cold WebView2 start
+/// can spend several seconds parsing; each attempt sleeps 50 ms, so 200 ≈ 10 s
+/// and 50 ≈ 2.5 s. Mirrors the keyboard interceptor's bound, for the same
+/// reason.
+const JS_MOUSE_READY_MAX_RETRIES: u32 = if cfg!(target_os = "windows") { 200 } else { 50 };
+
+/// Which way the reader asked to go, as `frontend/src/mouse-navigation.ts`
+/// spells it.
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum NavigationDirection {
+    Back,
+    Forward,
+}
+
+/// Bridge the mouse's back / forward side buttons to the history actions.
+///
+/// The buttons reach the page rather than the window: they arrive as a
+/// `mousedown` inside the WebView, so the listener that reads them is in JS
+/// and this is the half that turns a direction into the action the menu and
+/// the keyboard already dispatch.
+pub(super) fn setup_mouse_navigation(state: AppState) {
+    use_hook(move || {
+        spawn(async move {
+            let mut eval = document::eval(&format!(
+                r#"
+            (async () => {{
+                let retries = 0;
+                while (!window.Arto?.mouse?.onNavigate && retries++ < {max}) {{
+                    await new Promise(r => setTimeout(r, 50));
+                }}
+                if (!window.Arto?.mouse?.onNavigate) {{
+                    console.error("Mouse navigation API not available after timeout");
+                    return;
+                }}
+                window.Arto.mouse.onNavigate((direction) => {{
+                    dioxus.send(direction);
+                }});
+            }})();
+            "#,
+                max = JS_MOUSE_READY_MAX_RETRIES,
+            ));
+
+            while let Ok(direction) = eval.recv::<NavigationDirection>().await {
+                let action = match direction {
+                    NavigationDirection::Back => Action::HistoryBack,
+                    NavigationDirection::Forward => Action::HistoryForward,
+                };
+                dispatch_action(&action, state);
+            }
+        });
+    });
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -17,6 +17,7 @@ import {
 import { rasterizeMathBlock, rasterizeMermaidBlock } from "./special-block-rasterizer";
 import * as findInPage from "./find-in-page";
 import * as keyboardInterceptor from "./keyboard-interceptor";
+import * as mouseNavigation from "./mouse-navigation";
 import * as scrollController from "./scroll-controller";
 import * as contentCursor from "./content-cursor";
 import * as actionFeedback from "./action-feedback";
@@ -70,6 +71,10 @@ declare global {
         resume: typeof keyboardInterceptor.resume;
         setMenuAccelerators: typeof keyboardInterceptor.setMenuAccelerators;
         setReservedKeyOverrides: typeof keyboardInterceptor.setReservedKeyOverrides;
+      };
+      mouse: {
+        /** Register a callback for the mouse's back / forward side buttons. */
+        onNavigate: typeof mouseNavigation.onNavigate;
       };
       scroll: {
         down: typeof scrollController.down;
@@ -365,6 +370,9 @@ export function init(): void {
       setMenuAccelerators: keyboardInterceptor.setMenuAccelerators,
       setReservedKeyOverrides: keyboardInterceptor.setReservedKeyOverrides,
     },
+    mouse: {
+      onNavigate: mouseNavigation.onNavigate,
+    },
     scroll: {
       down: scrollController.down,
       up: scrollController.up,
@@ -415,6 +423,9 @@ export function init(): void {
 
   // Set up keyboard interceptor event listeners
   keyboardInterceptor.setup();
+
+  // The mouse's thumb buttons, which walk the history like the arrows do.
+  mouseNavigation.setup();
 
   // Listen for theme changes from Rust
   document.addEventListener("arto:theme-changed", ((event: CustomEvent) => {

--- a/frontend/src/mouse-navigation.test.ts
+++ b/frontend/src/mouse-navigation.test.ts
@@ -1,0 +1,53 @@
+import { describe, test, expect, beforeEach } from "vitest";
+
+import { navigationDirection, onNavigate, setup } from "./mouse-navigation";
+
+describe("navigationDirection", () => {
+  test("reads the two side buttons as the two ways through the history", () => {
+    expect(navigationDirection(3)).toBe("back");
+    expect(navigationDirection(4)).toBe("forward");
+  });
+
+  test("leaves the buttons that open documents alone", () => {
+    // Left and middle belong to the markdown link handler; right opens the
+    // context menu.
+    expect(navigationDirection(0)).toBeNull();
+    expect(navigationDirection(1)).toBeNull();
+    expect(navigationDirection(2)).toBeNull();
+    expect(navigationDirection(5)).toBeNull();
+  });
+});
+
+describe("the side-button listener", () => {
+  let directions: string[];
+
+  beforeEach(() => {
+    directions = [];
+    // The listener is the same function every time, so the repeated call
+    // across tests registers it once.
+    setup();
+    onNavigate((direction) => directions.push(direction));
+  });
+
+  /** A press of `button` on the document, and whether the page kept it. */
+  const press = (button: number): boolean => {
+    const event = new MouseEvent("mousedown", { button, bubbles: true, cancelable: true });
+    document.body.dispatchEvent(event);
+    return event.defaultPrevented;
+  };
+
+  test("hands a side-button press to the callback", () => {
+    press(3);
+    press(4);
+    expect(directions).toEqual(["back", "forward"]);
+  });
+
+  test("keeps the WebView from walking its own history", () => {
+    expect(press(3)).toBe(true);
+  });
+
+  test("lets every other button through untouched", () => {
+    expect(press(0)).toBe(false);
+    expect(directions).toEqual([]);
+  });
+});

--- a/frontend/src/mouse-navigation.ts
+++ b/frontend/src/mouse-navigation.ts
@@ -1,0 +1,54 @@
+/**
+ * The mouse's two side buttons, walking the history.
+ *
+ * A reader whose mouse has thumb buttons expects them to go back and forward
+ * the way every browser and most native apps do — the same places `Cmd+[` and
+ * the header's arrows reach. The WebView hands the presses to the page as
+ * `mousedown` with `button` 3 and 4, and nothing else in the app reads those:
+ * the markdown link handler takes only left and middle, and the keybinding
+ * engine speaks keys alone.
+ *
+ * The Rust side registers the callback and turns a direction into
+ * `Action::HistoryBack` / `Action::HistoryForward`; see
+ * `crates/arto/src/components/app/mouse_navigation.rs`.
+ */
+
+/** Which way through the history a press asks to go. */
+export type NavigationDirection = "back" | "forward";
+
+/** The side buttons as `MouseEvent.button` reports them. */
+const BACK_BUTTON = 3;
+const FORWARD_BUTTON = 4;
+
+type NavigateCallback = (direction: NavigationDirection) => void;
+
+let currentCallback: NavigateCallback | null = null;
+
+/**
+ * The direction a `MouseEvent.button` asks for, or null when it is not one of
+ * the two side buttons.
+ */
+export function navigationDirection(button: number): NavigationDirection | null {
+  if (button === BACK_BUTTON) return "back";
+  if (button === FORWARD_BUTTON) return "forward";
+  return null;
+}
+
+function handleMouseDown(e: MouseEvent): void {
+  const direction = navigationDirection(e.button);
+  if (direction === null) return;
+  // The app is one page the WebView never leaves, so whatever session history
+  // the engine would walk on its own is not the history the reader means.
+  e.preventDefault();
+  currentCallback?.(direction);
+}
+
+/** Register a callback for side-button presses. */
+export function onNavigate(callback: NavigateCallback): void {
+  currentCallback = callback;
+}
+
+/** Set up the side-button listener (call once during init). */
+export function setup(): void {
+  document.addEventListener("mousedown", handleMouseDown);
+}


### PR DESCRIPTION
## Summary

- `frontend/src/mouse-navigation.ts` — a document-level `mousedown` listener that reads `button` 3 as back and 4 as forward, calls `preventDefault()` and hands the direction to a registered callback. Exposed as `window.Arto.mouse.onNavigate`.
- `crates/arto/src/components/app/mouse_navigation.rs` — waits for that API the way the keyboard interceptor's bridge does, then turns each direction into `Action::HistoryBack` / `Action::HistoryForward` and dispatches it.
- `frontend/src/mouse-navigation.test.ts` — the button-to-direction mapping, the callback firing, `preventDefault`, and every other button passing through untouched.

## Why

A mouse with thumb buttons is expected to go back and forward with them, the way a browser does. Arto read only the left and middle buttons, and only on a markdown link, so the two side buttons reached nothing at all — while the same places were a keystroke (`Cmd+[`) or a header arrow away.

The presses arrive inside the WebView rather than at the window: WebKit maps `NSEvent.buttonNumber` 3 and 4 to `MouseButton::Back` / `Forward` ([`PlatformEventFactoryMac.mm`](https://github.com/WebKit/WebKit/blob/main/Source/WebCore/platform/mac/PlatformEventFactoryMac.mm)), and the DOM `button` value follows from the enum ([`MouseEventTypes.h`](https://github.com/WebKit/WebKit/blob/main/Source/WebCore/dom/MouseEventTypes.h)), which matches the W3C UI Events values. So the listener lives in the page and only the dispatch lives in Rust.

Routing through `dispatch_action` rather than calling the history manager directly means the side buttons get exactly what the menu and the keyboard get, including `save_scroll_and_go_back`'s handling of the reading position — there is no second path to keep in step.

The listener stops the press from reaching the engine's own session history, which belongs to the single page the app is drawn into and is not the history the reader means.

## Test Plan

- [x] `just fmt check test` — clippy, oxlint, workspace tests, 114 frontend tests
- [ ] **Needs real hardware**: press the side buttons on a mouse and confirm they walk the history. The mapping is confirmed against WebKit's source, but whether the presses reach the page at all could not be checked without a physical mouse. If they do not arrive, the fallback is to read them natively as tao's `WindowEvent::MouseInput { button: MouseButton::Other(n) }` instead.

## Out of scope

Trackpad two-finger swipe, which #58 notes as needing OS-level event handling separate from the buttons.

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Em4jUTWMqsRB9rKP4R39yP

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/arto-app/codesmith/Arto/pr/293"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791809207&installation_model_id=435827&pr_number=293&repository=arto-app%2FArto&return_to=https%3A%2F%2Fgithub.com%2Farto-app%2FArto%2Fpull%2F293&signature=1119671eeab24ce5fc55ad86ec71a78518340210fc42a36a05bcfbc7d040ab0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->