### PR TITLE
Let the app answer a request, not the connection thread

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,11 @@ jobs:
   # This job cannot make a crate that does not exist yet: crates.io only lets
   # a trusted publisher be configured on a crate that is already there, so
   # each name's first version was published by hand. See CONTRIBUTING.md.
+  #
+  # A renamed crate is a new name, and the registry does not learn it from
+  # the rename: it has to be claimed by hand before the release that would
+  # first publish it, or this job fails on a member it has no token for —
+  # after the members ahead of it have already gone out irrevocably.
   publish:
     needs: bundle
     runs-on: blacksmith-6vcpu-macos-15

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -205,6 +205,26 @@ it, and `0.0.0` is superseded by the first real version — which is also when
 the registry page starts showing the README, keywords and categories, since
 crates.io renders the latest version's metadata.
 
+### Renaming a crate
+
+A rename is a new name by these rules, and the registry does not learn it
+from the rename: nothing in git tells crates.io anything. Both halves have to
+be done by hand, **before** the release that would first publish the new
+name, or the `publish` job fails on a member it has no token for — after the
+members ahead of it in the dependency order have already gone out, which
+cannot be undone.
+
+1. Claim the new name exactly as above, excluding every member the registry
+   already carries.
+2. Add the trusted publisher for it.
+3. Decide what becomes of the old name. It cannot be deleted, so it either
+   stays as it is, is yanked, or gets one last version whose description
+   points at the new name. Leaving it alone leaves a crate on the registry
+   that still looks current.
+
+A grep of the working tree will not catch this: what needs changing is the
+state of the registry, not a file.
+
 [Trusted Publishing]: https://crates.io/docs/trusted-publishing
 
 ## Code Style

--- a/crates/arto-lsp/src/client.rs
+++ b/crates/arto-lsp/src/client.rs
@@ -47,6 +47,32 @@ pub enum SendResult {
 /// the point of waiting is to not have to guess how many.
 pub const READY_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// How long the instance gets to apply a request nobody is waiting on.
+///
+/// Only the main thread coming round, which is the next turn of the event
+/// loop unless something is very wrong — but "very wrong" includes a window
+/// busy drawing a large document, so it is not instant.
+pub const APPLY_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// What the instance's own deadline is extended by for the launch waiting
+/// on it.
+///
+/// The two clocks start within microseconds of each other, and the instance
+/// answers *at* its deadline — `ready: false`, or an error. Given the same
+/// bound, that answer would always arrive just after this end stopped
+/// listening, and every slow request would read as a vanished primary.
+const DEADLINE_MARGIN: Duration = Duration::from_secs(5);
+
+/// How long this launch listens for an answer.
+fn client_deadline(wait_ready: bool) -> Duration {
+    let theirs = if wait_ready {
+        READY_TIMEOUT
+    } else {
+        APPLY_TIMEOUT
+    };
+    theirs + DEADLINE_MARGIN
+}
+
 /// How much of the handshake got through before anything was asked for.
 ///
 /// Kept apart from [`SendResult`] because the two halves of a handoff fail
@@ -200,11 +226,13 @@ fn request(
         return SendResult::Failed(error);
     }
 
-    // The answer to this one can be a whole document being drawn away.
-    if wait_ready {
-        if let Err(error) = socket::set_socket_timeout(reader.get_mut(), client_ready_timeout()) {
-            tracing::debug!(%error, "Could not extend the IPC socket timeout for the ready wait");
-        }
+    // The answer to this one is the app's, not the connection thread's, so
+    // it takes as long as the app does — a whole document being drawn, when
+    // the launch asked to wait. Either way this end listens for longer than
+    // the instance is allowed to take, so the instance's own answer always
+    // arrives while somebody is still reading.
+    if let Err(error) = socket::set_socket_timeout(reader.get_mut(), client_deadline(wait_ready)) {
+        tracing::debug!(%error, "Could not set the IPC socket timeout for the answer");
     }
 
     match read_response(reader) {
@@ -226,18 +254,6 @@ fn request(
         },
         None => SendResult::Unanswered,
     }
-}
-
-/// How long the launch waits for an answer it was told to wait for.
-///
-/// Longer than the primary's own [`READY_TIMEOUT`], deliberately. The two
-/// start at nearly the same moment and the primary answers `ready: false`
-/// when its wait runs out; given the same bound, that answer would always
-/// arrive just after this end had stopped listening, and a launch would
-/// never learn the difference between "the window did not draw" and "the
-/// primary vanished".
-fn client_ready_timeout() -> Duration {
-    READY_TIMEOUT + Duration::from_secs(5)
 }
 
 fn invalid_data(message: impl std::fmt::Display) -> std::io::Error {
@@ -381,9 +397,10 @@ mod tests {
     }
 
     #[test]
-    fn the_launch_waits_longer_than_the_instance_it_is_waiting_on() {
-        // Given the same bound, the instance's own `ready: false` would
-        // always arrive just after this end stopped listening.
-        assert!(client_ready_timeout() > READY_TIMEOUT);
+    fn the_launch_always_waits_longer_than_the_instance_it_waits_on() {
+        // The instance answers *at* its own deadline; listening for exactly
+        // as long would miss that answer every time.
+        assert!(client_deadline(true) > READY_TIMEOUT);
+        assert!(client_deadline(false) > APPLY_TIMEOUT);
     }
 }

--- a/crates/arto-lsp/src/lib.rs
+++ b/crates/arto-lsp/src/lib.rs
@@ -16,7 +16,7 @@
 //! ```text
 //! 1st launch (primary):
 //!   send_to_existing_instance() → NoExistingInstance
-//!   Server::bind() → serve(|event, ready| ...)   accepts later launches
+//!   Server::bind() → serve(|call, responder| ...)  accepts later launches
 //!
 //! 2nd launch (secondary):
 //!   send_to_existing_instance() → Sent → exit

--- a/crates/arto-lsp/src/server.rs
+++ b/crates/arto-lsp/src/server.rs
@@ -1,9 +1,8 @@
 //! The primary instance's side: accept later launches and hand their
 //! events to the app.
 
-use crate::client::READY_TIMEOUT;
+use crate::client::{APPLY_TIMEOUT, READY_TIMEOUT};
 use crate::methods::{self, PeerInfo};
-use crate::protocol::OpenEvent;
 use crate::socket::{self, IpcError};
 use crate::{framing, jsonrpc};
 use interprocess::local_socket::prelude::*;
@@ -13,24 +12,41 @@ use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 use std::sync::Arc;
 
-/// The app's end of a launch that is waiting to be told the window drew it.
+/// The app's end of a request that is waiting for its answer.
 ///
-/// Handed to the events callback only when the launch asked to wait, and
-/// carried by the app to whatever finally knows the answer. Dropping it
-/// without a call to [`ReadySignal::fire`] releases the waiting launch too:
-/// nothing that can still answer exists once the last one is gone.
-pub struct ReadySignal(mpsc::Sender<()>);
+/// Every request gets one. The connection thread is holding the socket open
+/// on it, so an answer here is what the peer finally reads — which is why
+/// the app, not this crate, decides what a request amounts to: only the app
+/// knows whether the document opened, where the reader is, or what the
+/// window has drawn.
+///
+/// Carried across threads and, for a launch waiting on a window, across an
+/// arbitrary stretch of time. Dropping it without answering releases the
+/// peer too, with an error: nothing that could still answer exists once the
+/// last one is gone.
+pub struct Responder(mpsc::Sender<Result<serde_json::Value, jsonrpc::ResponseError>>);
 
-impl ReadySignal {
-    /// Tell the waiting launch the window has drawn what it asked for.
-    pub fn fire(self) {
-        let _ = self.0.send(());
+impl Responder {
+    /// Answer the request with what it asked for.
+    ///
+    /// A value that cannot be serialized is answered as an internal error
+    /// rather than dropped, so the peer hears something either way.
+    pub fn ok<T: serde::Serialize>(self, value: T) {
+        let answer = serde_json::to_value(value).map_err(|error| {
+            jsonrpc::ResponseError::new(jsonrpc::ErrorCode::InternalError, error.to_string())
+        });
+        let _ = self.0.send(answer);
+    }
+
+    /// Answer the request with why it could not be carried out.
+    pub fn err(self, error: jsonrpc::ResponseError) {
+        let _ = self.0.send(Err(error));
     }
 }
 
-impl std::fmt::Debug for ReadySignal {
+impl std::fmt::Debug for Responder {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("ReadySignal")
+        f.write_str("Responder")
     }
 }
 
@@ -72,29 +88,27 @@ impl Server {
         &self.socket_path
     }
 
-    /// Accept connections forever, calling `on_event` with what each one
+    /// Accept connections forever, calling `on_request` with what each one
     /// asks for, in order.
     ///
     /// Each connection is read on its own thread so a slow or stalled
     /// client cannot hold up the next one; reads time out after
     /// [`IPC_TIMEOUT`](crate::IPC_TIMEOUT). A connection that sends nothing
-    /// parseable does not call `on_event` at all. Blocks the calling
+    /// parseable does not call `on_request` at all. Blocks the calling
     /// thread for the life of the listener.
     ///
-    /// `on_event` is handed one request at a time, each answered before the
-    /// next is read. Its second argument is `Some` only for a launch that
-    /// asked to wait for its window; firing it releases that launch. See
-    /// [`ReadySignal`].
+    /// `on_request` is handed one request at a time, each answered before
+    /// the next is read, and every one of them carries a [`Responder`]: this
+    /// crate knows what was asked, and only the app knows the answer.
     ///
     /// `server_info` is what `initialize` reports back — the app's name and
     /// build, which this crate deliberately does not know.
     pub fn serve(
         self,
         server_info: PeerInfo,
-        on_event: impl Fn(OpenEvent, Option<ReadySignal>) + Send + Sync + 'static,
+        on_request: impl Fn(methods::Call, Responder) + Send + Sync + 'static,
     ) {
-        let on_event: Arc<dyn Fn(OpenEvent, Option<ReadySignal>) + Send + Sync> =
-            Arc::new(on_event);
+        let on_request: Arc<dyn Fn(methods::Call, Responder) + Send + Sync> = Arc::new(on_request);
 
         for conn in self.listener.incoming() {
             let stream = match conn {
@@ -105,7 +119,7 @@ impl Server {
                 }
             };
 
-            let handler = Arc::clone(&on_event);
+            let handler = Arc::clone(&on_request);
             let info = server_info.clone();
             let spawned = std::thread::Builder::new()
                 .name("ipc-client-handler".into())
@@ -124,7 +138,7 @@ impl Server {
 fn handle_connection(
     stream: Stream,
     server_info: &PeerInfo,
-    on_event: &dyn Fn(OpenEvent, Option<ReadySignal>),
+    on_request: &dyn Fn(methods::Call, Responder),
 ) {
     // Set read timeout to avoid blocking forever
     if let Err(error) = socket::set_socket_timeout(&stream, socket::IPC_TIMEOUT) {
@@ -132,7 +146,7 @@ fn handle_connection(
     }
 
     let mut reader = std::io::BufReader::new(stream);
-    handle_jsonrpc(&mut reader, server_info, on_event);
+    handle_jsonrpc(&mut reader, server_info, on_request);
 }
 
 /// Serve one connection's worth of JSON-RPC.
@@ -143,7 +157,7 @@ fn handle_connection(
 fn handle_jsonrpc<S: std::io::Read + Write>(
     reader: &mut std::io::BufReader<S>,
     server_info: &PeerInfo,
-    on_event: &dyn Fn(OpenEvent, Option<ReadySignal>),
+    on_request: &dyn Fn(methods::Call, Responder),
 ) {
     let mut initialized = false;
 
@@ -179,7 +193,7 @@ fn handle_jsonrpc<S: std::io::Read + Write>(
 
         match message {
             jsonrpc::Message::Request(request) => {
-                let response = answer(request, server_info, &mut initialized, on_event);
+                let response = answer(request, server_info, &mut initialized, on_request);
                 respond(reader, response);
             }
             jsonrpc::Message::Notification(notification) => {
@@ -201,7 +215,7 @@ fn answer(
     request: jsonrpc::Request,
     server_info: &PeerInfo,
     initialized: &mut bool,
-    on_event: &dyn Fn(OpenEvent, Option<ReadySignal>),
+    on_request: &dyn Fn(methods::Call, Responder),
 ) -> jsonrpc::Response {
     let id = request.id.clone();
 
@@ -238,30 +252,49 @@ fn answer(
         Err(error) => return jsonrpc::Response::error(id, error),
     };
 
-    tracing::debug!(method = %request.method, "Applying a JSON-RPC request");
+    tracing::debug!(method = %request.method, "Handing a JSON-RPC request to the app");
 
-    if !call.wait_ready {
-        on_event(call.event, None);
-        return applied(id, false);
-    }
+    // How long the app gets to answer. A request that asked to wait is
+    // waiting on a window being drawn; every other one is waiting only for
+    // the main thread to come round. The peer listens for longer than
+    // either, so whatever is answered here is still being read.
+    let wait_ready = call.wait_ready;
+    let deadline = if wait_ready {
+        READY_TIMEOUT
+    } else {
+        APPLY_TIMEOUT
+    };
 
     let (sender, receiver) = mpsc::channel();
-    on_event(call.event, Some(ReadySignal(sender)));
-    let ready = match receiver.recv_timeout(READY_TIMEOUT) {
-        Ok(()) => true,
-        // Disconnected means every signal was dropped, so no answer is ever
-        // coming; saying so at once beats holding the launch for the full
-        // timeout to reach the same place.
-        Err(error) => {
-            tracing::debug!(%error, "No window reported ready for a waiting launch");
-            false
-        }
-    };
-    applied(id, ready)
-}
+    on_request(call, Responder(sender));
 
-fn applied(id: jsonrpc::RequestId, ready: bool) -> jsonrpc::Response {
-    result_or_internal_error(id, methods::AppliedResult { ready })
+    // The app's answer, not this crate's. Answering here before the main
+    // thread had done anything is what made an `arto/open` report success
+    // the instant it was queued — true of the queue, and nothing the peer
+    // actually asked about.
+    match receiver.recv_timeout(deadline) {
+        Ok(Ok(value)) => jsonrpc::Response::result(id, value),
+        Ok(Err(error)) => jsonrpc::Response::error(id, error),
+        // Running out of time, and every responder being dropped, are the
+        // same thing to the peer: no answer is coming. For a launch that
+        // was waiting on a window, that *is* the answer — the window did
+        // not draw — and saying so beats an error, which the launch would
+        // report as the instance refusing a request it in fact carried out.
+        Err(error) if wait_ready => {
+            tracing::debug!(%error, "No window reported ready for a waiting launch");
+            result_or_internal_error(id, methods::AppliedResult { ready: false })
+        }
+        Err(error) => {
+            tracing::debug!(%error, "The app did not answer a request");
+            jsonrpc::Response::error(
+                id,
+                jsonrpc::ResponseError::new(
+                    jsonrpc::ErrorCode::InternalError,
+                    "the running instance did not answer",
+                ),
+            )
+        }
+    }
 }
 
 /// Answer with the encoded result, or with an internal error when the
@@ -355,20 +388,20 @@ mod tests {
 
     /// Drive a whole connection and answer with what the server wrote and
     /// what it handed the app.
-    fn serve_once(incoming: Vec<u8>) -> (Vec<jsonrpc::Response>, Vec<OpenEvent>) {
+    ///
+    /// The stand-in app answers every request at once, the way the real one
+    /// does for anything that is not waiting on a window.
+    fn serve_once(incoming: Vec<u8>) -> (Vec<jsonrpc::Response>, Vec<crate::OpenEvent>) {
         let applied = Mutex::new(Vec::new());
         let mut reader = std::io::BufReader::new(Duplex {
             incoming: std::io::Cursor::new(incoming),
             outgoing: Vec::new(),
         });
 
-        handle_jsonrpc(&mut reader, &server_info(), &|event, ready| {
-            applied.lock().unwrap().push(event);
-            // Nothing here has a window, so a launch that asked to wait is
-            // told so at once rather than left for the timeout.
-            if let Some(ready) = ready {
-                ready.fire();
-            }
+        handle_jsonrpc(&mut reader, &server_info(), &|call, responder| {
+            let waited = call.wait_ready;
+            applied.lock().unwrap().push(call.event);
+            responder.ok(methods::AppliedResult { ready: waited });
         });
 
         let written = std::mem::take(&mut reader.get_mut().outgoing);
@@ -433,7 +466,7 @@ mod tests {
         );
         assert_eq!(
             applied,
-            vec![OpenEvent::Open(OpenRequest {
+            vec![crate::OpenEvent::Open(OpenRequest {
                 files: vec!["/README.md".into()],
                 directory: None,
                 behavior: None,

--- a/crates/arto/src/components/app/ready_reporter.rs
+++ b/crates/arto/src/components/app/ready_reporter.rs
@@ -1,4 +1,4 @@
-use arto_lsp::ReadySignal;
+use arto_lsp::{AppliedResult, Responder};
 use dioxus::desktop::tao::window::WindowId;
 use dioxus::desktop::window;
 use dioxus::document;
@@ -72,13 +72,13 @@ async fn report_pending(window_id: WindowId) {
     }
 }
 
-/// Wait for the page to finish drawing, then release `signals`.
+/// Wait for the page to finish drawing, then release `responders`.
 ///
-/// The signals are held here rather than left in the registry so that a
+/// The responders are held here rather than left in the registry so that a
 /// request arriving mid-draw is not answered by a draw it never asked for.
 /// Holding them also means a window torn down while this runs drops them,
 /// which releases the launches rather than stranding them.
-async fn report_once_drawn(window_id: WindowId, signals: Vec<ReadySignal>) {
+async fn report_once_drawn(window_id: WindowId, responders: Vec<Responder>) {
     let drawn = document::eval(indoc::indoc! {r#"
         (async () => {
             // The renderer bundle arrives after the first frame, and a cold
@@ -109,23 +109,29 @@ async fn report_once_drawn(window_id: WindowId, signals: Vec<ReadySignal>) {
     })
     .await;
 
-    match answered {
-        Ok(Ok(true)) => tracing::debug!(?window_id, "Window drew; releasing the waiting launches"),
-        Ok(Ok(false)) => tracing::warn!(
-            ?window_id,
-            "Renderer never appeared; releasing the waiting launches anyway"
-        ),
-        Ok(Err(error)) => tracing::warn!(
-            ?window_id,
-            %error,
-            "Could not ask the page whether it had drawn; releasing the waiting launches anyway"
-        ),
-        Err(_) => tracing::warn!(
-            ?window_id,
-            "Window did not report a draw in time; releasing the waiting launches anyway"
-        ),
-    }
-    for signal in signals {
-        signal.fire();
+    // Only the page saying so counts as drawn. Every other outcome releases
+    // the waiting launches — leaving them to time out helps nobody — but
+    // releases them with `ready: false`, because the one thing `--wait-ready`
+    // rules out is reporting success for a window that never drew.
+    let drew = match answered {
+        Ok(Ok(true)) => {
+            tracing::debug!(?window_id, "Window drew; releasing the waiting launches");
+            true
+        }
+        Ok(Ok(false)) => {
+            tracing::warn!(?window_id, "Renderer never appeared");
+            false
+        }
+        Ok(Err(error)) => {
+            tracing::warn!(?window_id, %error, "Could not ask the page whether it had drawn");
+            false
+        }
+        Err(_) => {
+            tracing::warn!(?window_id, "Window did not report a draw in time");
+            false
+        }
+    };
+    for responder in responders {
+        responder.ok(AppliedResult { ready: drew });
     }
 }

--- a/crates/arto/src/ipc.rs
+++ b/crates/arto/src/ipc.rs
@@ -112,8 +112,11 @@ pub fn start_ipc_server() {
         };
         tracing::info!(socket_path = ?server.socket_path(), "IPC server ready for connections");
 
-        server.serve(peer_info("arto"), |event, ready| {
-            push_queued_event(QueuedEvent { event, ready });
+        server.serve(peer_info("arto"), |call, responder| {
+            push_queued_event(QueuedEvent {
+                call,
+                responder: Some(responder),
+            });
             wake_main_thread();
         });
     });
@@ -235,11 +238,22 @@ fn handle_event_on_main_thread(
     desktop: &std::rc::Rc<dioxus::desktop::DesktopService>,
     queued: QueuedEvent,
 ) {
-    let QueuedEvent { event, ready } = queued;
-    match event {
+    let QueuedEvent { call, responder } = queued;
+
+    // Only a request that asked to wait travels on: it is answered by
+    // whichever window ends up drawing it. Everything else is answered here,
+    // below, once it has actually been applied — not when it was queued,
+    // which is all the protocol crate could have known.
+    let (waiting, answer_when_applied) = if call.wait_ready {
+        (responder, None)
+    } else {
+        (None, responder)
+    };
+
+    match call.event {
         OpenEvent::Open(request) => {
             tracing::debug!(?request, "Processing open request event");
-            open_request_with_behavior(desktop, request, ready);
+            open_request_with_behavior(desktop, request, waiting);
         }
         OpenEvent::Reopen {
             behavior,
@@ -247,15 +261,19 @@ fn handle_event_on_main_thread(
             window,
         } => {
             tracing::debug!(?behavior, behind, ?window, "Processing reopen event");
-            reopen_with_behavior(desktop, behavior, behind, window, ready);
+            reopen_with_behavior(desktop, behavior, behind, window, waiting);
         }
+    }
+
+    if let Some(responder) = answer_when_applied {
+        responder.ok(arto_lsp::AppliedResult { ready: false });
     }
 }
 
 fn open_request_with_behavior(
     desktop: &std::rc::Rc<dioxus::desktop::DesktopService>,
     request: OpenRequest,
-    ready: Option<arto_lsp::ReadySignal>,
+    ready: Option<arto_lsp::Responder>,
 ) {
     let behavior = request
         .behavior
@@ -294,7 +312,7 @@ fn open_request_with_behavior(
 ///
 /// The window is already open and has no reason to notice that anything now
 /// waits on it, so it is told.
-fn watch_existing_window(window_id: WindowId, ready: Option<arto_lsp::ReadySignal>) {
+fn watch_existing_window(window_id: WindowId, ready: Option<arto_lsp::Responder>) {
     let Some(ready) = ready else {
         return;
     };
@@ -307,7 +325,7 @@ fn watch_existing_window(window_id: WindowId, ready: Option<arto_lsp::ReadySigna
 /// Must be called before the window is asked for: the window claims what is
 /// waiting as it mounts, and a signal parked afterwards would be claimed by
 /// nothing until some later window happened to appear.
-fn watch_new_window(ready: Option<arto_lsp::ReadySignal>) {
+fn watch_new_window(ready: Option<arto_lsp::Responder>) {
     if let Some(ready) = ready {
         ready::await_new_window(ready);
     }
@@ -354,7 +372,7 @@ fn reopen_with_behavior(
     behavior: Option<crate::config::FileOpenBehavior>,
     behind: bool,
     window: arto_lsp::WindowOptions,
-    ready: Option<arto_lsp::ReadySignal>,
+    ready: Option<arto_lsp::Responder>,
 ) {
     // A reopen asks for the app to come forward, which is the one thing
     // `--behind` refuses to do: every window, visible or hidden, is left
@@ -471,12 +489,12 @@ mod tests {
         let remaining = drain_events();
         assert_eq!(remaining.len(), 2);
         assert!(matches!(
-            &remaining[0].event,
+            &remaining[0].call.event,
             OpenEvent::Open(OpenRequest { files, directory: Some(directory), .. })
             if files.is_empty() && directory == Path::new("/second")
         ));
         assert!(matches!(
-            &remaining[1].event,
+            &remaining[1].call.event,
             OpenEvent::Reopen {
                 behavior: None,
                 behind: false,

--- a/crates/arto/src/ipc/queue.rs
+++ b/crates/arto/src/ipc/queue.rs
@@ -3,7 +3,7 @@
 //! signal sets for the main thread to act on.
 
 use super::OpenEvent;
-use arto_lsp::ReadySignal;
+use arto_lsp::{AppliedResult, Call, Responder};
 use parking_lot::Mutex;
 use std::collections::VecDeque;
 #[cfg(unix)]
@@ -34,14 +34,15 @@ fn get_event_queue() -> &'static Mutex<VecDeque<QueuedEvent>> {
     IPC_EVENT_QUEUE.get_or_init(|| Mutex::new(VecDeque::new()))
 }
 
-/// An event on its way to the main thread, and the launch waiting on it.
+/// A request on its way to the main thread, and the peer waiting on it.
 ///
-/// The signal rides beside the event rather than inside it because waiting
-/// is the sending connection's business: the same event means the same thing
-/// whether or not anyone is holding a socket open for it.
+/// The responder rides beside the call rather than inside it because who is
+/// waiting is the connection's business: the same call means the same thing
+/// whether it came over a socket or from this process's own command line.
+/// A request with no peer — the app's own startup event — carries `None`.
 pub struct QueuedEvent {
-    pub event: OpenEvent,
-    pub ready: Option<ReadySignal>,
+    pub call: Call,
+    pub responder: Option<Responder>,
 }
 
 /// Register signal handlers for clean socket cleanup.
@@ -137,12 +138,21 @@ fn request_shutdown(signal: i32) {
     }
 }
 
-/// Push an event to the IPC queue. Thread-safe.
+/// Push an event this process asked for itself. Thread-safe.
+///
+/// Nobody is waiting on it: it came from this launch's own command line,
+/// and this launch is the app.
 pub fn push_event(event: OpenEvent) {
-    push_queued_event(QueuedEvent { event, ready: None });
+    push_queued_event(QueuedEvent {
+        call: Call {
+            event,
+            wait_ready: false,
+        },
+        responder: None,
+    });
 }
 
-/// Push an event together with the launch waiting for its window.
+/// Push a request together with the peer waiting for its answer.
 pub fn push_queued_event(queued: QueuedEvent) {
     get_event_queue().lock().push_back(queued);
 }
@@ -152,15 +162,21 @@ pub fn push_queued_event(queued: QueuedEvent) {
 /// Normally this is what the launch itself asked for and nothing waits on
 /// it. But the IPC server starts listening before the launch queues its own
 /// event, so a second launch can slip in ahead of it and have its request
-/// become the first window's. That launch is waiting, so its signal is
-/// parked for the window this event is about to build rather than dropped —
-/// dropping it would answer a request that had in fact been carried out.
+/// become the first window's. That launch is owed an answer, and which
+/// answer depends on what it asked: a launch waiting for a window has its
+/// responder parked for the window this event is about to build, and one
+/// that is not waiting is answered now — holding its connection open for a
+/// draw it never asked about would time it out for nothing.
 pub fn try_pop_first_event() -> Option<OpenEvent> {
-    let queued = get_event_queue().lock().pop_front()?;
-    if let Some(signal) = queued.ready {
-        super::ready::await_new_window(signal);
+    let mut queued = get_event_queue().lock().pop_front()?;
+    if let Some(responder) = queued.responder.take() {
+        if queued.call.wait_ready {
+            super::ready::await_new_window(responder);
+        } else {
+            responder.ok(AppliedResult { ready: false });
+        }
     }
-    Some(queued.event)
+    Some(queued.call.event)
 }
 
 /// Drain all pending events from the IPC queue.

--- a/crates/arto/src/ipc/ready.rs
+++ b/crates/arto/src/ipc/ready.rs
@@ -7,9 +7,9 @@
 //!
 //! Which window that is depends on what the request did. A request that
 //! landed in a window already open names it, and [`await_window`] binds the
-//! signal to that id. A request that created one cannot: window creation is
+//! responder to that id. A request that created one cannot: window creation is
 //! fire-and-forget, so the id does not exist yet when the request is
-//! applied. [`await_new_window`] parks the signal instead and the first main
+//! applied. [`await_new_window`] parks the responder instead and the first main
 //! window to mount claims it.
 //!
 //! That is the window the request asked for, except in the one case where a
@@ -19,65 +19,69 @@
 //! "ready" that a launch naming several files can be given without waiting
 //! on the slowest.
 //!
-//! A window takes its signals *out* of here before it starts watching for a
-//! draw, so what it finally fires is what was waiting when the draw was
+//! A window takes its responders *out* of here before it starts watching for a
+//! draw, so what it finally answers is what was waiting when the draw was
 //! asked for. A request that arrives while the window is already drawing is
 //! left in the registry for the round after, because the draw in progress is
 //! not the one it asked about.
 //!
-//! A signal that is dropped rather than fired releases the launch too, so a
+//! A responder that is dropped rather than fired releases the launch too, so a
 //! window that closes — or is torn down mid-draw — strands nothing.
 
-use arto_lsp::ReadySignal;
+use arto_lsp::{AppliedResult, Responder};
 use dioxus::desktop::tao::window::WindowId;
 use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::sync::LazyLock;
 
 /// Signals whose window is already open.
-static AWAITING_WINDOW: LazyLock<Mutex<HashMap<WindowId, Vec<ReadySignal>>>> =
+static AWAITING_WINDOW: LazyLock<Mutex<HashMap<WindowId, Vec<Responder>>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
 /// Signals whose window has been asked for but does not exist yet.
-static AWAITING_NEW_WINDOW: LazyLock<Mutex<Vec<ReadySignal>>> =
+static AWAITING_NEW_WINDOW: LazyLock<Mutex<Vec<Responder>>> =
     LazyLock::new(|| Mutex::new(Vec::new()));
 
-/// Answer this signal when `window_id` next finishes drawing.
-pub fn await_window(window_id: WindowId, signal: ReadySignal) {
+/// Answer this responder when `window_id` next finishes drawing.
+pub fn await_window(window_id: WindowId, responder: Responder) {
     AWAITING_WINDOW
         .lock()
         .entry(window_id)
         .or_default()
-        .push(signal);
+        .push(responder);
 }
 
-/// Answer this signal when the window that is about to be created draws.
-pub fn await_new_window(signal: ReadySignal) {
-    AWAITING_NEW_WINDOW.lock().push(signal);
+/// Answer this responder when the window that is about to be created draws.
+pub fn await_new_window(responder: Responder) {
+    AWAITING_NEW_WINDOW.lock().push(responder);
 }
 
-/// Take over every signal parked for a window that did not exist yet.
+/// Take over every responder parked for a window that did not exist yet.
 ///
 /// Called by a main window as it mounts. What comes back is the window's to
 /// answer — or to drop, which answers it too.
-pub fn claim_new_window() -> Vec<ReadySignal> {
+pub fn claim_new_window() -> Vec<Responder> {
     std::mem::take(&mut *AWAITING_NEW_WINDOW.lock())
 }
 
-/// Take every signal currently waiting on this window.
-pub fn take_pending(window_id: WindowId) -> Vec<ReadySignal> {
+/// Take every responder currently waiting on this window.
+pub fn take_pending(window_id: WindowId) -> Vec<Responder> {
     AWAITING_WINDOW
         .lock()
         .remove(&window_id)
         .unwrap_or_default()
 }
 
-/// Drop every signal still bound to a window that is going away.
+/// Answer every request still bound to a window that is going away.
 ///
-/// Dropping is the honest answer: the window will never draw, and a launch
-/// released now beats one held until its own timeout runs out.
+/// `ready: false` is the honest answer: the window will never draw, and a
+/// launch told so now beats one held until its own timeout runs out.
 pub fn forget_window(window_id: WindowId) {
-    if AWAITING_WINDOW.lock().remove(&window_id).is_some() {
-        tracing::debug!(?window_id, "Window closed before it reported ready");
+    let Some(responders) = AWAITING_WINDOW.lock().remove(&window_id) else {
+        return;
+    };
+    tracing::debug!(?window_id, "Window closed before it reported ready");
+    for responder in responders {
+        responder.ok(AppliedResult { ready: false });
     }
 }


### PR DESCRIPTION
## Summary

- `ReadySignal` (one bit: the window drew) becomes `Responder` (a JSON result, or an error). Every request carries one, and the connection thread waits for the app instead of answering on its behalf.
- `serve`'s callback is now `Fn(Call, Responder)`.
- Four defects in what the peer was told, all of them introduced or left standing by #295, which has since merged: the deadline race, a non-waiting request parked for a window draw, a closed window reported as a refusal, and `ready: true` after a window failed to draw.

## Why

#288 wants `arto/state` — which document is open, where the reader is, the table of contents. All of that already lives in `AppState` on the main thread, so the method is little more than reading it and answering. What was missing is a way to answer at all: the callback returned `()`, and the only thing it could communicate back was the single bit `ReadySignal` carried.

Generalizing it fixes something else. `arto/open` reported success the instant it reached the queue — true of the queue, and nothing the peer asked about. `SendResult::Applied` meant "accepted for delivery" while reading as "carried out". The app now answers when it has actually applied the request.

### The answers themselves

**A deadline equal to the peer's own read timeout never arrives in time.** Both clocks start within microseconds of each other and the instance answers *at* its deadline, so a busy main thread — a large document rendering, a modal — turned `arto README.md` into `exit 1` and "got no answer" for a file that opened a moment later. `client_deadline` now states both bounds in one place and the launch always listens for longer than the instance may take. The waiting path already did this, with a test; the other path did not.

**A launch that did not ask to wait had its answer parked for a window draw.** Popping the first event dropped `wait_ready` along with the rest of the call, so such a connection was held through a cold start and then answered `ready: true` — contradicting what `AppliedResult::ready` is documented to mean.

**A window closed mid-draw reached the launch as a refusal.** Its responders were dropped, which became an error, which `lib.rs` prints as "the running instance refused the request" — for a document that had in fact opened. A missed deadline on a waiting request now answers `ready: false`.

**The reporter said `ready: true` on every outcome.** It distinguished four, logged two as warnings, and then reported success regardless. A launch gating a screen capture was told the window had drawn after twenty seconds of it not drawing, which is the one thing `--wait-ready` exists to rule out.

## Not in this PR

`arto/state` and `arto/goto` themselves, and the MCP adapter. The adapter needs the permission story #288 flags as open — an MCP server that can open arbitrary local paths in a GUI is not something to expose unconditionally — which is a decision rather than an implementation detail.

Window identity is the other prerequisite: `tao::WindowId` is opaque and not serializable, so anything that names a window over the wire needs a stable id assigned at registration.

## Test Plan

- [x] `just fmt check test` — clippy, oxlint, 778 Rust tests (arto-lsp: 45), 114 frontend tests
- [x] `just arto::doc` — intra-doc links resolve under `-D warnings`
- [ ] **Needs the app run**: that `arto README.md` against a busy instance still exits 0, and that `--wait-ready` exits non-zero when the window is closed mid-draw

```
arto README.md                       # exits 0 even when the primary is busy
arto --wait-ready big.md             # close the window while it draws; echo $status
```

Refs #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Em4jUTWMqsRB9rKP4R39yP

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/arto-app/codesmith/Arto/pr/296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791843510&installation_model_id=435827&pr_number=296&repository=arto-app%2FArto&return_to=https%3A%2F%2Fgithub.com%2Farto-app%2FArto%2Fpull%2F296&signature=03cfb8dfc250cbf5d8b2a09c446b14033617d5d246e7f1dd3b816dd18c957556"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->