### PR TITLE
Place, size, theme and wait for a window from the command line

### DIFF
--- a/.claude/rules/ipc.md
+++ b/.claude/rules/ipc.md
@@ -16,14 +16,40 @@ Protocol (JSON Lines):
 {"type":"open","files":["/path/to/file.md"],"directory":null,"behavior":"last_focused","behind":false}
 {"type":"open","files":[],"directory":"/path/to/dir","behavior":"new_window","behind":true}
 {"type":"reopen","behavior":"last_focused","behind":false}
+{"type":"reopen","behavior":"new_window","behind":false,"window":{"position":{"x":120,"y":64},"size":{"width":1400,"height":920},"theme":"light"},"wait_ready":true}
 ```
 
 `behind` (from `arto --behind`) tells the primary to apply the request
 without activating itself or moving the focus; it defaults to `false` when
 a message omits it.
 
+`window` (from `--position`, `--size`, `--theme`) says what the request
+asks of the window it lands in, rather than what to read there. Each field
+is optional and an absent one leaves the running instance's own answer
+alone, so the object is omitted entirely when nothing was asked — which is
+what keeps the line byte-identical to what a primary from before these
+options existed expects. A `reopen` carries it too: naming no path is how a
+window is asked for as a window.
+
+`wait_ready` (from `--wait-ready`) is the one thing that is not about the
+request at all but about the connection. The primary stops reading at a
+message that sets it — such a client will not close the socket, because
+that is what it is waiting on — applies what it has, and answers on the
+same connection once the target window has drawn:
+
+```json
+{"type":"ready"}
+{"type":"timeout"}
+```
+
+Which window that is depends on what the request did, and
+`crates/arto/src/ipc/ready.rs` is the whole rule: a request that reused a
+window names it, a request that created one parks its signal for the next
+window to mount. A signal dropped rather than fired releases the waiting
+launch too, so a window that closes before it draws strands nothing.
+
 The older `file` and `directory` messages are still accepted from a
-not-yet-upgraded secondary instance.
+not-yet-upgraded secondary instance; neither can ask to wait.
 
 Where it lives:
 

--- a/crates/arto-config/src/theme.rs
+++ b/crates/arto-config/src/theme.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// `Auto` follows the operating system; resolving it to light or dark is the
 /// app's job, since it needs the system appearance.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Theme {
     #[default]

--- a/crates/arto-ipc/src/client.rs
+++ b/crates/arto-ipc/src/client.rs
@@ -1,9 +1,9 @@
 //! The secondary instance's side: hand the request to whoever is listening.
 
-use crate::protocol::{IpcMessage, OpenEvent};
+use crate::protocol::{IpcMessage, OpenEvent, ReadyReply};
 use crate::socket;
 use interprocess::local_socket::{prelude::*, GenericFilePath, Stream, ToFsName};
-use std::io::Write;
+use std::io::{BufRead, Write};
 use std::path::Path;
 use std::sync::mpsc;
 use std::time::Duration;
@@ -21,37 +21,80 @@ pub enum SendResult {
     Failed(std::io::Error),
 }
 
+/// How long a launch that asked to wait will hold the connection open.
+///
+/// Far longer than [`socket::IPC_TIMEOUT`], which bounds a handshake: this
+/// bounds a document being read from disk, parsed, and drawn with its
+/// diagrams and formulas. A cold start with a large document is seconds, and
+/// the point of waiting is to not have to guess how many.
+pub const READY_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// Try to hand an event to an already running instance.
 ///
 /// Connecting is bounded by a timeout so a wedged primary cannot hang a
 /// new launch; no answer within it counts as no instance.
-pub fn send_to_existing_instance(event: &OpenEvent) -> SendResult {
+///
+/// With `wait_ready`, the connection stays open until the primary says the
+/// target window has drawn the request, or until [`READY_TIMEOUT`] passes.
+/// A primary too old to understand the flag closes the connection instead of
+/// replying, which reads as no reply and returns just as a reply would — the
+/// request itself was still delivered.
+pub fn send_to_existing_instance(event: &OpenEvent, wait_ready: bool) -> SendResult {
     let socket_path = socket::socket_path();
 
     let Some(stream) = connect_with_timeout(&socket_path, socket::IPC_TIMEOUT) else {
         return SendResult::NoExistingInstance;
     };
 
-    match send_event(stream, event) {
+    match send_event(stream, event, wait_ready) {
         Ok(()) => SendResult::Sent,
         Err(error) => SendResult::Failed(error),
     }
 }
 
 /// Write one JSON line and make sure it went out.
-fn send_event(mut stream: Stream, event: &OpenEvent) -> std::io::Result<()> {
+fn send_event(mut stream: Stream, event: &OpenEvent, wait_ready: bool) -> std::io::Result<()> {
     // A write timeout keeps a stuck primary from hanging this process.
     if let Err(error) = socket::set_socket_timeout(&stream, socket::IPC_TIMEOUT) {
         tracing::debug!(%error, "Could not set the IPC socket timeout");
     }
 
-    let message = IpcMessage::from(event.clone());
+    let message = IpcMessage::from_event(event.clone(), wait_ready);
     let json = serde_json::to_string(&message)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
     writeln!(stream, "{json}")?;
 
     // Flush and verify - this will fail if primary crashed
-    stream.flush()
+    stream.flush()?;
+
+    if wait_ready {
+        await_ready(stream);
+    }
+    Ok(())
+}
+
+/// Block until the primary answers, it hangs up, or the wait runs out.
+///
+/// Nothing here fails the send: the request was delivered and acknowledged
+/// by the write above, and what is being waited for is a courtesy on top of
+/// it. Every way the wait can end is therefore a debug line and a return.
+fn await_ready(stream: Stream) {
+    if let Err(error) = socket::set_socket_timeout(&stream, READY_TIMEOUT) {
+        tracing::debug!(%error, "Could not extend the IPC socket timeout for the ready wait");
+    }
+
+    let mut line = String::new();
+    match std::io::BufReader::new(stream).read_line(&mut line) {
+        Ok(0) => tracing::debug!("Primary closed the connection without a ready reply"),
+        Ok(_) => match serde_json::from_str::<ReadyReply>(line.trim()) {
+            Ok(ReadyReply::Ready) => tracing::debug!("Target window reported ready"),
+            Ok(ReadyReply::Timeout) => {
+                tracing::debug!("Primary gave up waiting for the target window")
+            }
+            Err(error) => tracing::debug!(%line, %error, "Unparseable ready reply"),
+        },
+        Err(error) => tracing::debug!(%error, "Gave up waiting for the ready reply"),
+    }
 }
 
 /// Try to connect to a socket with timeout.

--- a/crates/arto-ipc/src/lib.rs
+++ b/crates/arto-ipc/src/lib.rs
@@ -31,11 +31,18 @@
 //! {"type":"open","files":["/path/to/file.md"],"directory":null,"behavior":"last_focused","behind":false}
 //! {"type":"open","files":[],"directory":"/path/to/dir","behavior":"new_window","behind":true}
 //! {"type":"reopen","behavior":"last_focused","behind":false}
+//! {"type":"reopen","behavior":"new_window","behind":false,"window":{"position":{"x":120,"y":64}},"wait_ready":true}
 //! ```
 //!
 //! The older `file` and `directory` messages are still accepted so a
 //! freshly upgraded primary understands a not-yet-upgraded secondary, and
-//! `behind` defaults to `false` when a message omits it.
+//! `behind` defaults to `false` when a message omits it. [`WindowOptions`]
+//! and `wait_ready` are left out of the line when nothing asked for them,
+//! so the common case is the line it has always been.
+//!
+//! A message that sets `wait_ready` gets an answer back down the same
+//! connection ([`ReadyReply`]) once the app fires the [`ReadySignal`] it was
+//! handed; everything else is written and forgotten.
 //!
 //! # Socket location
 //!

--- a/crates/arto-ipc/src/protocol.rs
+++ b/crates/arto-ipc/src/protocol.rs
@@ -1,6 +1,60 @@
-use arto_config::FileOpenBehavior;
+use arto_config::{FileOpenBehavior, Theme};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
+
+/// A window's top-left corner in screen coordinates, in logical pixels.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WindowPoint {
+    pub x: i32,
+    pub y: i32,
+}
+
+/// A window's size in logical pixels.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WindowExtent {
+    pub width: u32,
+    pub height: u32,
+}
+
+/// What a launch asks of the window it lands in, beyond what to read.
+///
+/// Every field is absent by default, and an absent field leaves the running
+/// instance's own answer — the preferences, or the window as it already
+/// stands — untouched. Automation is what these exist for: placing a window
+/// where a screen capture expects it, and pinning the theme so the capture
+/// does not change with the time of day.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WindowOptions {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub position: Option<WindowPoint>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size: Option<WindowExtent>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub theme: Option<Theme>,
+}
+
+impl WindowOptions {
+    /// Whether the launch asked for nothing at all, in which case the window
+    /// is left exactly as the running instance would have made it.
+    pub fn is_empty(&self) -> bool {
+        *self == Self::default()
+    }
+
+    /// What the *other* windows of one launch inherit.
+    ///
+    /// A launch naming several files gives each one a window. The theme is
+    /// how this invocation's windows should look, so all of them take it;
+    /// a position and a size name one place and one shape, and a place holds
+    /// one window — stacking the rest exactly on top of the first would hide
+    /// them behind it.
+    pub fn without_geometry(&self) -> Self {
+        Self {
+            position: None,
+            size: None,
+            theme: self.theme,
+        }
+    }
+}
 
 /// What a launch asks the running instance to open.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -15,6 +69,9 @@ pub struct OpenRequest {
     /// activating Arto or moving the keyboard focus.
     #[serde(default)]
     pub behind: bool,
+    /// Geometry and theme for the window this request lands in.
+    #[serde(default)]
+    pub window: WindowOptions,
 }
 
 /// A request in the form the running instance handles: the wire messages,
@@ -28,6 +85,7 @@ pub enum OpenEvent {
     Reopen {
         behavior: Option<FileOpenBehavior>,
         behind: bool,
+        window: WindowOptions,
     },
 }
 
@@ -53,6 +111,12 @@ pub enum IpcMessage {
         behavior: Option<FileOpenBehavior>,
         #[serde(default)]
         behind: bool,
+        #[serde(default, skip_serializing_if = "WindowOptions::is_empty")]
+        window: WindowOptions,
+        /// Hold the connection open until the target window has drawn what
+        /// this request asked for, and answer with [`ReadyReply`] then.
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        wait_ready: bool,
     },
     /// Reopen/activate the application (no paths provided).
     Reopen {
@@ -60,10 +124,68 @@ pub enum IpcMessage {
         behavior: Option<FileOpenBehavior>,
         #[serde(default)]
         behind: bool,
+        #[serde(default, skip_serializing_if = "WindowOptions::is_empty")]
+        window: WindowOptions,
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        wait_ready: bool,
     },
 }
 
+/// The one line the primary writes back, and only to a launch that asked to
+/// wait: the target window has drawn what the request asked for.
+///
+/// A reply travels the other way down the same connection, so it carries its
+/// own `type` tag rather than reusing [`IpcMessage`]'s — a future reply of a
+/// different kind is then a variant here, not a message the primary would
+/// have to distinguish from a request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ReadyReply {
+    /// The window drew the request.
+    Ready,
+    /// The primary gave up waiting; the request itself was still applied.
+    Timeout,
+}
+
 impl IpcMessage {
+    /// The wire form of `event`, with the transport's own `wait_ready` flag.
+    ///
+    /// Waiting is not part of the event: it says what the *connection* does
+    /// after the request is handed over, which is the sender's business and
+    /// none of the app's.
+    pub fn from_event(event: OpenEvent, wait_ready: bool) -> Self {
+        match event {
+            OpenEvent::Open(request) => IpcMessage::Open {
+                files: request.files,
+                directory: request.directory,
+                behavior: request.behavior,
+                behind: request.behind,
+                window: request.window,
+                wait_ready,
+            },
+            OpenEvent::Reopen {
+                behavior,
+                behind,
+                window,
+            } => IpcMessage::Reopen {
+                behavior,
+                behind,
+                window,
+                wait_ready,
+            },
+        }
+    }
+
+    /// Whether the sender is holding the connection open for a reply.
+    pub fn wait_ready(&self) -> bool {
+        match self {
+            IpcMessage::File { .. } | IpcMessage::Directory { .. } => false,
+            IpcMessage::Open { wait_ready, .. } | IpcMessage::Reopen { wait_ready, .. } => {
+                *wait_ready
+            }
+        }
+    }
+
     /// Normalize into the event the running instance handles.
     pub fn into_open_event(self) -> OpenEvent {
         match self {
@@ -72,40 +194,46 @@ impl IpcMessage {
                 directory: None,
                 behavior: None,
                 behind: false,
+                window: WindowOptions::default(),
             }),
             IpcMessage::Directory { path } => OpenEvent::Open(OpenRequest {
                 files: Vec::new(),
                 directory: Some(path),
                 behavior: None,
                 behind: false,
+                window: WindowOptions::default(),
             }),
             IpcMessage::Open {
                 files,
                 directory,
                 behavior,
                 behind,
+                window,
+                wait_ready: _,
             } => OpenEvent::Open(OpenRequest {
                 files,
                 directory,
                 behavior,
                 behind,
+                window,
             }),
-            IpcMessage::Reopen { behavior, behind } => OpenEvent::Reopen { behavior, behind },
+            IpcMessage::Reopen {
+                behavior,
+                behind,
+                window,
+                wait_ready: _,
+            } => OpenEvent::Reopen {
+                behavior,
+                behind,
+                window,
+            },
         }
     }
 }
 
 impl From<OpenEvent> for IpcMessage {
     fn from(event: OpenEvent) -> Self {
-        match event {
-            OpenEvent::Open(request) => IpcMessage::Open {
-                files: request.files,
-                directory: request.directory,
-                behavior: request.behavior,
-                behind: request.behind,
-            },
-            OpenEvent::Reopen { behavior, behind } => IpcMessage::Reopen { behavior, behind },
-        }
+        Self::from_event(event, false)
     }
 }
 
@@ -145,6 +273,8 @@ mod tests {
             directory: Some(PathBuf::from("/path/to/dir")),
             behavior: Some(FileOpenBehavior::LastFocused),
             behind: false,
+            window: WindowOptions::default(),
+            wait_ready: false,
         };
         let json = serde_json::to_string(&msg).unwrap();
         assert_eq!(
@@ -154,10 +284,116 @@ mod tests {
     }
 
     #[test]
+    fn a_launch_that_asks_for_nothing_writes_the_line_it_always_wrote() {
+        // Geometry, theme and the ready wait are all absent by default and
+        // are left out of the line entirely, so a primary from before they
+        // existed reads exactly what it used to.
+        let msg = IpcMessage::Reopen {
+            behavior: None,
+            behind: false,
+            window: WindowOptions::default(),
+            wait_ready: false,
+        };
+        assert_eq!(
+            serde_json::to_string(&msg).unwrap(),
+            r#"{"type":"reopen","behavior":null,"behind":false}"#
+        );
+    }
+
+    #[test]
+    fn window_options_round_trip_through_the_wire_format() {
+        let msg = IpcMessage::Open {
+            files: Vec::new(),
+            directory: None,
+            behavior: Some(FileOpenBehavior::NewWindow),
+            behind: false,
+            window: WindowOptions {
+                position: Some(WindowPoint { x: 120, y: 64 }),
+                size: Some(WindowExtent {
+                    width: 1400,
+                    height: 920,
+                }),
+                theme: Some(Theme::Light),
+            },
+            wait_ready: true,
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert_eq!(
+            json,
+            r#"{"type":"open","files":[],"directory":null,"behavior":"new_window","behind":false,"window":{"position":{"x":120,"y":64},"size":{"width":1400,"height":920},"theme":"light"},"wait_ready":true}"#
+        );
+        assert_eq!(serde_json::from_str::<IpcMessage>(&json).unwrap(), msg);
+    }
+
+    #[test]
+    fn waiting_is_the_connections_business_and_not_the_events() {
+        // The event the app handles says nothing about waiting; the flag
+        // rides beside it on the wire and is read straight off the message.
+        let event = OpenEvent::Reopen {
+            behavior: None,
+            behind: false,
+            window: WindowOptions::default(),
+        };
+        let waiting = IpcMessage::from_event(event.clone(), true);
+        assert!(waiting.wait_ready());
+        assert_eq!(waiting.into_open_event(), event);
+
+        let plain = IpcMessage::from_event(event.clone(), false);
+        assert!(!plain.wait_ready());
+        assert_eq!(plain.into_open_event(), event);
+    }
+
+    #[test]
+    fn a_legacy_message_never_asks_to_wait() {
+        let legacy: IpcMessage =
+            serde_json::from_str(r#"{"type":"file","path":"/tmp/a.md"}"#).unwrap();
+        assert!(!legacy.wait_ready());
+    }
+
+    #[test]
+    fn the_other_windows_of_a_launch_take_the_theme_but_not_the_place() {
+        let asked = WindowOptions {
+            position: Some(WindowPoint { x: 120, y: 64 }),
+            size: Some(WindowExtent {
+                width: 1400,
+                height: 920,
+            }),
+            theme: Some(Theme::Dark),
+        };
+        assert_eq!(
+            asked.without_geometry(),
+            WindowOptions {
+                position: None,
+                size: None,
+                theme: Some(Theme::Dark),
+            }
+        );
+    }
+
+    #[test]
+    fn a_launch_that_asked_for_nothing_passes_nothing_on() {
+        assert!(WindowOptions::default().without_geometry().is_empty());
+    }
+
+    #[test]
+    fn ready_replies_carry_their_own_tag() {
+        assert_eq!(
+            serde_json::to_string(&ReadyReply::Ready).unwrap(),
+            r#"{"type":"ready"}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&ReadyReply::Timeout).unwrap(),
+            r#"{"type":"timeout"}"#
+        );
+    }
+
+    #[test]
     fn reopen_serializes_with_type_tag() {
         let msg = IpcMessage::Reopen {
             behavior: Some(FileOpenBehavior::LastFocused),
             behind: false,
+            window: WindowOptions::default(),
+            wait_ready: false,
         };
         let json = serde_json::to_string(&msg).unwrap();
         assert_eq!(
@@ -177,6 +413,8 @@ mod tests {
                 directory: Some(PathBuf::from("/path/to/dir")),
                 behavior: Some(FileOpenBehavior::LastFocused),
                 behind: true,
+                window: WindowOptions::default(),
+                wait_ready: false,
             }
         );
     }
@@ -194,6 +432,8 @@ mod tests {
                 directory: None,
                 behavior: None,
                 behind: false,
+                window: WindowOptions::default(),
+                wait_ready: false,
             }
         );
     }
@@ -207,6 +447,8 @@ mod tests {
             IpcMessage::Reopen {
                 behavior: Some(FileOpenBehavior::LastFocused),
                 behind: false,
+                window: WindowOptions::default(),
+                wait_ready: false,
             }
         );
 
@@ -216,6 +458,8 @@ mod tests {
             IpcMessage::Reopen {
                 behavior: None,
                 behind: false,
+                window: WindowOptions::default(),
+                wait_ready: false,
             }
         );
     }
@@ -253,6 +497,7 @@ mod tests {
                 directory: None,
                 behavior: None,
                 behind: false,
+                window: WindowOptions::default(),
             })
         );
         assert_eq!(
@@ -265,6 +510,7 @@ mod tests {
                 directory: Some(PathBuf::from("/tmp/docs")),
                 behavior: None,
                 behind: false,
+                window: WindowOptions::default(),
             })
         );
         assert_eq!(
@@ -273,6 +519,8 @@ mod tests {
                 directory: Some(PathBuf::from("/test/dir")),
                 behavior: Some(FileOpenBehavior::CurrentScreen),
                 behind: true,
+                window: WindowOptions::default(),
+                wait_ready: false,
             }
             .into_open_event(),
             OpenEvent::Open(OpenRequest {
@@ -280,17 +528,21 @@ mod tests {
                 directory: Some(PathBuf::from("/test/dir")),
                 behavior: Some(FileOpenBehavior::CurrentScreen),
                 behind: true,
+                window: WindowOptions::default(),
             })
         );
         assert_eq!(
             IpcMessage::Reopen {
                 behavior: Some(FileOpenBehavior::LastFocused),
                 behind: true,
+                window: WindowOptions::default(),
+                wait_ready: false,
             }
             .into_open_event(),
             OpenEvent::Reopen {
                 behavior: Some(FileOpenBehavior::LastFocused),
                 behind: true,
+                window: WindowOptions::default(),
             }
         );
     }
@@ -303,20 +555,24 @@ mod tests {
                 directory: Some(PathBuf::from("/dir")),
                 behavior: Some(FileOpenBehavior::NewWindow),
                 behind: false,
+                window: WindowOptions::default(),
             }),
             OpenEvent::Open(OpenRequest {
                 files: vec![PathBuf::from("/a.md")],
                 directory: None,
                 behavior: None,
                 behind: true,
+                window: WindowOptions::default(),
             }),
             OpenEvent::Reopen {
                 behavior: None,
                 behind: false,
+                window: WindowOptions::default(),
             },
             OpenEvent::Reopen {
                 behavior: None,
                 behind: true,
+                window: WindowOptions::default(),
             },
         ];
         for event in events {
@@ -348,16 +604,22 @@ mod tests {
                     directory: None,
                     behavior: Some(FileOpenBehavior::LastFocused),
                     behind: false,
+                    window: WindowOptions::default(),
+                    wait_ready: false,
                 },
                 IpcMessage::Open {
                     files: Vec::new(),
                     directory: Some(PathBuf::from("/dir")),
                     behavior: Some(FileOpenBehavior::NewWindow),
                     behind: true,
+                    window: WindowOptions::default(),
+                    wait_ready: false,
                 },
                 IpcMessage::Reopen {
                     behavior: Some(FileOpenBehavior::CurrentScreen),
                     behind: false,
+                    window: WindowOptions::default(),
+                    wait_ready: false,
                 },
             ]
         );

--- a/crates/arto-ipc/src/server.rs
+++ b/crates/arto-ipc/src/server.rs
@@ -1,13 +1,36 @@
 //! The primary instance's side: accept later launches and hand their
 //! events to the app.
 
-use crate::protocol::{IpcMessage, OpenEvent};
+use crate::client::READY_TIMEOUT;
+use crate::protocol::{IpcMessage, OpenEvent, ReadyReply};
 use crate::socket::{self, IpcError};
 use interprocess::local_socket::prelude::*;
 use interprocess::local_socket::{Listener, Stream};
-use std::io::BufRead;
+use std::io::{BufRead, Write};
 use std::path::{Path, PathBuf};
+use std::sync::mpsc;
 use std::sync::Arc;
+
+/// The app's end of a launch that is waiting to be told the window drew it.
+///
+/// Handed to the events callback only when the launch asked to wait, and
+/// carried by the app to whatever finally knows the answer. Dropping it
+/// without a call to [`ReadySignal::fire`] releases the waiting launch too:
+/// nothing that can still answer exists once the last one is gone.
+pub struct ReadySignal(mpsc::Sender<()>);
+
+impl ReadySignal {
+    /// Tell the waiting launch the window has drawn what it asked for.
+    pub fn fire(self) {
+        let _ = self.0.send(());
+    }
+}
+
+impl std::fmt::Debug for ReadySignal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("ReadySignal")
+    }
+}
 
 /// A bound listener, ready to accept secondary instances.
 pub struct IpcServer {
@@ -55,8 +78,16 @@ impl IpcServer {
     /// [`IPC_TIMEOUT`](crate::IPC_TIMEOUT). A connection that sends nothing
     /// parseable does not call `on_events` at all. Blocks the calling
     /// thread for the life of the listener.
-    pub fn serve(self, on_events: impl Fn(Vec<OpenEvent>) + Send + Sync + 'static) {
-        let on_events: Arc<dyn Fn(Vec<OpenEvent>) + Send + Sync> = Arc::new(on_events);
+    ///
+    /// The second argument is `Some` only for a launch that asked to wait
+    /// for its window; firing it writes the reply that lets that launch
+    /// exit. See [`ReadySignal`].
+    pub fn serve(
+        self,
+        on_events: impl Fn(Vec<OpenEvent>, Option<ReadySignal>) + Send + Sync + 'static,
+    ) {
+        let on_events: Arc<dyn Fn(Vec<OpenEvent>, Option<ReadySignal>) + Send + Sync> =
+            Arc::new(on_events);
 
         for conn in self.listener.incoming() {
             let stream = match conn {
@@ -83,30 +114,40 @@ impl IpcServer {
 
 /// Read JSON Lines until the client closes or the read times out, then
 /// hand everything received to the app at once.
-fn handle_connection(stream: Stream, on_events: &dyn Fn(Vec<OpenEvent>)) {
+///
+/// A message that asks to wait ends the read early instead: such a client is
+/// not going to close the connection — that is what it is waiting on — so
+/// reading to EOF would deadlock the two of them against each other. It
+/// sends exactly one message, so everything it had to say has been read by
+/// the time the flag is seen.
+fn handle_connection(stream: Stream, on_events: &dyn Fn(Vec<OpenEvent>, Option<ReadySignal>)) {
     // Set read timeout to avoid blocking forever
     if let Err(error) = socket::set_socket_timeout(&stream, socket::IPC_TIMEOUT) {
         tracing::debug!(%error, "Could not set the IPC socket timeout");
     }
 
-    let reader = std::io::BufReader::new(stream);
+    let mut reader = std::io::BufReader::new(stream);
     let mut events = Vec::new();
+    let mut wait_ready = false;
 
-    for line in reader.lines() {
-        let line = match line {
-            Ok(line) => line,
+    loop {
+        let mut line = String::new();
+        match reader.read_line(&mut line) {
+            Ok(0) => break,
+            Ok(_) => {}
             Err(error) => {
                 // Timeout or connection closed
                 tracing::debug!(%error, "Error reading from IPC client");
                 break;
             }
-        };
+        }
 
+        let line = line.trim_end_matches(['\r', '\n']);
         if line.is_empty() {
             continue;
         }
 
-        let message: IpcMessage = match serde_json::from_str(&line) {
+        let message: IpcMessage = match serde_json::from_str(line) {
             Ok(message) => message,
             Err(error) => {
                 tracing::debug!(%line, %error, "Failed to parse IPC message");
@@ -115,11 +156,44 @@ fn handle_connection(stream: Stream, on_events: &dyn Fn(Vec<OpenEvent>)) {
         };
 
         tracing::debug!(?message, "Received IPC message");
+        wait_ready = message.wait_ready();
         events.push(message.into_open_event());
+        if wait_ready {
+            break;
+        }
     }
 
-    if !events.is_empty() {
-        on_events(events);
+    if events.is_empty() {
+        return;
+    }
+
+    if !wait_ready {
+        on_events(events, None);
+        return;
+    }
+
+    let (sender, receiver) = mpsc::channel();
+    on_events(events, Some(ReadySignal(sender)));
+
+    let reply = match receiver.recv_timeout(READY_TIMEOUT) {
+        Ok(()) => ReadyReply::Ready,
+        // Disconnected means every signal was dropped, so no answer is ever
+        // coming; saying so at once beats holding the launch for the full
+        // timeout to reach the same place.
+        Err(error) => {
+            tracing::debug!(%error, "No window reported ready for a waiting launch");
+            ReadyReply::Timeout
+        }
+    };
+    reply_to_waiting_client(reader.into_inner(), &reply);
+}
+
+fn reply_to_waiting_client(mut stream: Stream, reply: &ReadyReply) {
+    let Ok(json) = serde_json::to_string(reply) else {
+        return;
+    };
+    if let Err(error) = writeln!(stream, "{json}").and_then(|()| stream.flush()) {
+        tracing::debug!(%error, "Could not send the ready reply");
     }
 }
 

--- a/crates/arto/src/cli.rs
+++ b/crates/arto/src/cli.rs
@@ -1,3 +1,4 @@
+use arto_ipc::{WindowExtent, WindowPoint};
 use std::path::PathBuf;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -27,4 +28,115 @@ pub struct CliInvocation {
     pub open_mode: CliOpenMode,
     /// Open without activating Arto, leaving the keyboard focus where it is.
     pub behind: bool,
+    /// Geometry and theme asked for by this invocation, for the window it
+    /// lands in. Empty when the invocation asked for none of them.
+    pub window: arto_ipc::WindowOptions,
+    /// Return only once the target window has drawn the document, rather
+    /// than as soon as the request is handed over.
+    pub wait_ready: bool,
+}
+
+/// Read `--position=<x>,<y>`.
+///
+/// Negative coordinates are ordinary: a display left of or above the main
+/// one starts at a negative origin, and a window placed there is placed
+/// deliberately.
+pub fn parse_position(value: &str) -> Result<WindowPoint, String> {
+    let (x, y) = split_pair(value, "x,y")?;
+    Ok(WindowPoint {
+        x: parse_field::<i32>(x, "x")?,
+        y: parse_field::<i32>(y, "y")?,
+    })
+}
+
+/// Read `--size=<w>,<h>`.
+pub fn parse_size(value: &str) -> Result<WindowExtent, String> {
+    let (width, height) = split_pair(value, "width,height")?;
+    let extent = WindowExtent {
+        width: parse_field::<u32>(width, "width")?,
+        height: parse_field::<u32>(height, "height")?,
+    };
+    if extent.width == 0 || extent.height == 0 {
+        return Err("width and height must both be greater than zero".to_string());
+    }
+    Ok(extent)
+}
+
+fn split_pair<'a>(value: &'a str, shape: &str) -> Result<(&'a str, &'a str), String> {
+    match value.split_once(',') {
+        Some((first, second)) => Ok((first.trim(), second.trim())),
+        None => Err(format!(
+            "expected {shape}, as two numbers separated by a comma"
+        )),
+    }
+}
+
+fn parse_field<T: std::str::FromStr>(value: &str, name: &str) -> Result<T, String> {
+    value
+        .parse()
+        .map_err(|_| format!("{name} is not a number: {value:?}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_position_is_two_numbers_separated_by_a_comma() {
+        assert_eq!(parse_position("120,64"), Ok(WindowPoint { x: 120, y: 64 }));
+        assert_eq!(
+            parse_position(" 120 , 64 "),
+            Ok(WindowPoint { x: 120, y: 64 })
+        );
+    }
+
+    #[test]
+    fn a_display_left_of_the_main_one_has_a_negative_origin() {
+        assert_eq!(
+            parse_position("-1920,-200"),
+            Ok(WindowPoint { x: -1920, y: -200 })
+        );
+    }
+
+    #[test]
+    fn a_size_is_two_numbers_separated_by_a_comma() {
+        assert_eq!(
+            parse_size("1400,920"),
+            Ok(WindowExtent {
+                width: 1400,
+                height: 920
+            })
+        );
+    }
+
+    #[test]
+    fn a_window_cannot_be_asked_for_with_no_extent() {
+        assert!(parse_size("0,920").is_err());
+        assert!(parse_size("1400,0").is_err());
+        assert!(parse_size("-1,920").is_err());
+    }
+
+    #[test]
+    fn a_pair_that_is_not_a_pair_says_what_was_expected() {
+        assert_eq!(
+            parse_position("120"),
+            Err("expected x,y, as two numbers separated by a comma".to_string())
+        );
+        assert_eq!(
+            parse_size("1400"),
+            Err("expected width,height, as two numbers separated by a comma".to_string())
+        );
+    }
+
+    #[test]
+    fn a_field_that_is_not_a_number_says_which_one() {
+        assert_eq!(
+            parse_position("120,middle"),
+            Err(r#"y is not a number: "middle""#.to_string())
+        );
+        assert_eq!(
+            parse_size("wide,920"),
+            Err(r#"width is not a number: "wide""#.to_string())
+        );
+    }
 }

--- a/crates/arto/src/components/app.rs
+++ b/crates/arto/src/components/app.rs
@@ -2,6 +2,7 @@ mod drag_drop_overlay;
 mod drop_handlers;
 mod keybinding_engine;
 mod listeners;
+mod ready_reporter;
 mod shortcut_overlay;
 
 use dioxus::desktop::tao::dpi::{LogicalPosition, LogicalSize};
@@ -30,6 +31,7 @@ use drag_drop_overlay::DragDropOverlay;
 use drop_handlers::handle_dropped_files;
 use keybinding_engine::setup_keybinding_engine;
 use listeners::setup_window_listeners;
+use ready_reporter::setup_ready_reporter;
 use shortcut_overlay::{
     build_shortcut_help_items, close_shortcut_overlay, split_shortcut_help_columns,
     ShortcutHelpOverlay, ShortcutOverlayVisibility,
@@ -181,6 +183,9 @@ pub fn App(
     });
 
     setup_window_listeners(state);
+
+    // Answer any launch that is holding its socket open for this window.
+    setup_ready_reporter();
 
     // Keep the window title on the document being read
     use_effect(move || {

--- a/crates/arto/src/components/app/ready_reporter.rs
+++ b/crates/arto/src/components/app/ready_reporter.rs
@@ -1,0 +1,131 @@
+use arto_ipc::ReadySignal;
+use dioxus::desktop::tao::window::WindowId;
+use dioxus::desktop::window;
+use dioxus::document;
+use dioxus::prelude::*;
+use tokio::sync::broadcast::error::RecvError;
+
+use crate::events::REPORT_READY_IN_WINDOW;
+use crate::ipc::ready;
+
+/// How long this window will wait for the page to say it has drawn.
+///
+/// Only a backstop. The waiting launch has a longer bound of its own, so
+/// giving up here answers it a little early rather than leaving it to time
+/// out — which is the better of the two, because the request was applied
+/// either way and the launch should hear so.
+const DRAW_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
+
+/// Answer the launches that are waiting for this window to draw.
+///
+/// Two ways a window comes to owe an answer, and both are handled here. A
+/// window created to satisfy a request claims what was parked for it as it
+/// mounts, because nothing else could have been meant. A window that was
+/// already open is told over [`REPORT_READY_IN_WINDOW`], since a request
+/// that only moved or repainted it leaves nothing for it to notice.
+pub(super) fn setup_ready_reporter() {
+    use_future(move || async move {
+        let window_id = window().id();
+
+        // Subscribed before anything is awaited, because a broadcast reaches
+        // only the receivers that already exist: a request arriving while
+        // this window is drawing would otherwise be announced to nobody and
+        // sit in the registry until the window closed.
+        let mut rx = REPORT_READY_IN_WINDOW.subscribe();
+
+        let claimed = ready::claim_new_window();
+        if !claimed.is_empty() {
+            report_once_drawn(window_id, claimed).await;
+        }
+
+        loop {
+            match rx.recv().await {
+                Ok(target) if target == window_id => report_pending(window_id).await,
+                Ok(_) => {}
+                // Falling behind loses messages, not requests: what is
+                // waiting lives in the registry, and the message is only a
+                // nudge to go and look. So look, and keep listening — the
+                // alternative is a window that never answers again.
+                Err(RecvError::Lagged(missed)) => {
+                    tracing::debug!(
+                        ?window_id,
+                        missed,
+                        "Missed ready notifications; checking the registry instead"
+                    );
+                    report_pending(window_id).await;
+                }
+                Err(RecvError::Closed) => break,
+            }
+        }
+    });
+
+    // A window that closes before it draws still owes an answer, and the
+    // honest one is "no window" rather than silence until the launch's own
+    // wait runs out.
+    use_drop(move || ready::forget_window(window().id()));
+}
+
+async fn report_pending(window_id: WindowId) {
+    let pending = ready::take_pending(window_id);
+    if !pending.is_empty() {
+        report_once_drawn(window_id, pending).await;
+    }
+}
+
+/// Wait for the page to finish drawing, then release `signals`.
+///
+/// The signals are held here rather than left in the registry so that a
+/// request arriving mid-draw is not answered by a draw it never asked for.
+/// Holding them also means a window torn down while this runs drops them,
+/// which releases the launches rather than stranding them.
+async fn report_once_drawn(window_id: WindowId, signals: Vec<ReadySignal>) {
+    let drawn = document::eval(indoc::indoc! {r#"
+        (async () => {
+            // The renderer bundle arrives after the first frame, and a cold
+            // start can be a second or two behind this.
+            for (let attempt = 0; attempt < 100; attempt++) {
+                if (window.Arto?.render?.onComplete) break;
+                await new Promise(r => setTimeout(r, 50));
+            }
+            if (!window.Arto?.render?.onComplete) {
+                dioxus.send(false);
+                return;
+            }
+            // A callback fires on the next batch render, and a batch render
+            // happens when the document changes. Asking for one is what
+            // makes this answer a document that is already settled — a
+            // window that was only moved, or one showing the welcome page.
+            await new Promise(resolve => {
+                window.Arto.render.onComplete(resolve);
+                window.Arto.render.schedule();
+            });
+            dioxus.send(true);
+        })();
+    "#});
+
+    let answered = tokio::time::timeout(DRAW_TIMEOUT, async move {
+        let mut drawn = drawn;
+        drawn.recv::<bool>().await
+    })
+    .await;
+
+    match answered {
+        Ok(Ok(true)) => tracing::debug!(?window_id, "Window drew; releasing the waiting launches"),
+        Ok(Ok(false)) => tracing::warn!(
+            ?window_id,
+            "Renderer never appeared; releasing the waiting launches anyway"
+        ),
+        Ok(Err(error)) => tracing::warn!(
+            ?window_id,
+            %error,
+            "Could not ask the page whether it had drawn; releasing the waiting launches anyway"
+        ),
+        Err(_) => tracing::warn!(
+            ?window_id,
+            "Window did not report a draw in time; releasing the waiting launches anyway"
+        ),
+    }
+    for signal in signals {
+        signal.fire();
+    }
+}

--- a/crates/arto/src/components/main_app.rs
+++ b/crates/arto/src/components/main_app.rs
@@ -91,15 +91,29 @@ pub fn MainApp() -> Element {
         _ => (Document::default(), Vec::new(), None),
     };
 
+    // What the launch asked of the window itself. The geometry was applied
+    // when the window was built (see `run`); the theme is a prop, so it is
+    // applied here — and the two have to agree, because the custom index was
+    // already written in the theme the launch named.
+    let window_options = match &first_event {
+        Some(OpenEvent::Open(request)) => request.window,
+        Some(OpenEvent::Reopen { window, .. }) => *window,
+        None => Default::default(),
+    };
+
     // Everything after the first path, once — a launch naming several files is
     // a request for several windows, and dropping them would lose what the
     // command line asked for.
     use_hook(move || {
+        // The theme carries to every window of one launch; the geometry does
+        // not, having named one place. See `WindowOptions::without_geometry`.
+        let inherited = window_options.without_geometry();
         for path in rest {
             crate::window::create_main_window_sync(
                 &window(),
                 Document::new(path),
-                crate::window::CreateMainWindowConfigParams::default(),
+                crate::window::CreateMainWindowConfigParams::default()
+                    .with_window_options(&inherited),
             );
         }
     });
@@ -144,7 +158,7 @@ pub fn MainApp() -> Element {
         crate::components::app::App {
             document: document,
             temps: temps,
-            theme: theme_pref.theme,
+            theme: window_options.theme.unwrap_or(theme_pref.theme),
             content_full_width,
             sidebar_pinned: sidebar_pref.pinned,
             sidebar_width: sidebar_pref.width,

--- a/crates/arto/src/events.rs
+++ b/crates/arto/src/events.rs
@@ -2,6 +2,7 @@
 //!
 //! This module provides broadcast channels for cross-window communication:
 //! - Preferences acting on the window that opened it
+//! - A launch waiting to be told the window it reached has drawn
 
 use dioxus::desktop::tao::window::WindowId;
 use tokio::sync::broadcast;
@@ -22,4 +23,18 @@ pub static SET_SIDEBAR_ZOOM_IN_WINDOW: std::sync::LazyLock<broadcast::Sender<(Wi
 ///
 /// The counterpart of [`SET_SIDEBAR_ZOOM_IN_WINDOW`] for the page itself.
 pub static SET_CONTENT_ZOOM_IN_WINDOW: std::sync::LazyLock<broadcast::Sender<(WindowId, f64)>> =
+    std::sync::LazyLock::new(|| broadcast::channel(10).0);
+
+// ============================================================================
+// Readiness
+// ============================================================================
+
+/// Ask one window to report once it has next finished drawing.
+///
+/// Sent when a request from `arto --wait-ready` lands in a window that was
+/// already open, because such a window has no reason to notice on its own
+/// that anything is now waiting on it. A window created *for* the request
+/// needs no event: it claims what is waiting as it mounts (see
+/// [`crate::ipc::ready`]).
+pub static REPORT_READY_IN_WINDOW: std::sync::LazyLock<broadcast::Sender<WindowId>> =
     std::sync::LazyLock::new(|| broadcast::channel(10).0);

--- a/crates/arto/src/ipc.rs
+++ b/crates/arto/src/ipc.rs
@@ -23,6 +23,7 @@
 //! ```
 
 mod queue;
+pub mod ready;
 mod request;
 mod window_selection;
 
@@ -34,6 +35,7 @@ pub use queue::*;
 pub use request::*;
 
 use crate::cli::CliInvocation;
+use dioxus::desktop::tao::window::WindowId;
 use queue::{drain_events, SHUTDOWN_REQUESTED, SHUTDOWN_SIGNAL, SHUTDOWN_STARTED};
 use std::sync::atomic::Ordering;
 use window_selection::{select_target_window, select_target_window_with_behavior};
@@ -46,7 +48,7 @@ use window_selection::{select_target_window, select_target_window_with_behavior}
 /// site has to remember that rule.
 pub fn try_send_to_existing_instance(invocation: &CliInvocation) -> SendResult {
     let event = open_event_for_invocation(invocation);
-    match arto_ipc::send_to_existing_instance(&event) {
+    match arto_ipc::send_to_existing_instance(&event, invocation.wait_ready) {
         SendResult::Failed(error) => {
             tracing::warn!(%error, "Failed to send to the primary instance; becoming primary");
             SendResult::NoExistingInstance
@@ -95,9 +97,16 @@ pub fn start_ipc_server() {
         };
         tracing::info!(socket_path = ?server.socket_path(), "IPC server ready for connections");
 
-        server.serve(|events| {
-            for event in events {
-                push_event(event);
+        server.serve(|events, ready| {
+            // One connection, one waiting launch, and it sends one message —
+            // so the signal goes to the last event, which is that message.
+            let mut ready = ready;
+            let last = events.len().saturating_sub(1);
+            for (index, event) in events.into_iter().enumerate() {
+                push_queued_event(QueuedEvent {
+                    event,
+                    ready: if index == last { ready.take() } else { None },
+                });
             }
             // Wake main thread once per client connection.
             wake_main_thread();
@@ -219,16 +228,21 @@ fn process_shutdown_request() {
 /// Handle a single event by creating/showing windows. Runs on main thread.
 fn handle_event_on_main_thread(
     desktop: &std::rc::Rc<dioxus::desktop::DesktopService>,
-    event: OpenEvent,
+    queued: QueuedEvent,
 ) {
+    let QueuedEvent { event, ready } = queued;
     match event {
         OpenEvent::Open(request) => {
             tracing::debug!(?request, "Processing open request event");
-            open_request_with_behavior(desktop, request);
+            open_request_with_behavior(desktop, request, ready);
         }
-        OpenEvent::Reopen { behavior, behind } => {
-            tracing::debug!(?behavior, behind, "Processing reopen event");
-            reopen_with_behavior(desktop, behavior, behind);
+        OpenEvent::Reopen {
+            behavior,
+            behind,
+            window,
+        } => {
+            tracing::debug!(?behavior, behind, ?window, "Processing reopen event");
+            reopen_with_behavior(desktop, behavior, behind, window, ready);
         }
     }
 }
@@ -236,6 +250,7 @@ fn handle_event_on_main_thread(
 fn open_request_with_behavior(
     desktop: &std::rc::Rc<dioxus::desktop::DesktopService>,
     request: OpenRequest,
+    ready: Option<arto_ipc::ReadySignal>,
 ) {
     let behavior = request
         .behavior
@@ -244,9 +259,11 @@ fn open_request_with_behavior(
     if let Some(window_id) = select_target_window_with_behavior(behavior) {
         if let Some(mut state) = crate::window::main::get_window_state(window_id) {
             apply_open_request_to_state(desktop, &mut state, &request);
+            crate::window::apply_window_options(window_id, &request.window);
             if !request.behind {
                 let _ = crate::window::main::focus_window(window_id);
             }
+            watch_existing_window(window_id, ready);
             return;
         }
     }
@@ -255,15 +272,40 @@ fn open_request_with_behavior(
         directory: request.directory,
         focused: !request.behind,
         ..Default::default()
-    };
+    }
+    .with_window_options(&request.window);
 
     let mut files = request.files.iter();
     let first = files
         .next()
         .map(crate::state::Document::new)
         .unwrap_or_default();
+    watch_new_window(ready);
     crate::window::create_main_window_sync(desktop, first, params);
-    open_each_in_its_own_window(desktop, files);
+    open_each_in_its_own_window(desktop, files, &request.window);
+}
+
+/// Hold the launch until `window_id` next finishes drawing.
+///
+/// The window is already open and has no reason to notice that anything now
+/// waits on it, so it is told.
+fn watch_existing_window(window_id: WindowId, ready: Option<arto_ipc::ReadySignal>) {
+    let Some(ready) = ready else {
+        return;
+    };
+    ready::await_window(window_id, ready);
+    let _ = crate::events::REPORT_READY_IN_WINDOW.send(window_id);
+}
+
+/// Hold the launch until the window about to be created finishes drawing.
+///
+/// Must be called before the window is asked for: the window claims what is
+/// waiting as it mounts, and a signal parked afterwards would be claimed by
+/// nothing until some later window happened to appear.
+fn watch_new_window(ready: Option<arto_ipc::ReadySignal>) {
+    if let Some(ready) = ready {
+        ready::await_new_window(ready);
+    }
 }
 
 fn apply_open_request_to_state(
@@ -278,22 +320,26 @@ fn apply_open_request_to_state(
     if let Some(first) = files.next() {
         state.open_file(first);
     }
-    open_each_in_its_own_window(desktop, files);
+    open_each_in_its_own_window(desktop, files, &request.window);
 }
 
 /// Give every remaining file a window of its own.
 ///
 /// A window reads one document, so a request naming several is a request for
-/// several windows; sending them all to one would leave only the last.
+/// several windows; sending them all to one would leave only the last. They
+/// inherit what the launch asked for minus the geometry, which named one
+/// place — see [`arto_ipc::WindowOptions::without_geometry`].
 fn open_each_in_its_own_window<'a>(
     desktop: &std::rc::Rc<dioxus::desktop::DesktopService>,
     files: impl Iterator<Item = &'a std::path::PathBuf>,
+    window: &arto_ipc::WindowOptions,
 ) {
+    let inherited = window.without_geometry();
     for path in files {
         crate::window::create_main_window_sync(
             desktop,
             crate::state::Document::new(path),
-            crate::window::CreateMainWindowConfigParams::default(),
+            crate::window::CreateMainWindowConfigParams::default().with_window_options(&inherited),
         );
     }
 }
@@ -302,12 +348,31 @@ fn reopen_with_behavior(
     desktop: &std::rc::Rc<dioxus::desktop::DesktopService>,
     behavior: Option<crate::config::FileOpenBehavior>,
     behind: bool,
+    window: arto_ipc::WindowOptions,
+    ready: Option<arto_ipc::ReadySignal>,
 ) {
     // A reopen asks for the app to come forward, which is the one thing
     // `--behind` refuses to do: every window, visible or hidden, is left
-    // exactly as it is. Events are only dispatched once a window exists, so
-    // there is never one to create here either.
-    if behind {
+    // exactly as it is — unless it also asked for a geometry or a theme,
+    // which is a request to change a window rather than to look at it, and
+    // is carried out below without anything being brought forward.
+    if behind && window.is_empty() {
+        return;
+    }
+
+    // `new_window` means a window of its own whether or not any path was
+    // named. Asking the selector would answer `None` here — the same answer
+    // it gives when no window is suitable — and the fallbacks below would
+    // then raise an existing window instead, which is the opposite of what
+    // was asked for.
+    if behavior == Some(crate::config::FileOpenBehavior::NewWindow) {
+        let params = crate::window::CreateMainWindowConfigParams {
+            focused: !behind,
+            ..Default::default()
+        }
+        .with_window_options(&window);
+        watch_new_window(ready);
+        crate::window::create_main_window_sync(desktop, crate::state::Document::default(), params);
         return;
     }
 
@@ -318,22 +383,40 @@ fn reopen_with_behavior(
 
     // First try to focus an existing visible window
     if let Some(window_id) = target_window {
-        if crate::window::main::focus_window(window_id) {
+        crate::window::apply_window_options(window_id, &window);
+        if behind || crate::window::main::focus_window(window_id) {
+            watch_existing_window(window_id, ready);
             return;
         }
     }
 
+    // Nothing visible to act on, and `--behind` is the promise not to make
+    // something appear: raising the hidden window would put the app in front
+    // of whatever the user is working in, and creating one would leave them
+    // with a window they never asked to see.
+    if behind {
+        tracing::debug!(
+            "Nothing visible to apply a --behind request to; leaving every window as it is"
+        );
+        return;
+    }
+
     // If no visible windows, try to show and focus a hidden window (e.g., MainApp with WindowHides)
     if crate::window::main::show_and_focus_hidden_window() {
+        // The window that came back is the one the request is for, and it is
+        // the one now focused.
+        if let Some(window_id) = crate::window::main::get_last_focused_window() {
+            crate::window::apply_window_options(window_id, &window);
+            watch_existing_window(window_id, ready);
+        }
         return;
     }
 
     // If no windows at all, create a new one
-    crate::window::create_main_window_sync(
-        desktop,
-        crate::state::Document::default(),
-        crate::window::CreateMainWindowConfigParams::default(),
-    );
+    let params =
+        crate::window::CreateMainWindowConfigParams::default().with_window_options(&window);
+    watch_new_window(ready);
+    crate::window::create_main_window_sync(desktop, crate::state::Document::default(), params);
 }
 
 #[cfg(test)]
@@ -356,16 +439,19 @@ mod tests {
             directory: None,
             behavior: None,
             behind: false,
+            window: Default::default(),
         }));
         push_event(OpenEvent::Open(OpenRequest {
             files: Vec::new(),
             directory: Some(PathBuf::from("/second")),
             behavior: None,
             behind: false,
+            window: Default::default(),
         }));
         push_event(OpenEvent::Reopen {
             behavior: None,
             behind: false,
+            window: Default::default(),
         });
 
         // try_pop_first_event returns FIFO order
@@ -380,15 +466,16 @@ mod tests {
         let remaining = drain_events();
         assert_eq!(remaining.len(), 2);
         assert!(matches!(
-            &remaining[0],
+            &remaining[0].event,
             OpenEvent::Open(OpenRequest { files, directory: Some(directory), .. })
             if files.is_empty() && directory == Path::new("/second")
         ));
         assert!(matches!(
-            &remaining[1],
+            &remaining[1].event,
             OpenEvent::Reopen {
                 behavior: None,
-                behind: false
+                behind: false,
+                ..
             }
         ));
 

--- a/crates/arto/src/ipc/queue.rs
+++ b/crates/arto/src/ipc/queue.rs
@@ -3,6 +3,7 @@
 //! signal sets for the main thread to act on.
 
 use super::OpenEvent;
+use arto_ipc::ReadySignal;
 use parking_lot::Mutex;
 use std::collections::VecDeque;
 #[cfg(unix)]
@@ -24,13 +25,23 @@ use std::sync::OnceLock;
 /// operations are infallible — there is no recovery strategy for a poisoned
 /// mutex, and panicking while holding the lock indicates a bug, not a state
 /// that other threads should reason about.
-static IPC_EVENT_QUEUE: OnceLock<Mutex<VecDeque<OpenEvent>>> = OnceLock::new();
+static IPC_EVENT_QUEUE: OnceLock<Mutex<VecDeque<QueuedEvent>>> = OnceLock::new();
 pub(super) static SHUTDOWN_REQUESTED: AtomicBool = AtomicBool::new(false);
 pub(super) static SHUTDOWN_STARTED: AtomicBool = AtomicBool::new(false);
 pub(super) static SHUTDOWN_SIGNAL: AtomicI32 = AtomicI32::new(0);
 
-fn get_event_queue() -> &'static Mutex<VecDeque<OpenEvent>> {
+fn get_event_queue() -> &'static Mutex<VecDeque<QueuedEvent>> {
     IPC_EVENT_QUEUE.get_or_init(|| Mutex::new(VecDeque::new()))
+}
+
+/// An event on its way to the main thread, and the launch waiting on it.
+///
+/// The signal rides beside the event rather than inside it because waiting
+/// is the sending connection's business: the same event means the same thing
+/// whether or not anyone is holding a socket open for it.
+pub struct QueuedEvent {
+    pub event: OpenEvent,
+    pub ready: Option<ReadySignal>,
 }
 
 /// Register signal handlers for clean socket cleanup.
@@ -128,15 +139,31 @@ fn request_shutdown(signal: i32) {
 
 /// Push an event to the IPC queue. Thread-safe.
 pub fn push_event(event: OpenEvent) {
-    get_event_queue().lock().push_back(event);
+    push_queued_event(QueuedEvent { event, ready: None });
+}
+
+/// Push an event together with the launch waiting for its window.
+pub fn push_queued_event(queued: QueuedEvent) {
+    get_event_queue().lock().push_back(queued);
 }
 
 /// Pop the first event from the queue (for initial event in MainApp).
+///
+/// Normally this is what the launch itself asked for and nothing waits on
+/// it. But the IPC server starts listening before the launch queues its own
+/// event, so a second launch can slip in ahead of it and have its request
+/// become the first window's. That launch is waiting, so its signal is
+/// parked for the window this event is about to build rather than dropped —
+/// dropping it would answer a request that had in fact been carried out.
 pub fn try_pop_first_event() -> Option<OpenEvent> {
-    get_event_queue().lock().pop_front()
+    let queued = get_event_queue().lock().pop_front()?;
+    if let Some(signal) = queued.ready {
+        super::ready::await_new_window(signal);
+    }
+    Some(queued.event)
 }
 
 /// Drain all pending events from the IPC queue.
-pub(super) fn drain_events() -> VecDeque<OpenEvent> {
+pub(super) fn drain_events() -> VecDeque<QueuedEvent> {
     std::mem::take(&mut *get_event_queue().lock())
 }

--- a/crates/arto/src/ipc/ready.rs
+++ b/crates/arto/src/ipc/ready.rs
@@ -1,0 +1,83 @@
+//! Telling a launch that asked to wait that its window has drawn.
+//!
+//! `arto --wait-ready` exists so a script does not have to guess how long a
+//! document takes to appear. The launch holds its socket open and the
+//! primary answers it here, once — and only once — the window that took the
+//! request has finished drawing.
+//!
+//! Which window that is depends on what the request did. A request that
+//! landed in a window already open names it, and [`await_window`] binds the
+//! signal to that id. A request that created one cannot: window creation is
+//! fire-and-forget, so the id does not exist yet when the request is
+//! applied. [`await_new_window`] parks the signal instead and the first main
+//! window to mount claims it.
+//!
+//! That is the window the request asked for, except in the one case where a
+//! single launch asks for several — `arto --wait-ready a.md b.md`, which
+//! gives each file a window of its own. The answer then comes from whichever
+//! of them drew first rather than from all of them, which is the reading of
+//! "ready" that a launch naming several files can be given without waiting
+//! on the slowest.
+//!
+//! A window takes its signals *out* of here before it starts watching for a
+//! draw, so what it finally fires is what was waiting when the draw was
+//! asked for. A request that arrives while the window is already drawing is
+//! left in the registry for the round after, because the draw in progress is
+//! not the one it asked about.
+//!
+//! A signal that is dropped rather than fired releases the launch too, so a
+//! window that closes — or is torn down mid-draw — strands nothing.
+
+use arto_ipc::ReadySignal;
+use dioxus::desktop::tao::window::WindowId;
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
+/// Signals whose window is already open.
+static AWAITING_WINDOW: LazyLock<Mutex<HashMap<WindowId, Vec<ReadySignal>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Signals whose window has been asked for but does not exist yet.
+static AWAITING_NEW_WINDOW: LazyLock<Mutex<Vec<ReadySignal>>> =
+    LazyLock::new(|| Mutex::new(Vec::new()));
+
+/// Answer this signal when `window_id` next finishes drawing.
+pub fn await_window(window_id: WindowId, signal: ReadySignal) {
+    AWAITING_WINDOW
+        .lock()
+        .entry(window_id)
+        .or_default()
+        .push(signal);
+}
+
+/// Answer this signal when the window that is about to be created draws.
+pub fn await_new_window(signal: ReadySignal) {
+    AWAITING_NEW_WINDOW.lock().push(signal);
+}
+
+/// Take over every signal parked for a window that did not exist yet.
+///
+/// Called by a main window as it mounts. What comes back is the window's to
+/// answer — or to drop, which answers it too.
+pub fn claim_new_window() -> Vec<ReadySignal> {
+    std::mem::take(&mut *AWAITING_NEW_WINDOW.lock())
+}
+
+/// Take every signal currently waiting on this window.
+pub fn take_pending(window_id: WindowId) -> Vec<ReadySignal> {
+    AWAITING_WINDOW
+        .lock()
+        .remove(&window_id)
+        .unwrap_or_default()
+}
+
+/// Drop every signal still bound to a window that is going away.
+///
+/// Dropping is the honest answer: the window will never draw, and a launch
+/// released now beats one held until its own timeout runs out.
+pub fn forget_window(window_id: WindowId) {
+    if AWAITING_WINDOW.lock().remove(&window_id).is_some() {
+        tracing::debug!(?window_id, "Window closed before it reported ready");
+    }
+}

--- a/crates/arto/src/ipc/request.rs
+++ b/crates/arto/src/ipc/request.rs
@@ -11,12 +11,17 @@ use std::path::Path;
 
 /// The event a CLI invocation asks for: an open request when it names any
 /// valid file or directory, otherwise a plain reopen.
+///
+/// A reopen still carries the geometry and theme, because naming no path is
+/// how a window is asked for *as a window* — placed, sized, and pinned to a
+/// theme, with whatever it was already reading left in it.
 pub fn open_event_for_invocation(invocation: &CliInvocation) -> OpenEvent {
     match build_open_request(invocation) {
         Some(request) => OpenEvent::Open(request),
         None => OpenEvent::Reopen {
             behavior: invocation.open_mode.to_file_open_behavior(),
             behind: invocation.behind,
+            window: invocation.window,
         },
     }
 }
@@ -56,6 +61,7 @@ pub fn build_open_request(invocation: &CliInvocation) -> Option<OpenRequest> {
         directory,
         behavior: invocation.open_mode.to_file_open_behavior(),
         behind: invocation.behind,
+        window: invocation.window,
     })
 }
 
@@ -70,12 +76,14 @@ pub fn validate_path(path: impl AsRef<Path>) -> Option<OpenEvent> {
             directory: None,
             behavior: None,
             behind: false,
+            window: Default::default(),
         })),
         Some(PathKind::Directory(canonical)) => Some(OpenEvent::Open(OpenRequest {
             files: Vec::new(),
             directory: Some(canonical),
             behavior: None,
             behind: false,
+            window: Default::default(),
         })),
         None => {
             tracing::warn!(
@@ -120,6 +128,8 @@ mod tests {
             directory: None,
             open_mode: CliOpenMode::LastFocused,
             behind: false,
+            window: Default::default(),
+            wait_ready: false,
         };
 
         let request = build_open_request(&invocation).unwrap();
@@ -141,6 +151,8 @@ mod tests {
             directory: Some(option_directory.clone()),
             open_mode: CliOpenMode::LastFocused,
             behind: false,
+            window: Default::default(),
+            wait_ready: false,
         };
 
         let request = build_open_request(&invocation).unwrap();
@@ -162,6 +174,8 @@ mod tests {
             directory: None,
             open_mode: CliOpenMode::CurrentScreen,
             behind: false,
+            window: Default::default(),
+            wait_ready: false,
         };
 
         let request = build_open_request(&invocation).unwrap();
@@ -179,6 +193,8 @@ mod tests {
             directory: None,
             open_mode: CliOpenMode::Config,
             behind: true,
+            window: Default::default(),
+            wait_ready: false,
         };
 
         let request = build_open_request(&invocation).unwrap();
@@ -192,6 +208,8 @@ mod tests {
             directory: None,
             open_mode: CliOpenMode::Config,
             behind: true,
+            window: Default::default(),
+            wait_ready: false,
         };
 
         assert_eq!(
@@ -199,6 +217,7 @@ mod tests {
             OpenEvent::Reopen {
                 behavior: None,
                 behind: true,
+                window: Default::default(),
             }
         );
     }
@@ -214,6 +233,8 @@ mod tests {
             directory: None,
             open_mode: CliOpenMode::Config,
             behind: false,
+            window: Default::default(),
+            wait_ready: false,
         };
 
         let request = build_open_request(&invocation).unwrap();
@@ -227,6 +248,8 @@ mod tests {
             directory: None,
             open_mode: CliOpenMode::NewWindow,
             behind: false,
+            window: Default::default(),
+            wait_ready: false,
         };
 
         assert_eq!(
@@ -234,6 +257,7 @@ mod tests {
             OpenEvent::Reopen {
                 behavior: Some(FileOpenBehavior::NewWindow),
                 behind: false,
+                window: Default::default(),
             }
         );
     }
@@ -242,5 +266,79 @@ mod tests {
     fn validate_path_rejects_missing_paths() {
         let temp = tempfile::tempdir().unwrap();
         assert!(validate_path(temp.path().join("missing.md")).is_none());
+    }
+
+    /// What `--position=120,64 --size=1400,920 --theme=light` amounts to.
+    fn geometry_and_theme() -> arto_ipc::WindowOptions {
+        arto_ipc::WindowOptions {
+            position: Some(arto_ipc::WindowPoint { x: 120, y: 64 }),
+            size: Some(arto_ipc::WindowExtent {
+                width: 1400,
+                height: 920,
+            }),
+            theme: Some(crate::config::Theme::Light),
+        }
+    }
+
+    #[test]
+    fn an_open_request_carries_the_geometry_and_theme() {
+        let temp = tempfile::tempdir().unwrap();
+        let file = temp.path().join("README.md");
+        std::fs::write(&file, "# test").unwrap();
+
+        let invocation = CliInvocation {
+            paths: vec![file],
+            directory: None,
+            open_mode: CliOpenMode::Config,
+            behind: false,
+            window: geometry_and_theme(),
+            wait_ready: false,
+        };
+
+        assert_eq!(
+            build_open_request(&invocation).unwrap().window,
+            geometry_and_theme()
+        );
+    }
+
+    #[test]
+    fn naming_no_path_still_asks_for_the_window() {
+        // `arto --open=new --position=80,64` is a request for a window, not
+        // for a document, and the window half has to survive having nothing
+        // to read.
+        let invocation = CliInvocation {
+            paths: Vec::new(),
+            directory: None,
+            open_mode: CliOpenMode::NewWindow,
+            behind: false,
+            window: geometry_and_theme(),
+            wait_ready: false,
+        };
+
+        assert_eq!(
+            open_event_for_invocation(&invocation),
+            OpenEvent::Reopen {
+                behavior: Some(FileOpenBehavior::NewWindow),
+                behind: false,
+                window: geometry_and_theme(),
+            }
+        );
+    }
+
+    #[test]
+    fn an_invocation_that_asks_for_no_window_carries_none() {
+        let invocation = CliInvocation {
+            paths: Vec::new(),
+            directory: None,
+            open_mode: CliOpenMode::Config,
+            behind: false,
+            window: Default::default(),
+            wait_ready: false,
+        };
+
+        let OpenEvent::Reopen { window, .. } = open_event_for_invocation(&invocation) else {
+            panic!("a pathless invocation is a reopen");
+        };
+        assert!(window.is_empty());
     }
 }

--- a/crates/arto/src/lib.rs
+++ b/crates/arto/src/lib.rs
@@ -60,19 +60,29 @@ pub fn run(invocation: cli::CliInvocation) -> RunResult {
     ipc::start_ipc_server();
 
     // Push CLI request to IPC event queue (MainApp will pop and apply it as initial state)
+    //
+    // A launch naming no path queues nothing, and the window opens on the
+    // welcome page — unless it asked for a geometry or a theme, which the
+    // first window has to be told about, and the event is how it is told.
     if let Some(request) = ipc::build_open_request(&invocation) {
         let event = ipc::OpenEvent::Open(request);
         tracing::debug!(?event, "Pushing CLI request to IPC event queue");
+        ipc::push_event(event);
+    } else if !invocation.window.is_empty() {
+        let event = ipc::open_event_for_invocation(&invocation);
+        tracing::debug!(?event, "Pushing CLI window options to IPC event queue");
         ipc::push_event(event);
     }
 
     // let menu = menu::build_menu();
 
-    // Get window parameters for first window from preferences
+    // Get window parameters for first window from preferences, with anything
+    // this launch asked for laid over them.
     let params = window::CreateMainWindowConfigParams {
         focused: !invocation.behind,
         ..window::CreateMainWindowConfigParams::from_preferences(true)
-    };
+    }
+    .with_window_options(&invocation.window);
 
     let config = window::create_main_window_config(&params).with_custom_event_handler(
         move |event, _target| {
@@ -104,6 +114,7 @@ pub fn run(invocation: cli::CliInvocation) -> RunResult {
                     ipc::push_event(ipc::OpenEvent::Reopen {
                         behavior: None,
                         behind: false,
+                        window: Default::default(),
                     });
                     ipc::process_main_thread_tasks();
                 }

--- a/crates/arto/src/main.rs
+++ b/crates/arto/src/main.rs
@@ -1,4 +1,5 @@
-use arto::cli::{CliInvocation, CliOpenMode};
+use arto::cli::{parse_position, parse_size, CliInvocation, CliOpenMode};
+use arto_ipc::{WindowExtent, WindowOptions, WindowPoint};
 use clap::{Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;
 
@@ -17,6 +18,26 @@ enum OpenModeArg {
     New,
 }
 
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum ThemeArg {
+    /// Always light, whatever the system is set to
+    Light,
+    /// Always dark, whatever the system is set to
+    Dark,
+    /// Follow the system appearance
+    System,
+}
+
+impl From<ThemeArg> for arto_config::Theme {
+    fn from(arg: ThemeArg) -> Self {
+        match arg {
+            ThemeArg::Light => Self::Light,
+            ThemeArg::Dark => Self::Dark,
+            ThemeArg::System => Self::Auto,
+        }
+    }
+}
+
 /// Arto — the Art of Reading Markdown
 #[derive(Parser, Debug)]
 #[command(
@@ -26,7 +47,11 @@ enum OpenModeArg {
         A local app that faithfully recreates GitHub-style Markdown rendering\n\
         for a beautiful reading experience.\n\n\
         Arto runs as a single instance — if already running, paths are sent\n\
-        to the existing process instead of launching a new one.",
+        to the existing process instead of launching a new one.\n\n\
+        --position, --size and --theme apply to the window --open selects,\n\
+        whether that window is reused or created, and whether or not any\n\
+        paths were named; --wait-ready then holds the command until that\n\
+        window has drawn what it was given.",
     after_long_help = "Examples:\n\
         \x20 arto                     Launch Arto (shows welcome screen)\n\
         \x20 arto README.md           Open a specific file\n\
@@ -34,6 +59,9 @@ enum OpenModeArg {
         \x20 arto --open=new README.md\n\
         \x20 arto --behind README.md  Open without taking the focus\n\
         \x20 arto --directory=. README.md\n\
+        \x20 arto --position=120,120 --size=1400,920 README.md\n\
+        \x20 arto --theme=light --wait-ready README.md\n\
+        \x20 arto --open=new --position=80,64 --size=1400,920 --theme=dark --wait-ready\n\
         \x20 arto docs/               Open a directory in the file explorer\n\
         \x20 arto file1.md file2.md   Open each file in its own window\n\
         \x20 arto page README.md      Print README.md as a self-contained HTML page",
@@ -54,6 +82,22 @@ struct Cli {
     /// Root directory for the file explorer sidebar
     #[arg(long)]
     directory: Option<PathBuf>,
+    /// Place the window at these screen coordinates, as X,Y
+    #[arg(long, value_name = "X,Y", value_parser = parse_position, allow_hyphen_values = true)]
+    position: Option<WindowPoint>,
+    /// Give the window this size, as WIDTH,HEIGHT
+    #[arg(long, value_name = "WIDTH,HEIGHT", value_parser = parse_size)]
+    size: Option<WindowExtent>,
+    /// Theme for this invocation, overriding the configured one
+    #[arg(long, value_enum)]
+    theme: Option<ThemeArg>,
+    /// Return only once the window has drawn the document.
+    ///
+    /// Applies when Arto is already running and this invocation hands its
+    /// request over. A launch that starts Arto itself becomes the app and
+    /// runs until it is quit, with or without this flag.
+    #[arg(long)]
+    wait_ready: bool,
     /// Files or directories to open
     #[arg()]
     paths: Vec<PathBuf>,
@@ -121,6 +165,12 @@ fn main() {
         directory: cli.directory,
         open_mode,
         behind: cli.behind,
+        window: WindowOptions {
+            position: cli.position,
+            size: cli.size,
+            theme: cli.theme.map(arto_config::Theme::from),
+        },
+        wait_ready: cli.wait_ready,
     };
 
     if let arto::RunResult::SentToExistingInstance = arto::run(invocation) {

--- a/crates/arto/src/window.rs
+++ b/crates/arto/src/window.rs
@@ -55,7 +55,8 @@ pub use child::{
 #[cfg(target_os = "macos")]
 pub use main::has_any_main_windows;
 pub use main::{
-    close_all_main_windows, create_main_window_config, create_main_window_sync,
-    get_any_main_window, register_main_window, register_window_state, shutdown_all_windows,
-    unregister_window_state, update_last_focused_window, CreateMainWindowConfigParams,
+    apply_window_options, close_all_main_windows, create_main_window_config,
+    create_main_window_sync, get_any_main_window, register_main_window, register_window_state,
+    shutdown_all_windows, unregister_window_state, update_last_focused_window,
+    CreateMainWindowConfigParams,
 };

--- a/crates/arto/src/window/main.rs
+++ b/crates/arto/src/window/main.rs
@@ -76,6 +76,14 @@ pub struct CreateMainWindowConfigParams {
     pub zoom_level: f64,
     pub size: LogicalSize<u32>,
     pub position: LogicalPosition<i32>,
+    /// Put the window exactly at `position`, rather than cascading it clear
+    /// of the windows already there.
+    ///
+    /// The cascade is a courtesy to a reader opening a second window by
+    /// hand; a position named on the command line is the whole point of
+    /// naming it, and moving the window "helpfully" off it would make the
+    /// option useless for placing a window for a screen capture.
+    pub exact_position: bool,
     /// Take the keyboard focus once the window exists. `arto --behind` clears
     /// it so the window can appear without interrupting what the user is doing.
     pub focused: bool,
@@ -105,8 +113,28 @@ impl CreateMainWindowConfigParams {
             zoom_level: zoom_pref.zoom_level,
             size: size_pref.size,
             position: position_pref.position,
+            exact_position: false,
             focused: true,
         }
+    }
+
+    /// Lay what a launch asked for over what the preferences answered.
+    ///
+    /// Only the fields the launch named are touched, so `--size` alone still
+    /// opens where the preferences say, and an invocation that names none of
+    /// them is the invocation that was there before these options existed.
+    pub fn with_window_options(mut self, options: &arto_ipc::WindowOptions) -> Self {
+        if let Some(position) = options.position {
+            self.position = LogicalPosition::new(position.x, position.y);
+            self.exact_position = true;
+        }
+        if let Some(size) = options.size {
+            self.size = LogicalSize::new(size.width, size.height);
+        }
+        if let Some(theme) = options.theme {
+            self.theme = theme;
+        }
+        self
     }
 }
 
@@ -272,6 +300,9 @@ pub(crate) fn resolve_directory(
 
 /// Compute the shifted position for a new window, avoiding overlap with existing windows.
 fn compute_shifted_position(params: &CreateMainWindowConfigParams) -> LogicalPosition<i32> {
+    if params.exact_position {
+        return params.position;
+    }
     let position_offset = CONFIG.read().window_position.position_offset;
     let (screen_origin, screen_size) = get_current_display_bounds()
         .unwrap_or_else(|| (LogicalPosition::new(0, 0), LogicalSize::new(1000, 800)));
@@ -367,6 +398,41 @@ pub fn get_any_main_window() -> Option<Rc<DesktopService>> {
 
 pub fn update_last_focused_window(window_id: WindowId) {
     LAST_FOCUSED_WINDOW.with(|last| *last.borrow_mut() = Some(window_id));
+}
+
+/// Move, resize and repaint a window that is already open.
+///
+/// The counterpart of [`CreateMainWindowConfigParams::with_window_options`]
+/// for the window a launch reuses rather than creates: the same options,
+/// applied to a window that already has a position, a size and a theme.
+/// Only what the launch named is touched.
+pub fn apply_window_options(window_id: WindowId, options: &arto_ipc::WindowOptions) {
+    if options.is_empty() {
+        return;
+    }
+
+    if let Some(context) = list_main_windows()
+        .into_iter()
+        .find(|context| context.window.id() == window_id)
+    {
+        if let Some(position) = options.position {
+            context
+                .window
+                .set_outer_position(LogicalPosition::new(position.x, position.y));
+        }
+        if let Some(size) = options.size {
+            context
+                .window
+                .set_inner_size(LogicalSize::new(size.width, size.height));
+        }
+    }
+
+    if let Some(theme) = options.theme {
+        if let Some(state) = get_window_state(window_id) {
+            let mut current_theme = state.current_theme;
+            current_theme.set(theme);
+        }
+    }
 }
 
 // ============================================================================
@@ -483,6 +549,75 @@ fn shift_position_if_needed(
 mod tests {
     use super::*;
     use dioxus::desktop::tao::dpi::{LogicalPosition, LogicalSize};
+
+    /// Params that name nothing, so a test can see exactly what an option
+    /// changed and what it left alone.
+    fn blank_params() -> CreateMainWindowConfigParams {
+        CreateMainWindowConfigParams {
+            directory: None,
+            temps: Vec::new(),
+            theme: Theme::Auto,
+            content_full_width: false,
+            sidebar_pinned: false,
+            sidebar_width: 280.0,
+            sidebar_show_all_files: false,
+            sidebar_zoom_level: 1.0,
+            zoom_level: 1.0,
+            size: LogicalSize::new(1000, 800),
+            position: LogicalPosition::new(50, 50),
+            exact_position: false,
+            focused: true,
+        }
+    }
+
+    #[test]
+    fn an_invocation_that_named_nothing_leaves_every_preference_alone() {
+        let params = blank_params().with_window_options(&arto_ipc::WindowOptions::default());
+        assert_eq!(params.position, LogicalPosition::new(50, 50));
+        assert_eq!(params.size, LogicalSize::new(1000, 800));
+        assert_eq!(params.theme, Theme::Auto);
+        assert!(!params.exact_position);
+    }
+
+    #[test]
+    fn each_option_replaces_only_its_own_preference() {
+        let params = blank_params().with_window_options(&arto_ipc::WindowOptions {
+            size: Some(arto_ipc::WindowExtent {
+                width: 1400,
+                height: 920,
+            }),
+            ..Default::default()
+        });
+        assert_eq!(params.size, LogicalSize::new(1400, 920));
+        // `--size` alone still opens where the preferences say.
+        assert_eq!(params.position, LogicalPosition::new(50, 50));
+        assert_eq!(params.theme, Theme::Auto);
+    }
+
+    #[test]
+    fn a_named_position_is_exact() {
+        let params = blank_params().with_window_options(&arto_ipc::WindowOptions {
+            position: Some(arto_ipc::WindowPoint { x: 120, y: 64 }),
+            ..Default::default()
+        });
+        assert_eq!(params.position, LogicalPosition::new(120, 64));
+        // The cascade that keeps hand-opened windows from stacking would
+        // undo the placement, which is the whole point of naming it.
+        assert!(params.exact_position);
+        assert_eq!(
+            compute_shifted_position(&params),
+            LogicalPosition::new(120, 64)
+        );
+    }
+
+    #[test]
+    fn a_named_theme_replaces_the_configured_one() {
+        let params = blank_params().with_window_options(&arto_ipc::WindowOptions {
+            theme: Some(Theme::Dark),
+            ..Default::default()
+        });
+        assert_eq!(params.theme, Theme::Dark);
+    }
 
     #[test]
     fn test_resolve_directory_none_when_no_config_and_no_file() {


### PR DESCRIPTION
## Summary

- `--position=X,Y`, `--size=W,H`, `--theme=<light|dark|system>` and `--wait-ready`, parsed in `cli.rs` (the pair parsing is pure and unit-tested) and declared in `main.rs`.
- The single-instance protocol carries a `window` object (position / size / theme, each optional) on both `open` and `reopen`, plus a `wait_ready` flag with a `{"type":"ready"}` / `{"type":"timeout"}` reply.
- `ipc/ready.rs` and `components/app/ready_reporter.rs` decide which window a waiting launch is waiting for, and release it when that window reports a completed render.
- `CreateMainWindowConfigParams::with_window_options` for a window being created, `window::apply_window_options` for one being reused.

## Why

Automating anything that involves a window — a screen capture, a demo, a scripted repro — meant AppleScript for the geometry and a fixed sleep for the timing. A sleep long enough to be safe is wrong every time, and Arto could already say what to open and where to root the tree but nothing about the window that opened it. These are the four things #147 lists, and they are the four an automation script cannot work around.

Two things needed fixing rather than adding along the way:

**`--open=new` with no path raised an existing window.** `select_target_window_with_behavior` answers `None` both for "make a new one" and for "nothing suitable was found", and the fallbacks below it read every `None` as the latter. The `NewWindow` case is now decided before the selector is asked.

**A named position was being cascaded away.** The offset that keeps hand-opened windows from stacking is a courtesy to a reader opening a second window; applied to a position a capture script named, it makes the option useless. `exact_position` marks the difference.

Where a launch names several files, each gets a window and all of them take the theme — the theme is how this invocation's windows should look — while the geometry stays on the first, because it names one place and a place holds one window (`WindowOptions::without_geometry`).

`--wait-ready` is the only part that changes the transport. The socket was written and forgotten; now a launch that asks to wait holds it open, and the primary stops reading at that message — such a client will not close the socket, since that is exactly what it is waiting on, so reading to EOF would deadlock the two against each other — applies what it has, and answers once the window reports a completed render (`window.Arto.render.onComplete`, with an explicit `schedule()` so a document that is already settled still answers).

The window options and the flag are both omitted from the wire format when nothing asked for them, so the line a plain launch writes is byte for byte the line it wrote before, and a primary from before this change reads it unchanged.

## Review

`/code-review high` raised eight findings; six were real and are fixed in this branch:

1. The `REPORT_READY_IN_WINDOW` subscription was created after the first draw wait, so a request arriving while a window was drawing was broadcast to nobody and sat until the launch timed out.
2. `report_drawn` fired every signal bound to a window, including one registered for a later request — releasing a launch before its own document had drawn, which is the single guarantee `--wait-ready` sells. Signals are now taken out of the registry before the draw is watched for.
3. `RecvError::Lagged` ended the listener loop permanently. It now re-reads the registry and keeps listening: what is waiting lives in the registry, and the message is only a nudge to go and look.
4. `--behind` carrying window options could create a stray window when nothing visible was open.
5. `arto --theme=dark a.md b.md` rendered `b.md` in the configured theme.
6. `try_pop_first_event` dropped a `ReadySignal` in the narrow window where the IPC server is listening before the primary queues its own event.

Two were accepted as-is: `--theme` persisting into `state.json` under `on_startup: last_closed` (a window opened dark *is* a dark window, and `--position` / `--size` behave the same way through `capture_window_metrics`), and `--wait-ready` being inert on a cold start (a launch that starts Arto becomes the app and holds the terminal with or without the flag — `--help` now says so).

## Test Plan

- [x] `just fmt check test` — clippy, oxlint, 386 + 20 + 35 workspace tests, 117 frontend tests
- [x] `arto --help`, and rejection of `--position=abc,1` and `--size=0,900`
- [ ] **Needs the app run**: geometry, resize, theme and the `--wait-ready` round trip against a running instance:

```
arto --position=120,120 --size=1400,920 --theme=light README.md
arto --open=new --position=80,64 --size=1000,700 --theme=dark
time arto --wait-ready README.md
```

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Em4jUTWMqsRB9rKP4R39yP

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/arto-app/codesmith/Arto/pr/294"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791811162&installation_model_id=435827&pr_number=294&repository=arto-app%2FArto&return_to=https%3A%2F%2Fgithub.com%2Farto-app%2FArto%2Fpull%2F294&signature=635432cdc7a98a470a63ad58335f409dcb9cfc13b55d7be34e8c91a681177f41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->